### PR TITLE
Add CSS forworkshop-event

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,6 +16,7 @@
 <link rel="stylesheet" href="css/bookcover.css">
 <!-- most color styles are extracted out to here -->
 <link rel="stylesheet" href="css/theme-precice.css">
+<link rel="stylesheet" href="css/workshop.css">
 
 {% if page.url == "/index.html" %}
 <link rel="stylesheet" href="css/landing-page.css">

--- a/css/workshop.css
+++ b/css/workshop.css
@@ -1,0 +1,17 @@
+.workshop-event
+{
+    border: 1px solid #555753;
+    border-radius: 6px;
+    padding:5px;
+    margin-bottom:5px;
+}
+
+.workshop-event summary
+{
+    margin-bottom:5px;
+}
+
+*:focus
+{
+    outline: none;
+}


### PR DESCRIPTION
In the [old website we had a CSS file for the workshop events](https://github.com/precice/precice.github.io_old/blob/master/css/workshop.css), so that `<details>` content is more discoverable and the different items more readable. This PR adds the same file here (the new workshop page already applies the same CSS classes, just the style was missing).

We need a better solution, see #19.