### PR TITLE
Troubleshooting documentation

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -283,8 +283,20 @@ entries:
     output: web, pdf
     folderitems:
 
-    - title: Troubleshooting
-      url: /topic_1_page_1.html
+    - title: Communication
+      url: /troubleshooting-communication.html
+      output: web, pdf
+
+    - title: preCICE error messages
+      url: /troubleshooting-preCICE-error-messages.html
+      output: web, pdf
+
+    - title: python bindings
+      url: /troubleshooting-python-bindings.html
+      output: web, pdf
+
+    - title: matlab bindings
+      url: /troubleshooting-matlab-bindings.html
       output: web, pdf
 
   - title: Literature guide

--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -185,6 +185,10 @@ entries:
       url: /topic_1_page_1.html
       output: web, pdf
 
+    - title: FEniCS
+      url: /adapter-fenics.html
+      output: web, pdf
+
     - title: Code_Aster
       url: /topic_1_page_1.html
       output: web, pdf

--- a/pages/docs/adapters/fenics/adapter-fenics.md
+++ b/pages/docs/adapters/fenics/adapter-fenics.md
@@ -1,0 +1,25 @@
+---
+title: The FEniCS adapter
+permalink: adapter-fenics.html
+keywords: adapter, fenics
+summary: "A python package providing a preCICE-adapter for the open source computing platform FEniCS."
+---
+
+## FEniCS adapter
+
+For details on installation and usage of the adapter, please refer to its github repository [`precice/fenics-adapter`](https://github.com/precice/fenics-adapter).
+
+You may also refer to the following tutorial cases using the FEniCS adapter:
+
+* Solving the heat equation in a partitioned fashion
+* Flow over plate
+* Perpendicular flap
+* Cylinder with flap
+
+## How to cite
+
+We are currently working on an up-to-date reference paper. Until then, please cite this adapter by referring to its github repository [`precice/fenics-adapter`](https://github.com/precice/fenics-adapter).
+
+## Related literature
+
+[1] Richard Hertrich. Partitioned fluid structure interaction: Coupling FEniCS and OpenFOAM via preCICE. Bachelor's thesis, Munich School of Engineering, Technical University of Munich, 2019.

--- a/pages/docs/troubleshooting/troubleshooting-communication.md
+++ b/pages/docs/troubleshooting/troubleshooting-communication.md
@@ -1,0 +1,44 @@
+---
+title: Problems with Establishing the Communication
+permalink: troubleshooting-communication.html
+keywords: troubleshooting, communication
+summary: "This page gives you guidance on common communication problems between preCICE participants."
+---
+
+This is a standard issue that many users face. You start both solver of your coupled simulation and they both hang at: 
+```
+(0) 18:57:09 [impl::SolverInterfaceImpl]:253 in initialize: Setting up master communication to coupling partner/s
+```
+What could be the problem? Let's take one step back and have a look how preCICE sets up the communication. In order to establish the communication between the master ranks of both solvers, preCICE exchanges initial communication data by writing them into the directory `precice-run/`. You can define the location where this file is written and read in the configuration (_exchange-directory_). 
+
+Note: Before v1.6.0, this data were written to a hidden file called `.MySolver1-MySolver2.address`.
+
+Several things can go wrong now: 
+
+## Problem 1: Wrong relative folders
+
+From the folders where you start your two solvers, the _exchange-directory_ needs to point to the same location. For example, you start both solvers in the same folder. Then, the exchange-directory could be `"."`. This is also the default value, so you don't need to define this in the preCICE configuration. However, if you start both solvers from sub-folders `Folder1` and `Folder2`, you should configure:
+```xml
+<m2n:sockets from="MySolver1" to="MySolver2" exchange-directory="../"/>
+``` 
+
+## Problem 2: Wrong permissions
+
+Do you have write and read permissions on the exchange directory? What does `ls -la` say?
+
+## Problem 3: Dirty files from last run
+
+If your simulation crashes during initialization, there might leftover address files from the last run. We normally clean them up, but if your simulation just crashes at the wrong moment, we might have had no chance to do that for you. Go look for old address files and remove them, i.e. **delete the directory `precice-run`**.
+
+Before preCICE v1.6.0, these files used to be named `.Participant1-Participant2.address`.
+
+## Problem 4: Network-related issues
+
+In case you are using a supercomputer / cluster, make sure that you are specifying the appropriate network interface in the configuration file (e.g. `network="ib0"`). The default for network is the loopback interface `lo`. For a particular cluster, you need to find out what the actual network interface is called. Often it is `ib0` (for infiniband) or `eth0` (for older linux systems). You can try to find it out by using the command `ip link`. In doubt, contact your cluster administrator. 
+
+There is currently an [issue](https://github.com/precice/precice/issues/45) preventing the communication of participants when there is no network connection (even when the communication is completely local). We are currently working on this issue.
+
+***
+
+All that does not help? Do the [tests](Tests) work for you? Changing from _sockets_ to _mpi_ and vice versa might give more insight. [Let us know!](https://www.precice.org/resources/#contact)  
+

--- a/pages/docs/troubleshooting/troubleshooting-matlab-bindings.md
+++ b/pages/docs/troubleshooting/troubleshooting-matlab-bindings.md
@@ -1,0 +1,8 @@
+---
+title: Troubleshooting the matlab language bindings.
+permalink: troubleshooting-matlab-bindings.html
+keywords: matlab bindings
+summary: "This page tries to help you when facing problems with the matlab bindings."
+---
+
+**TODO:** Everything is currently [on github in a README](https://github.com/precice/matlab-bindings#troubleshooting) and should be moved here.

--- a/pages/docs/troubleshooting/troubleshooting-preCICE-error-messages.md
+++ b/pages/docs/troubleshooting/troubleshooting-preCICE-error-messages.md
@@ -1,0 +1,31 @@
+---
+title: Understanding preCICE errors
+permalink: troubleshooting-preCICE-error-messages.html
+keywords: error messages, tests
+summary: "This page tries to help you understanding preCICE error messages."
+---
+
+In this page you can find some description for common errors.
+
+**Note:** In preCICE v2.1, [all the error messages were rewritten](https://github.com/precice/precice/issues/698) and many of them now offer next steps. A good reason to upgrade!
+
+## Receive failed
+
+```
+ERROR: Receive failed: read: End of file
+``` 
+
+This error means that the connection for communication crashed while preCICE was sending or receiving data. This happened most probably because the other participant, which you couple to, has crashed. Therefore, please look at the output of the other participant to see what went wrong. 
+
+## Serial and parallel simulations
+
+```
+ERROR: You cannot use a master with a serial participant.
+```
+
+This error means that you have defined the `<master: ... />` tag in the `precice-config.xml` for a participant that you run in serial.
+
+Note: One user has reported falsely getting this error while using MPICH, which they solved by changing to OpenMPI. We are investigating this.
+
+
+More will follow soon

--- a/pages/docs/troubleshooting/troubleshooting-python-bindings.md
+++ b/pages/docs/troubleshooting/troubleshooting-python-bindings.md
@@ -1,0 +1,8 @@
+---
+title: Troubleshooting the python language bindings.
+permalink: troubleshooting-python-bindings.html
+keywords: python bindings
+summary: "This page tries to help you when facing problems with the python bindings."
+---
+
+**TODO:** Everything is currently [on github in a README](https://github.com/precice/python-bindings#troubleshooting--miscellaneous) and should be moved here.


### PR DESCRIPTION
We decided that we want to get rid of the troubleshooting pages and move the content, where it belongs. This PR provides an overview over the currently existing troubleshooting pages and still needs a lot of restructuring.