### PR TITLE
Style attribute removed from css

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,7 +52,7 @@
     </script>
     {% if page.datatable == true %}
     <!-- Include the standard DataTables bits -->
-    <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.13/css/jquery.dataTables.css">
+    <link rel="stylesheet"  href="//cdn.datatables.net/1.10.13/css/jquery.dataTables.css">
     <script type="text/javascript" charset="utf8" src="//cdn.datatables.net/1.10.13/js/jquery.dataTables.js"></script>
     <!-- First, this walks through the tables that occur between ...-begin
          and ...-end and add the "datatable" class to them.


### PR DESCRIPTION
This is the first attempt to improve the errors generated during HTML site validation. A style attribute is removed from the website's page.