### PR TITLE
Remove duplicated test run from GH actions

### DIFF
--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -1,5 +1,9 @@
 name: Lint docs
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 jobs:
   check_md:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Our tests are currently duplicated in PRs, since the `push` event is triggered as well as the `pull_request` event. We should definitely specify the test branches here so that the `pull_request` event is triggered when opening and syncing PRs and the `push` event is triggered when we actually merge and push to master.