### PR TITLE
Provide more information on vanilla CalculiX

### DIFF
--- a/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
@@ -129,7 +129,8 @@ The source code is now in the `~/CalculiX/ccx_VERSION/src` directory. The adapte
 
 ### Building the "vanilla" CalculiX (optional)
 
-If you want to build the "vanilla" (i.e. without preCICE) CalculiX, you can now run `make` inside the `src/` directory. Depending on how you installed the dependencies above (using `apt` or from source), you might get compilation errors, such as. Often these errors can be easily fixed by modifying CalculiX `Makefile`. Please refer to [our adapter's makefile options](https://www.precice.org/adapter-calculix-get-adapter.html#makefile-options) for a list of library and include flag you might have to set depending on your installation procedure.
+If you want to build the "vanilla" (i.e. without preCICE) CalculiX, you can now run `make` inside the `src/` directory. Depending on how you installed the dependencies above (using `apt` or from source), you might get compilation errors, such as `spooles.h:26:10: fatal error: misc.h: No such file or directory
+`. Often these errors can be easily fixed by modifying CalculiX `Makefile`. Please refer to [our adapter's makefile options](https://www.precice.org/adapter-calculix-get-adapter.html#makefile-options) for a list of library and include flag you might have to set depending on your installation procedure.
 
 ### Building the modified CalculiX
 

--- a/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
@@ -129,7 +129,7 @@ The source code is now in the `~/CalculiX/ccx_VERSION/src` directory. The adapte
 
 ### Building the "vanilla" CalculiX (optional)
 
-If you want to build the "vanilla" (i.e. without preCICE) CalculiX, you can now run `make` inside the `src/` directory. You may still run into issues with ARPACK in this case, but this is out of scope for our needs, as we use a different Makefile.
+If you want to build the "vanilla" (i.e. without preCICE) CalculiX, you can now run `make` inside the `src/` directory. Depending on how you installed the dependencies above (using `apt` or from source), you might get compilation errors, such as. Often these errors can be easily fixed by modifying CalculiX `Makefile`. Please refer to [our adapter's makefile options](https://www.precice.org/adapter-calculix-get-adapter.html#makefile-options) for a list of library and include flag you might have to set depending on your installation procedure.
 
 ### Building the modified CalculiX
 

--- a/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
@@ -129,7 +129,7 @@ The source code is now in the `~/CalculiX/ccx_VERSION/src` directory. The adapte
 
 ### Building the "vanilla" CalculiX (optional)
 
-If you want to build the "vanilla" (i.e. without preCICE) CalculiX, you can now run `make` inside the `src/` directory. Depending on how you installed the dependencies above (using `apt` or from source), you might get compilation errors, such as `spooles.h:26:10: fatal error: misc.h: No such file or directory`. Often these errors can be easily fixed by modifying CalculiX `Makefile`. Please refer to [our adapter's makefile options](adapter-calculix-get-adapter.html#makefile-options) for a list of library and include flag you might have to set depending on your installation procedure.
+If you want to build the "vanilla" (i.e. without preCICE) CalculiX, you can now run `make` inside the `src/` directory. Depending on how you installed the dependencies above (using `apt` or from source), you might get compilation errors, such as `spooles.h:26:10: fatal error: misc.h: No such file or directory`. Often these errors can be easily fixed by modifying CalculiX `Makefile`. Please refer to [our adapter's makefile options](https://www.precice.org/adapter-calculix-get-adapter.html#makefile-options) for a list of library and include flag you might have to set depending on your installation procedure.
 
 ### Building the modified CalculiX
 

--- a/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
@@ -129,8 +129,7 @@ The source code is now in the `~/CalculiX/ccx_VERSION/src` directory. The adapte
 
 ### Building the "vanilla" CalculiX (optional)
 
-If you want to build the "vanilla" (i.e. without preCICE) CalculiX, you can now run `make` inside the `src/` directory. Depending on how you installed the dependencies above (using `apt` or from source), you might get compilation errors, such as `spooles.h:26:10: fatal error: misc.h: No such file or directory
-`. Often these errors can be easily fixed by modifying CalculiX `Makefile`. Please refer to [our adapter's makefile options](https://www.precice.org/adapter-calculix-get-adapter.html#makefile-options) for a list of library and include flag you might have to set depending on your installation procedure.
+If you want to build the "vanilla" (i.e. without preCICE) CalculiX, you can now run `make` inside the `src/` directory. Depending on how you installed the dependencies above (using `apt` or from source), you might get compilation errors, such as `spooles.h:26:10: fatal error: misc.h: No such file or directory`. Often these errors can be easily fixed by modifying CalculiX `Makefile`. Please refer to [our adapter's makefile options](https://www.precice.org/adapter-calculix-get-adapter.html#makefile-options) for a list of library and include flag you might have to set depending on your installation procedure.
 
 ### Building the modified CalculiX
 

--- a/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
@@ -129,7 +129,7 @@ The source code is now in the `~/CalculiX/ccx_VERSION/src` directory. The adapte
 
 ### Building the "vanilla" CalculiX (optional)
 
-If you want to build the "vanilla" (i.e. without preCICE) CalculiX, you can now run `make` inside the `src/` directory. Depending on how you installed the dependencies above (using `apt` or from source), you might get compilation errors, such as `spooles.h:26:10: fatal error: misc.h: No such file or directory`. Often these errors can be easily fixed by modifying CalculiX `Makefile`. Please refer to [our adapter's makefile options](https://www.precice.org/adapter-calculix-get-adapter.html#makefile-options) for a list of library and include flag you might have to set depending on your installation procedure.
+If you want to build the "vanilla" (i.e. without preCICE) CalculiX, you can now run `make` inside the `src/` directory. Depending on how you installed the dependencies above (using `apt` or from source), you might get compilation errors, such as `spooles.h:26:10: fatal error: misc.h: No such file or directory`. Often these errors can be easily fixed by modifying CalculiX `Makefile`. Please refer to [our adapter's makefile options](adapter-calculix-get-adapter.html#makefile-options) for a list of library and include flag you might have to set depending on your installation procedure.
 
 ### Building the modified CalculiX
 


### PR DESCRIPTION
For review:

* Ideally you have never built CalculiX before.
* Install dependencies via `apt`
* Try to build vanilla CalculiX using the included Makefile
* Hopefully the documentation updates help you to find out how you have to modify the Makefile.
* If you already have some experience on include and library flags: Try to imagine how a user that has no idea what a include and library flag is would work with the documentation. Is it understandable even in this case?