### PR TITLE
Improve linking to preCICE in the documentation

### DIFF
--- a/pages/docs/installation/installation-linking.md
+++ b/pages/docs/installation/installation-linking.md
@@ -17,7 +17,16 @@ Linking to preCICE from a CMake project is simple.
 Use `find_package(precice)` and link `precice::precice` to your target:
 
 ```cmake
-find_package(precice REQUIRED CONFIG)
+find_package(precice 2.0 CONFIG HINTS ${precice_DIR})
+
+IF(NOT ${precice_FOUND})
+   MESSAGE(FATAL_ERROR "\n"
+    "*** Finding preCICE failed. ***\n\n"
+    "You may want to either pass a flag -Dprecice_DIR=/path/to/precice to cmake\n"
+    "(where the path points to the installation prefix or the build directory)\n"
+    " or set an environment variable \"precice_DIR\" that contains this path."
+    )
+ENDIF()
 
 add_executable(myTarget main.cpp)
 target_link_libraries(myTarget PRIVATE precice::precice)


### PR DESCRIPTION
I recently added this change in the deal.II adapter and I think it is much more descriptive. The `HINT precice_DIR` is required in case someone installs preCICE at a custom location and he just wants to specify the install prefix on the command line (otherwise, the exact cmake config file location would be necessary. 

Not sure if we want to make the error message part of the code. We could also add an `info` in the wiki. However, I really like this approach, but it is just a suggestion. 