### PR TITLE
Add the preCICE distribution page

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -131,6 +131,10 @@ entries:
       url: /installation-vm.html
       output: web, pdf
 
+    - title: preCICE distribution
+      url: /installation-distribution.html
+      output: web, pdf
+
   - title: Configuration
     output: web, pdf
     folderitems:

--- a/pages/docs/installation/installation-distribution.md
+++ b/pages/docs/installation/installation-distribution.md
@@ -1,0 +1,32 @@
+---
+title: The preCICE distribution
+permalink: installation-distribution.html
+keywords: installation, versions, compatibility, distribution
+summary: "A frozen state of component versions that work together."
+---
+
+## What is the preCICE distribution?
+
+preCICE is much more than the core library: it is a larger ecosystem that includes
+language bindings, adapters for popular solvers, tutorials, and more. We know that it
+can be difficult to figure out which versions to install, therefore we will be
+publishing here lists of known-to-work versions.
+
+## v2104.0
+
+This is the first preCICE distribution version, coming after the restructuring of our tutorials.
+
+It comprises of the following components:
+
+- preCICE: [v2.2.0](https://github.com/precice/precice/releases/tag/v2.2.0)
+- Python bindings: [v2.2.0.2](https://github.com/precice/python-bindings/releases/tag/v2.2.0.2)
+- Fortran module: commit [9826f27](https://github.com/precice/fortran-module/tree/9826f277e3302cc1aef50741530538bd9d8d23c7)
+- Matlab bindings: [v2.2.0.1](https://github.com/precice/matlab-bindings/releases/tag/v2.2.0.1)
+- OpenFOAM adapter: [v1.0.0](https://github.com/precice/openfoam-adapter/releases/tag/v1.0.0)
+- deal.II adapter: commit [685508e](https://github.com/precice/dealii-adapter/tree/685508e8c3391f29b74d7851c15318faa226fa1c)
+- FEniCS adapter: [v1.1.0](https://github.com/precice/fenics-adapter/releases/tag/v1.1.0)
+- CalculiX adapter: commit [9fefcef](https://github.com/precice/calculix-adapter/tree/9fefcef8ade330280cb300c25c78df6827b44684)
+- SU2 adapter: commit [ab84387](https://github.com/precice/su2-adapter/tree/ab843878c1d43302a4f0c66e25dcb364b7787478)
+- code_aster adapter: commit [ce995e0](https://github.com/precice/code_aster-adapter/tree/ce995e0c41b26fe891ce04fd47fd52cbeff854e9)
+- Tutorials: [v202104.1.1](https://github.com/precice/tutorials/releases/tag/v202104.1.1)
+- vm: [v202104.1.0](https://github.com/precice/vm/releases/tag/v202104.1.0)

--- a/pages/docs/installation/installation-overview.md
+++ b/pages/docs/installation/installation-overview.md
@@ -21,6 +21,9 @@ To find the right method for you, follow this decision graph, or simply read on!
     <area target="" alt="Demo Virtual Machine" title="Demo Virtual Machine" href="installation-vm.html" coords="439,340,562,401" shape="rect">
 </map>
 
+Note that preCICE is much more than the core library. To find out which library, bindings, adapters, and tutorials versions work together,
+have a look at the [preCICE distribution](installation-distribution.html).
+
 ### Operating systems
 
 <!-- markdownlint-disable-file MD036 -->


### PR DESCRIPTION
This adds a page listing the latest known-to-work-together versions of preCICE components.

@uekerman how do you like it?

![Screenshot from 2021-05-03 23-23-10](https://user-images.githubusercontent.com/4943683/116935463-af24d380-ac66-11eb-94ef-e0800123fbd3.png)
