### PR TITLE
Move OpenFOAM docs origin to master branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "openfoam-adapter"]
 	path = imported/openfoam-adapter
 	url = https://github.com/precice/openfoam-adapter.git
-	branch = docs
+	branch = master

--- a/_config.yml
+++ b/_config.yml
@@ -136,7 +136,7 @@ defaults:
       sidebar: docs_sidebar
       topnav: topnav
       toc: true
-      github_editme_path: https://github.com/precice/openfoam-adapter/tree/docs/ # ends in /
+      github_editme_path: https://github.com/precice/openfoam-adapter/tree/master/ # ends in /
   -
     scope:
       path: "pages/community"


### PR DESCRIPTION
In https://github.com/precice/openfoam-adapter/pull/161, we merged the documentation of the OpenFOAM adapter to `develop` and soon we will release it to `master`. :warning:  We should only merge this PR only after releasing the adapter!

@fsimonis do I need to update anything else?