### PR TITLE
Add doc for CalculiX adapter with PaStiX

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -307,6 +307,10 @@ entries:
           url: /adapter-calculix-get-adapter.html
           output: web, pdf
 
+        - title: Build the adapter with PaStiX
+          url: /adapter-calculix-pastix-build.html
+          output: web, pdf
+
         - title: Configuration
           url: /adapter-calculix-config.html
           output: web, pdf

--- a/pages/docs/adapters/calculix/adapter-calculix-get-adapter.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-adapter.md
@@ -24,7 +24,6 @@ After [installing preCICE](installation-overview.html) and [getting the CalculiX
 4. Build with `make` (e.g. `make -j 4` for parallel).
 5. You should now have a new executable `ccx_preCICE` in the `bin/` folder of the adapter. You may move this file to a path known by your system, or [add this to your `PATH`](https://unix.stackexchange.com/a/26059/36693) (careful when doing this!).
 
-
 ### Building the adapter with PaStiX
 
 Since version 2.17 of CalculiX, it is possible to link the PaStiX solver for increased performance, mostly through GPUs. Building the adapter with PaStix is quite tedious, as most dependencies of PaStiX and PaStiX itslef must be built from source. To help you go thorugh this, we provide [detailed instructions on a dedicated page](adapter-calculix-pastix-build.html).

--- a/pages/docs/adapters/calculix/adapter-calculix-get-adapter.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-adapter.md
@@ -24,6 +24,11 @@ After [installing preCICE](installation-overview.html) and [getting the CalculiX
 4. Build with `make` (e.g. `make -j 4` for parallel).
 5. You should now have a new executable `ccx_preCICE` in the `bin/` folder of the adapter. You may move this file to a path known by your system, or [add this to your `PATH`](https://unix.stackexchange.com/a/26059/36693) (careful when doing this!).
 
+
+### Building the adapter with PaStiX
+
+Since version 2.17 of CalculiX, it is possible to link the PaStiX solver for increased performance, mostly through GPUs. Building the adapter with PaStix is quite tedious, as most dependencies of PaStiX and PaStiX itslef must be built from source. To help you go thorugh this, we provide [detailed instructions on a dedicated page](adapter-calculix-pastix-build.html).
+
 ### Makefile options
 
 The adapter is built using GNU Make. The `Makefile` contains a few variables on top, which need to be adapted to your system:

--- a/pages/docs/adapters/calculix/adapter-calculix-get-adapter.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-adapter.md
@@ -26,7 +26,7 @@ After [installing preCICE](installation-overview.html) and [getting the CalculiX
 
 ### Building the adapter with PaStiX
 
-Since version 2.17 of CalculiX, it is possible to link the PaStiX solver for increased performance, mostly through GPUs. Building the adapter with PaStix is quite tedious, as most dependencies of PaStiX and PaStiX itslef must be built from source. To help you go thorugh this, we provide [detailed instructions on a dedicated page](adapter-calculix-pastix-build.html).
+Since version 2.17 of CalculiX, it is possible to link the PaStiX solver for increased performance, mostly through GPUs. Building the adapter with PaStiX is quite tedious, as most dependencies of PaStiX and PaStiX itslef must be built from source. Check our [detailed instructions on building the adapter with PaStiX](adapter-calculix-pastix-build.html).
 
 ### Makefile options
 

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -1,0 +1,123 @@
+---
+title: Building the Calculix adapter with PaStiX (and CalculiX 2.17)
+permalink: adapter-calculix-pastix-build.html
+keywords: adapter, calculix, pastix
+summary: "Since version 2.17, CalculiX can be built with the PaStiX library to increase performance with CUDA. Building the preCICE adapter
+is somehow harder with this version. This page gives a detailed walkthrough to build the modified adapter."
+---
+
+## Overview
+
+To build the preCICE adapter for CalculiX with PaStiX, it is first necessary to build PaStiX. A manual build is necessary for most steps, as specific compilation flags must be used for the dependencies : their standard distribution cannot be used. In particular, PaStiX (and CalculiX) must be compiled with flags to use 8 bytes integer. On this page, we provide a step-by-step build of the adapter, tested on Ubuntu 20.04. (LTS)
+This should work with some modifications on other systems.
+
+## Required packages
+
+Make sur you have a working installation of preCICE. Also run these installation commands :
+
+
+
+## Downloading CalculiX
+
+Build scripts assume that CalculiX' source code is in `/usr/local`. Donwload it, extract it there and add read/write access to the folder.
+
+```
+    cd /usr/local/ && sudo wget http://www.dhondt.de/ccx_2.17.src.tar.bz2
+    sudo bunzip2 ccx_2.17.src.tar.bz2
+    sudo tar -xvf ccx_2.17.src.tar
+    sudo chmod -R a+rw /usr/local/CalculiX
+
+```
+
+This contains the source code of CalculiX, but also scripts useful for building some libraries below with the correct flags.
+
+## Building PaStiX dependencies
+
+It is assumed that all these libraries will be built on the user home folder, `~`. Minor modifications will be required otherwise.
+PaStiX requires OpenBLAS, hwloc, Scotch and PaRSEC. All of these will be built before PaStiX itself.
+
+### Building OpenBLAS
+
+Clone OpenBLAS source code and build it with 8 bytes integers option.
+
+```
+    cd ~ 
+    git clone https://github.com/xianyi/OpenBLAS.git 
+    OpenBLAS ./OpenBLAS_i8
+    cd OpenBLAS_i8 
+    make -j 4 INTERFACE64=1 
+    sudo make install
+
+```
+
+### Building hwloc
+
+This library will be put in a subfolder of the PaStiX folder.
+```
+    mkdir -p ~/PaStiX/ 
+    cd ~/PaStiX/ 
+    wget https://download.open-mpi.org/release/hwloc/v2.1/hwloc-2.1.0.tar.bz2
+    bunzip2 hwloc-2.1.0.tar.bz2 && tar -xf hwloc-2.1.0.tar
+    sudo cp /usr/local/CalculiX/ccx_2.17/src/make_hwloc.sh ~/PaStiX/hwloc-2.1.0/make_hwloc.sh
+    ./configure --prefix=$HOME/PaStiX/hwloc_i8 CC=gcc CXX=g++ &&
+    make -j8
+    make install
+
+
+```
+
+### Building PaRSEC
+
+```
+    cd ~/PaStiX && git clone -b pastix-6.0.2 --single-branch https://bitbucket.org/mfaverge/parsec.git
+    cp /usr/local/CalculiX/ccx_2.17/src/make_parsec.sh ~/PaStiX/parsec
+    /make_parsec.sh
+
+```
+
+### Building Scotch 
+
+```
+    cd ~/PaStiX
+    wget https://gforge.inria.fr/frs/download.php/file/38114/scotch_6.0.8.tar.gz
+    tar -xf scotch_6.0.8.tar.gz
+    cp /usr/local/CalculiX/ccx_2.17/src/make_scotch.sh ~/PaStiX/scotch_6.0.8 &&
+    scotch_6.0.8
+    ./make_scotch.sh
+
+```
+
+## Start here
+
+1. [Get CalculiX and the dependencies](adapter-calculix-get-calculix.html)
+2. [Build the Adapter](adapter-calculix-get-adapter.html)
+3. [Configure and run simulations](adapter-calculix-config.html)
+4. Follow a tutorial:
+   * [Tutorial for CHT with OpenFOAM and CalculiX](https://github.com/precice/precice/wiki/Tutorial-for-CHT-with-OpenFOAM-and-CalculiX): Flow in a shell-and-tube heat exchanger
+   * [Tutorial for FSI with OpenFOAM and CalculiX](https://github.com/precice/precice/wiki/Tutorial-for-FSI-with-OpenFOAM-and-CalculiX): Flow in a channel with an elastic flap, either perpendicular, or parallel to the flow and attached to a cylinder.
+   * [Tutorial on structure-structure coupling](https://github.com/precice/precice/wiki/Tutorial-for-SSI-with-CalculiX): Elastic beam artificially cut into two halves.
+
+Are you encountering an unexpected error? Have a look at our [Troubleshooting](adapter-calculix-troubleshooting.html) page.
+
+Do you Want to build on a cluster? Look at our [instructions for SuperMUC](adapter-calculix-supermuc.html) (outdated).
+
+## Versions
+
+Please check the [Calculix adapter README](https://github.com/precice/calculix-adapter/blob/master/README.md) for the newest compatible CalculiX version.
+
+Adapters for older versions of CalculiX and preCICE are available in various branches. Branches compatible with **preCICE v2.x:**
+
+* master
+* v2.15_preCICE2.x
+
+All other branches are compatible with **preCICE v1.x**.
+
+## History
+
+The adapter was initially developed for conjugate heat transfer (CHT) simulations via preCICE by Lucia Cheung in the scope of her master’s thesis [[1]](https://www5.in.tum.de/pub/Cheung2016_Thesis.pdf) in cooperation with [SimScale](https://www.simscale.com/). For running the adapter for CHT simulations refer to this thesis. The adapter was extended to fluid-structure interaction by Alexander Rusch [[2]](https://www.gacm2017.uni-stuttgart.de/registration/Upload/ExtendedAbstracts/ExtendedAbstract_0138.pdf).
+
+## References
+
+[1] Lucia Cheung Yau. Conjugate heat transfer with the multiphysics coupling library precice. Master’s thesis, Department of Informatics, Technical University of Munich, 2016.
+
+[2] Benjamin Uekermann, Hans-Joachim Bungartz, Lucia Cheung Yau, Gerasimos Chourdakis and Alexander Rusch. Official preCICE Adapters for Standard Open-Source Solvers. In Proceedings of the _7th GACM Colloquium on Computational Mechanics for Young Scientists from Academia_, 2017.

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -135,7 +135,7 @@ Once all of these are done, simply run `make lib` in the `ARPACK` folder.
 To build the adapter, clone its repository and checkout the `2.17` branch : 
 
 ```
-    git clone -b 2.17 https://github.com/precice/calculix-adapter
+    git clone -b v2.17 https://github.com/precice/calculix-adapter
     cd calculix-adapter
 ```
 

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -13,7 +13,7 @@ This should work with some modifications on other systems.
 
 ## Required packages
 
-Make sur you have a working installation of preCICE. Also run these installation commands, (after a call to `sudo apt update` and `sudo apt upgrade`) :
+Make sure you have a working installation of preCICE. Also run these installation commands, (after a call to `sudo apt update` and `sudo apt upgrade`) :
 `sudo apt install build-essential cmake git gfortran flex bison zlib1g-dev nvidia-cuda-toolkit-gcc libspooles-dev libyaml-cpp-dev`
 
 ## Downloading CalculiX source

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -14,8 +14,9 @@ This should work with some modifications on other systems.
 ## Required packages
 
 Make sur you have a working installation of preCICE. Also run these installation commands, (after a call to `sudo apt update` and `sudo apt upgrade`) :
-build-essential cmake git gfortran flex bison zlib1g-dev
+`sudo apt install build-essential cmake git gfortran flex bison zlib1g-dev nvidia-cuda-toolkit-gcc`
 
+nvidia-cuda-toolkit-gcc ? liblapacke-dev ? 64 ?
 
 ## Downloading CalculiX
 
@@ -74,7 +75,7 @@ This library will be put in a subfolder of the PaStiX folder.
     cd ~/PaStiX && git clone -b pastix-6.0.2 --single-branch https://bitbucket.org/mfaverge/parsec.git
     cd parsec
     cp /usr/local/CalculiX/ccx_2.17/src/make_parsec.sh ~/PaStiX/parsec
-    /make_parsec.sh
+    ./make_parsec.sh
 
 ```
 

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -8,7 +8,7 @@ is somehow harder with this version. This page gives a detailed walkthrough to b
 
 ## Overview
 
-To build the preCICE adapter for CalculiX with PaStiX, it is first necessary to build PaStiX. A manual build is necessary for most steps, as specific compilation flags must be used for the dependencies : their standard distribution cannot be used. In particular, PaStiX (and CalculiX) must be compiled with flags to use 8 bytes integer. On this page, we provide a step-by-step build of the adapter, tested on Ubuntu 20.04. (LTS)
+To build the preCICE adapter for CalculiX with PaStiX, it is first necessary to build PaStiX. A manual build is necessary for most steps, as specific compilation flags must be used for the dependencies: pre-built packages cannot be used. In particular, PaStiX (and CalculiX) must be compiled with flags to use 8-byte integers. On this page, we provide a step-by-step building guide of the adapter, tested on Ubuntu 20.04.
 This should work with some modifications on other systems.
 
 ## Required packages

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -16,12 +16,11 @@ This should work with some modifications on other systems.
 Make sur you have a working installation of preCICE. Also run these installation commands, (after a call to `sudo apt update` and `sudo apt upgrade`) :
 `sudo apt install build-essential cmake git gfortran flex bison zlib1g-dev nvidia-cuda-toolkit-gcc libspooles-dev libyaml-cpp-dev`
 
-
 ## Downloading CalculiX source
 
 Build scripts assume that CalculiX' source code is in `/usr/local`. Donwload it, extract it there and add read/write access to the folder.
 
-```
+```bash
     cd /usr/local/ && sudo wget http://www.dhondt.de/ccx_2.17.src.tar.bz2
     sudo bunzip2 ccx_2.17.src.tar.bz2
     sudo tar -xvf ccx_2.17.src.tar
@@ -40,7 +39,7 @@ PaStiX requires OpenBLAS, hwloc, Scotch and PaRSEC. All of these will be built b
 
 Clone OpenBLAS source code and build it with 8 bytes integers option.
 
-```
+```bash
     cd ~ 
     git clone https://github.com/xianyi/OpenBLAS.git 
     mv OpenBLAS ./OpenBLAS_i8
@@ -53,7 +52,8 @@ Clone OpenBLAS source code and build it with 8 bytes integers option.
 ### Building hwloc
 
 This library will be put in a subfolder of the PaStiX folder.
-```
+
+```bash
     mkdir -p ~/PaStiX/ 
     cd ~/PaStiX/ 
     wget https://download.open-mpi.org/release/hwloc/v2.1/hwloc-2.1.0.tar.bz2
@@ -64,12 +64,11 @@ This library will be put in a subfolder of the PaStiX folder.
     make -j8
     make install
 
-
 ```
 
 ### Building PaRSEC
 
-```
+```bash
     cd ~/PaStiX && git clone -b pastix-6.0.2 --single-branch https://bitbucket.org/mfaverge/parsec.git
     cd parsec
     cp /usr/local/CalculiX/ccx_2.17/src/make_parsec.sh ~/PaStiX/parsec
@@ -77,9 +76,9 @@ This library will be put in a subfolder of the PaStiX folder.
 
 ```
 
-### Building Scotch 
+### Building Scotch
 
-```
+```bash
     cd ~/PaStiX
     wget https://gforge.inria.fr/frs/download.php/file/38114/scotch_6.0.8.tar.gz
     tar -xf scotch_6.0.8.tar.gz
@@ -89,10 +88,9 @@ This library will be put in a subfolder of the PaStiX folder.
 
 ```
 
-
 ## Building PaStiX
 
-```
+```bash
     git clone https://github.com/Dhondtguido/PaStiX4CalculiX 
     mv PaStiX4CalculiX pastix_src
     cd pastix_src
@@ -111,9 +109,9 @@ The github repository contains a `make_pastix.sh` file; be sure to use the one i
 
 ## Building ARPACK, a CalculiX dependency
 
-Calculix relies on ARPACK, and when built with PaStiX, we cannot rely on standard distributions of that library, because it doesn't feature 8-bytes integers by default. We need to compile it ourself. The source code can be found [here](https://www.caam.rice.edu/software/ARPACK/), or by running these commands : 
+Calculix relies on ARPACK, and when built with PaStiX, we cannot rely on standard distributions of that library, because it doesn't feature 8-bytes integers by default. We need to compile it ourself. The source code can be found [here](https://www.caam.rice.edu/software/ARPACK/), or by running these commands :
 
-```
+```bash
 cd ~
 wget https://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz
 wget https://www.caam.rice.edu/software/ARPACK/SRC/patch.tar.gz
@@ -122,19 +120,20 @@ zcat patch.tar.gz    | tar -xvf -
 
 ```
 
-Before building the library, the following modifications are required : 
-+ In `ARmake.inc`, change `PLAT` by the appropriate suffix (the adapter's makefile assumes INTEL)
-+ In `ARmake.inc`, change the Fortran compilation flags to add `-fdefault-integer-8`. You may also need to remove the flag `-cg89`.
-+ If you extracted the archive on another folder than your home repository, update `home` in `ARmake.inc` accordingly.
-+ In the file `UTIL/second.f`, comment with a star the line containing `EXTERNAL ETIME`.
+Before building the library, the following modifications are required :
+
+- In `ARmake.inc`, change `PLAT` by the appropriate suffix (the adapter's makefile assumes INTEL)
+- In `ARmake.inc`, change the Fortran compilation flags to add `-fdefault-integer-8`. You may also need to remove the flag `-cg89`.
+- If you extracted the archive on another folder than your home repository, update `home` in `ARmake.inc` accordingly.
+- In the file `UTIL/second.f`, comment with a star the line containing `EXTERNAL ETIME`.
 
 Once all of these are done, simply run `make lib` in the `ARPACK` folder.
 
 ## Building the adapter
 
-To build the adapter, clone its repository and checkout the `2.17` branch : 
+To build the adapter, clone its repository and checkout the `2.17` branch :
 
-```
+```bash
     git clone -b v2.17 https://github.com/precice/calculix-adapter
     cd calculix-adapter
 ```
@@ -143,28 +142,25 @@ To build the adapter, clone its repository and checkout the `2.17` branch :
 
 Due to some conflicts between CalculiX, PaStiX and the adapter (both CalculiX and PaStiX have a `pastix.h` file, and neither of them is local from the point of view of the adapter), some changes are required in the CalculiX codebase. We provide a script, `pastix_pre_build.sh` that does these changes. Run it.
 
-```
+```bash
     ./pastix_pre_build.sh
 ```
-
 
 ### Compilation
 
 To build the adapter, use the provided `Makefile_i8_PaStiX` : the regular Makefile would build the adapter without PaStiX. Assuming you followed the previous steps, it should be useable without modifications; otherwise, some paths updates could be required. Run this command in the `calculix-adapter` (and be sure to checkout the `2.17` branch) folder :
 
-
-```
+```bash
     make -f Makefile_i8_PaStiX -j 4 
 ```
 
 Once the build is successful, the adapter should be in `./bin/ccx_preCICE`.
 
-
 ### Updating shared libraries
 
-Running the adapter at this point should fail because of a missing shared library : `libparsec.so.2`. A possible fix to this is to copy it in your local library folder and run `ldconfig` : 
+Running the adapter at this point should fail because of a missing shared library : `libparsec.so.2`. A possible fix to this is to copy it in your local library folder and run `ldconfig` :
 
-```
+```bash
     sudo cp ~/PaStiX/parsec_i8/lib/libparsec.so.2 /usr/local/lib
     sudo ldconfig
 ```

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -79,10 +79,10 @@ This library will be put in a subfolder of the PaStiX folder.
 
 ```bash
     cd ~/PaStiX
-    wget https://gforge.inria.fr/frs/download.php/file/38114/scotch_6.0.8.tar.gz
-    tar -xf scotch_6.0.8.tar.gz
-    cp ~/CalculiX/ccx_2.17/src/make_scotch.sh ~/PaStiX/scotch_6.0.8
-    cd scotch_6.0.8
+    wget https://gitlab.inria.fr/scotch/scotch/-/archive/master/scotch-master.tar.gz
+    tar -xf scotch-master.tar.gz
+    cp ~/CalculiX/ccx_2.17/src/make_scotch.sh ~/PaStiX/scotch-master
+    cd scotch-master
     ./make_scotch.sh
 
 ```
@@ -90,6 +90,7 @@ This library will be put in a subfolder of the PaStiX folder.
 ## Building PaStiX
 
 ```bash
+    cd ~/PaStiX
     git clone https://github.com/Dhondtguido/PaStiX4CalculiX 
     mv PaStiX4CalculiX pastix_src
     cd pastix_src

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -102,7 +102,7 @@ This library will be put in a subfolder of the PaStiX folder.
 
 ```
 
-The github repository contains a `make_pastix.sh` file; be sure to use the one in the CalculiX folder and not this one !
+{% include warning.html content="The repository of PaStiX contains a `make_pastix.sh` file; be sure to use the one in the CalculiX folder and not the one from PaStiX!" %}
 
 ### Troubleshooting
 

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -11,10 +11,18 @@ is somehow harder with this version. This page gives a detailed walkthrough to b
 To build the preCICE adapter for CalculiX with PaStiX, it is first necessary to build PaStiX. A manual build is necessary for most steps, as specific compilation flags must be used for the dependencies: pre-built packages cannot be used. In particular, PaStiX (and CalculiX) must be compiled with flags to use 8-byte integers. On this page, we provide a step-by-step building guide of the adapter, tested on Ubuntu 20.04.
 This should work with some modifications on other systems. You may also need to tweak this depending on your needs, e.g. if you want to build some dependencies yourself instead of using a package manager.
 
+{% note %}
+This page was built following CalculiX' documentation with adaptations for preCICE and some additional tips from experience. Support of PaStiX is still experimental and feedback is highly valuable!
+{% endnote %}
+
 ## Required packages
 
 Make sure you have a working installation of preCICE. Also run these installation commands, (after a call to `sudo apt update` and `sudo apt upgrade`) :
 `sudo apt install build-essential cmake git gfortran flex bison zlib1g-dev nvidia-cuda-toolkit-gcc libspooles-dev libyaml-cpp-dev`
+
+{% note %}
+You can get these elsewhere or build them from source. In particular, it is probably wise to have a more up to date CUDA installation than the one provided on the Ubuntu repository. Again, feedback is appreciated!
+{% endnote %}
 
 ## Downloading CalculiX source
 

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -106,7 +106,7 @@ This library will be put in a subfolder of the PaStiX folder.
 
 ### Troubleshooting
 
-- On some occasions, a Python script called by CMake generates an incorrect Makefile because of errors in regular expressions. (The script being `cmake_modules/morse_cmake/modules/precision_generator/genDependencies.py`) This should be fixed by calling `pip install regex` (which requires installing the `python3-pip` Ubuntu package). You may also need to replace the `import re` line in that script by `import regex as re`, but the necessity seems to fluctuate among different machines.
+- On some occasions, a Python script called by CMake (`cmake_modules/morse_cmake/modules/precision_generator/genDependencies.py`) generates an incorrect Makefile because of errors in regular expressions. This should be fixed by calling `pip install regex` (which requires installing the `python3-pip` Ubuntu package). You may also need to replace the `import re` line in that script by `import regex as re`, but the necessity seems to fluctuate among different machines.
 - Some parts of the code require older versions of the GNU compilers. You may have to replace `gcc` by `gcc-7` and similarly for `g++` and `gfortran` in the `make_pastix.sh` script. This requires installing the relevant Ubuntu packages.
 
 ## Building ARPACK, a CalculiX dependency

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -48,6 +48,8 @@ Clone OpenBLAS source code and build it with 8 bytes integers option.
 
 ```
 
+You can also specify a custom installation path (to avoid calling `sudo`) by using the `PREFIX=path/to/install` option of the Makefile.
+
 ### Building hwloc
 
 This library will be put in a subfolder of the PaStiX folder.

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -147,7 +147,12 @@ Due to some conflicts between CalculiX, PaStiX and the adapter (both CalculiX an
 
 ### Compilation
 
-To build the adapter, use the provided `Makefile_i8_PaStiX`: the regular Makefile would build the adapter without PaStiX. Assuming you followed the previous steps, it should be useable without modifications other than giving Calculix' path; otherwise, some other paths updates could be required. Run this command in the `calculix-adapter` (and be sure to checkout the `2.17` branch) folder :
+To build the adapter, use the provided `Makefile_i8_PaStiX`: the regular Makefile would build the adapter without PaStiX. Assuming you followed the previous steps, it should be useable without modifications other than giving Calculix' path; otherwise, some other paths updates could be required. You also need to ensure then Makefile finds the required dependencies when calling `pkg-config`. This can be done by changing the `PKG_PATH_CONFIG` environment variable. Assuming you used suggested paths, this would look like this:
+```bash
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:~/PaStiX/pastix_i8/lib/pkgconfig/:~/PaStiX/hwloc_i8/lib/pkgconfig/:~/PaStiX/parsec_i8/lib/pkgconfig/
+```
+
+Then you can build the adapter with this command in the `calculix-adapter` (and be sure to checkout the `2.17` branch) folder :
 
 ```bash
     make -f Makefile_i8_PaStiX -j 4 CCX=~/CalculiX/ccx_2.17/src
@@ -157,9 +162,4 @@ Once the build is successful, the adapter should be in `./bin/ccx_preCICE`.
 
 ### Updating shared libraries
 
-Running the adapter at this point should fail because of a missing shared library: `libparsec.so.2`. A possible fix to this is to copy it in your local library folder and run `ldconfig`:
-
-```bash
-    sudo cp ~/PaStiX/parsec_i8/lib/libparsec.so.2 /usr/local/lib
-    sudo ldconfig
-```
+Running the adapter at this point should fail because of a missing shared library: `libparsec.so.2`. You can fix this by adding its path to the environment variable `LD_LIBRARY_PATH`: `export LD_LIBRARY_PATH=:$LD_LIBRARY_PATH:~/PaStiX/parsec_i8/lib`. You may have to do this everytime you load a new terminal, which is why we advise you to make this change permanent, for instance by adding this export commande at the end of your `.bashrc` file.

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -122,7 +122,7 @@ zcat patch.tar.gz    | tar -xvf -
 
 ```
 
-Before building the library, the following modifications are required :
+Before building the library, the following modifications are required:
 
 - In `ARmake.inc`, change `PLAT` by the appropriate suffix (the adapter's makefile assumes INTEL)
 - In `ARmake.inc`, change the Fortran compilation flags to add `-fdefault-integer-8`. You may also need to remove the flag `-cg89`.

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -159,6 +159,7 @@ Due to some conflicts between CalculiX, PaStiX and the adapter (both CalculiX an
 ### Compilation
 
 To build the adapter, use the provided `Makefile_i8_PaStiX`: the regular Makefile would build the adapter without PaStiX. Assuming you followed the previous steps, it should be useable without modifications other than giving Calculix' path; otherwise, some other paths updates could be required. You also need to ensure then Makefile finds the required dependencies when calling `pkg-config`. This can be done by changing the `PKG_PATH_CONFIG` environment variable. Assuming you used suggested paths, this would look like this:
+
 ```bash
 export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:~/PaStiX/pastix_i8/lib/pkgconfig/:~/PaStiX/hwloc_i8/lib/pkgconfig/:~/PaStiX/parsec_i8/lib/pkgconfig/
 ```

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -13,8 +13,8 @@ This should work with some modifications on other systems.
 
 ## Required packages
 
-Make sur you have a working installation of preCICE. Also run these installation commands :
-
+Make sur you have a working installation of preCICE. Also run these installation commands, (after a call to `sudo apt update` and `sudo apt upgrade`) :
+build-essential cmake git gfortran flex bison zlib1g-dev
 
 
 ## Downloading CalculiX
@@ -43,10 +43,11 @@ Clone OpenBLAS source code and build it with 8 bytes integers option.
 ```
     cd ~ 
     git clone https://github.com/xianyi/OpenBLAS.git 
-    OpenBLAS ./OpenBLAS_i8
+    mv OpenBLAS ./OpenBLAS_i8
     cd OpenBLAS_i8 
     make -j 4 INTERFACE64=1 
-    sudo make install
+    mkdir ~/OpenBLAS_i8_install
+    make install PREFIX=~/OpenBLAS_i8_install
 
 ```
 
@@ -59,7 +60,8 @@ This library will be put in a subfolder of the PaStiX folder.
     wget https://download.open-mpi.org/release/hwloc/v2.1/hwloc-2.1.0.tar.bz2
     bunzip2 hwloc-2.1.0.tar.bz2 && tar -xf hwloc-2.1.0.tar
     sudo cp /usr/local/CalculiX/ccx_2.17/src/make_hwloc.sh ~/PaStiX/hwloc-2.1.0/make_hwloc.sh
-    ./configure --prefix=$HOME/PaStiX/hwloc_i8 CC=gcc CXX=g++ &&
+    cd hwloc-2.1.0
+    ./configure --prefix=$HOME/PaStiX/hwloc_i8 CC=gcc CXX=g++
     make -j8
     make install
 
@@ -70,6 +72,7 @@ This library will be put in a subfolder of the PaStiX folder.
 
 ```
     cd ~/PaStiX && git clone -b pastix-6.0.2 --single-branch https://bitbucket.org/mfaverge/parsec.git
+    cd parsec
     cp /usr/local/CalculiX/ccx_2.17/src/make_parsec.sh ~/PaStiX/parsec
     /make_parsec.sh
 
@@ -81,11 +84,16 @@ This library will be put in a subfolder of the PaStiX folder.
     cd ~/PaStiX
     wget https://gforge.inria.fr/frs/download.php/file/38114/scotch_6.0.8.tar.gz
     tar -xf scotch_6.0.8.tar.gz
-    cp /usr/local/CalculiX/ccx_2.17/src/make_scotch.sh ~/PaStiX/scotch_6.0.8 &&
-    scotch_6.0.8
+    cp /usr/local/CalculiX/ccx_2.17/src/make_scotch.sh ~/PaStiX/scotch_6.0.8
+    cd scotch_6.0.8
     ./make_scotch.sh
 
 ```
+
+
+## Building PaStiX
+
+TODO : CUDA ??
 
 ## Start here
 

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -18,13 +18,12 @@ Make sure you have a working installation of preCICE. Also run these installatio
 
 ## Downloading CalculiX source
 
-Build scripts assume that CalculiX' source code is in `/usr/local`. Donwload it, extract it there and add read/write access to the folder.
+This guide assumes Calculix's source code is in the user's home folder `/home/user_name`, with the alias `~`. If you don't want to follow this convention, you may have to adapt slightly the instructions below. Donwload can be done on command line:
 
 ```bash
-    cd /usr/local/ && sudo wget http://www.dhondt.de/ccx_2.17.src.tar.bz2
-    sudo bunzip2 ccx_2.17.src.tar.bz2
-    sudo tar -xvf ccx_2.17.src.tar
-    sudo chmod -R a+rw /usr/local/CalculiX
+    cd ~ && wget http://www.dhondt.de/ccx_2.17.src.tar.bz2
+    bunzip2 ccx_2.17.src.tar.bz2
+    tar -xvf ccx_2.17.src.tar
 
 ```
 
@@ -58,7 +57,7 @@ This library will be put in a subfolder of the PaStiX folder.
     cd ~/PaStiX/ 
     wget https://download.open-mpi.org/release/hwloc/v2.1/hwloc-2.1.0.tar.bz2
     bunzip2 hwloc-2.1.0.tar.bz2 && tar -xf hwloc-2.1.0.tar
-    sudo cp /usr/local/CalculiX/ccx_2.17/src/make_hwloc.sh ~/PaStiX/hwloc-2.1.0/make_hwloc.sh
+    cp ~/CalculiX/ccx_2.17/src/make_hwloc.sh ~/PaStiX/hwloc-2.1.0/make_hwloc.sh
     cd hwloc-2.1.0
     ./configure --prefix=$HOME/PaStiX/hwloc_i8 CC=gcc CXX=g++
     make -j8
@@ -71,7 +70,7 @@ This library will be put in a subfolder of the PaStiX folder.
 ```bash
     cd ~/PaStiX && git clone -b pastix-6.0.2 --single-branch https://bitbucket.org/mfaverge/parsec.git
     cd parsec
-    cp /usr/local/CalculiX/ccx_2.17/src/make_parsec.sh ~/PaStiX/parsec
+    cp ~/CalculiX/ccx_2.17/src/make_parsec.sh ~/PaStiX/parsec
     ./make_parsec.sh
 
 ```
@@ -82,7 +81,7 @@ This library will be put in a subfolder of the PaStiX folder.
     cd ~/PaStiX
     wget https://gforge.inria.fr/frs/download.php/file/38114/scotch_6.0.8.tar.gz
     tar -xf scotch_6.0.8.tar.gz
-    cp /usr/local/CalculiX/ccx_2.17/src/make_scotch.sh ~/PaStiX/scotch_6.0.8
+    cp ~/CalculiX/ccx_2.17/src/make_scotch.sh ~/PaStiX/scotch_6.0.8
     cd scotch_6.0.8
     ./make_scotch.sh
 
@@ -95,7 +94,7 @@ This library will be put in a subfolder of the PaStiX folder.
     mv PaStiX4CalculiX pastix_src
     cd pastix_src
     rm make_pastix.sh
-    cp /usr/local/CalculiX/ccx_2.17/src/make_pastix.sh .
+    cp ~/CalculiX/ccx_2.17/src/make_pastix.sh .
     ./make_pastix.sh
 
 ```
@@ -148,10 +147,10 @@ Due to some conflicts between CalculiX, PaStiX and the adapter (both CalculiX an
 
 ### Compilation
 
-To build the adapter, use the provided `Makefile_i8_PaStiX` : the regular Makefile would build the adapter without PaStiX. Assuming you followed the previous steps, it should be useable without modifications; otherwise, some paths updates could be required. Run this command in the `calculix-adapter` (and be sure to checkout the `2.17` branch) folder :
+To build the adapter, use the provided `Makefile_i8_PaStiX`: the regular Makefile would build the adapter without PaStiX. Assuming you followed the previous steps, it should be useable without modifications other than giving Calculix' path; otherwise, some other paths updates could be required. Run this command in the `calculix-adapter` (and be sure to checkout the `2.17` branch) folder :
 
 ```bash
-    make -f Makefile_i8_PaStiX -j 4 
+    make -f Makefile_i8_PaStiX -j 4 CCX=~/CalculiX/ccx_2.17/src
 ```
 
 Once the build is successful, the adapter should be in `./bin/ccx_preCICE`.

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -111,7 +111,7 @@ This library will be put in a subfolder of the PaStiX folder.
 
 ## Building ARPACK, a CalculiX dependency
 
-Calculix relies on ARPACK, and when built with PaStiX, we cannot rely on standard distributions of that library, because it doesn't feature 8-bytes integers by default. We need to compile it ourself. The source code can be found [here](https://www.caam.rice.edu/software/ARPACK/), or by running these commands :
+Calculix relies on ARPACK, and when built with PaStiX, we cannot rely on standard distributions of that library, because it doesn't feature 8-byte integers by default. We need to build the [ARPACK code](https://www.caam.rice.edu/software/ARPACK/) ourselves:
 
 ```bash
 cd ~

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -36,7 +36,7 @@ PaStiX requires OpenBLAS, hwloc, Scotch and PaRSEC. All of these will be built b
 
 ### Building OpenBLAS
 
-Clone OpenBLAS source code and build it with 8 bytes integers option.
+Clone OpenBLAS source code and build it with 8-byte integers.
 
 ```bash
     cd ~ 

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -16,7 +16,6 @@ This should work with some modifications on other systems.
 Make sur you have a working installation of preCICE. Also run these installation commands, (after a call to `sudo apt update` and `sudo apt upgrade`) :
 `sudo apt install build-essential cmake git gfortran flex bison zlib1g-dev nvidia-cuda-toolkit-gcc libspooles-dev libyaml-cpp-dev`
 
-nvidia-cuda-toolkit-gcc ? liblapacke-dev ? 64 ?
 
 ## Downloading CalculiX source
 
@@ -48,7 +47,7 @@ Clone OpenBLAS source code and build it with 8 bytes integers option.
     cd OpenBLAS_i8 
     make -j 4 INTERFACE64=1 
     mkdir ~/OpenBLAS_i8_install
-    make install PREFIX=~/OpenBLAS_i8_install
+    sudo make install
 
 ```
 
@@ -122,44 +121,39 @@ The github repository contains a `make_pastix.sh` file; be sure to use the one i
 
 ## Building the adapter
 
-TODO : adapt makefile
+To build the adapter, clone its repository and checkout the `2.17` branch : 
+
+```
+    git clone -b 2.17 https://github.com/precice/calculix-adapter
+    cd calculix-adapter
+```
 
 ### Fixing the code
 
+Due to some conflicts between CalculiX, PaStiX and the adapter (both CalculiX and PaStiX have a `pastix.h` file, and neither of them is local from the point of view of the adapter), some changes are required in the CalculiX codebase. We provide a script, `pastix_pre_build.sh` that does these changes. Run it.
+
+```
+    ./pastix_pre_build.sh
+```
+
+
+### Compilation
+
+To build the adapter, use the provided `Makefile_i8_PaStiX` : the regular Makefile would build the adapter without PaStiX. Assuming you followed the previous steps, it should be useable without modifications; otherwise, some paths updates could be required. Run this command in the `calculix-adapter` (and be sure to checkout the `2.17` branch) folder :
+
+
+```
+    make -f Makefile_i8_PaStiX -j 4 
+```
+
+Once the build is successful, the adapter should be in `./bin/ccx_preCICE`.
+
+
 ### Updating shared libraries
 
+Running the adapter at this point should fail because of a missing shared library : `libparsec.so.2`. A possible fix to this is to copy it in your local library folder and run `ldconfig` : 
 
-## Start here
-
-1. [Get CalculiX and the dependencies](adapter-calculix-get-calculix.html)
-2. [Build the Adapter](adapter-calculix-get-adapter.html)
-3. [Configure and run simulations](adapter-calculix-config.html)
-4. Follow a tutorial:
-   * [Tutorial for CHT with OpenFOAM and CalculiX](https://github.com/precice/precice/wiki/Tutorial-for-CHT-with-OpenFOAM-and-CalculiX): Flow in a shell-and-tube heat exchanger
-   * [Tutorial for FSI with OpenFOAM and CalculiX](https://github.com/precice/precice/wiki/Tutorial-for-FSI-with-OpenFOAM-and-CalculiX): Flow in a channel with an elastic flap, either perpendicular, or parallel to the flow and attached to a cylinder.
-   * [Tutorial on structure-structure coupling](https://github.com/precice/precice/wiki/Tutorial-for-SSI-with-CalculiX): Elastic beam artificially cut into two halves.
-
-Are you encountering an unexpected error? Have a look at our [Troubleshooting](adapter-calculix-troubleshooting.html) page.
-
-Do you Want to build on a cluster? Look at our [instructions for SuperMUC](adapter-calculix-supermuc.html) (outdated).
-
-## Versions
-
-Please check the [Calculix adapter README](https://github.com/precice/calculix-adapter/blob/master/README.md) for the newest compatible CalculiX version.
-
-Adapters for older versions of CalculiX and preCICE are available in various branches. Branches compatible with **preCICE v2.x:**
-
-* master
-* v2.15_preCICE2.x
-
-All other branches are compatible with **preCICE v1.x**.
-
-## History
-
-The adapter was initially developed for conjugate heat transfer (CHT) simulations via preCICE by Lucia Cheung in the scope of her master’s thesis [[1]](https://www5.in.tum.de/pub/Cheung2016_Thesis.pdf) in cooperation with [SimScale](https://www.simscale.com/). For running the adapter for CHT simulations refer to this thesis. The adapter was extended to fluid-structure interaction by Alexander Rusch [[2]](https://www.gacm2017.uni-stuttgart.de/registration/Upload/ExtendedAbstracts/ExtendedAbstract_0138.pdf).
-
-## References
-
-[1] Lucia Cheung Yau. Conjugate heat transfer with the multiphysics coupling library precice. Master’s thesis, Department of Informatics, Technical University of Munich, 2016.
-
-[2] Benjamin Uekermann, Hans-Joachim Bungartz, Lucia Cheung Yau, Gerasimos Chourdakis and Alexander Rusch. Official preCICE Adapters for Standard Open-Source Solvers. In Proceedings of the _7th GACM Colloquium on Computational Mechanics for Young Scientists from Academia_, 2017.
+```
+    sudo cp ~/PaStiX/parsec_i8/lib/libparsec.so.2 /usr/local/lib
+    sudo ldconfig
+```

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -158,7 +158,7 @@ Once the build is successful, the adapter should be in `./bin/ccx_preCICE`.
 
 ### Updating shared libraries
 
-Running the adapter at this point should fail because of a missing shared library : `libparsec.so.2`. A possible fix to this is to copy it in your local library folder and run `ldconfig` :
+Running the adapter at this point should fail because of a missing shared library: `libparsec.so.2`. A possible fix to this is to copy it in your local library folder and run `ldconfig`:
 
 ```bash
     sudo cp ~/PaStiX/parsec_i8/lib/libparsec.so.2 /usr/local/lib

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -112,12 +112,24 @@ The github repository contains a `make_pastix.sh` file; be sure to use the one i
 
 ## Building ARPACK, a CalculiX dependency
 
-- PLAT=INTEL
-- FFLAGS : -fdefault-integer-8
-- Home path
-- Comment cg89 ?
-- UTIL/second.f
-- make lib
+Calculix relies on ARPACK, and when built with PaStiX, we cannot rely on standard distributions of that library, because it doesn't feature 8-bytes integers by default. We need to compile it ourself. The source code can be found [here](https://www.caam.rice.edu/software/ARPACK/), or by running these commands : 
+
+```
+cd ~
+wget https://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz
+wget https://www.caam.rice.edu/software/ARPACK/SRC/patch.tar.gz
+zcat arpack96.tar.gz | tar -xvf -
+zcat patch.tar.gz    | tar -xvf -
+
+```
+
+Before building the library, the following modifications are required : 
++ In `ARmake.inc', change `PLAT` by the appropriate suffix (the adapter's makefile assumes INTEL)
++ In `ARmake.inc', change the Fortran compilation flags to add `-fdefault-integer-8'. You may also need to remove the flag `-cg89'.
++ If you extracted the archive on another folder than your home repository, update `home` in `ARmake.inc` accordingly.
++ In the file `UTIL/second.f`, comment with a star the line containing `EXTERNAL ETIME`.
+
+Once all of these are done, simply run `make lib` in the `ARPACK` folder.
 
 ## Building the adapter
 

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -9,7 +9,7 @@ is somehow harder with this version. This page gives a detailed walkthrough to b
 ## Overview
 
 To build the preCICE adapter for CalculiX with PaStiX, it is first necessary to build PaStiX. A manual build is necessary for most steps, as specific compilation flags must be used for the dependencies: pre-built packages cannot be used. In particular, PaStiX (and CalculiX) must be compiled with flags to use 8-byte integers. On this page, we provide a step-by-step building guide of the adapter, tested on Ubuntu 20.04.
-This should work with some modifications on other systems.
+This should work with some modifications on other systems. You may also need to tweak this depending on your needs, e.g. if you want to build some dependencies yourself instead of using a package manager.
 
 ## Required packages
 
@@ -32,7 +32,7 @@ This contains the source code of CalculiX, but also scripts useful for building 
 ## Building PaStiX dependencies
 
 It is assumed that all these libraries will be built on the user home folder, `~`. Minor modifications will be required otherwise.
-PaStiX requires OpenBLAS, hwloc, Scotch and PaRSEC. All of these will be built before PaStiX itself.
+PaStiX requires OpenBLAS, hwloc, Scotch and PaRSEC. All of these will be built before PaStiX itself. We need to build them from source because specific flags are necessary to work with CalculiX' version of PaStiX, mostly the use of 8 bytes integers.
 
 ### Building OpenBLAS
 

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -14,11 +14,11 @@ This should work with some modifications on other systems.
 ## Required packages
 
 Make sur you have a working installation of preCICE. Also run these installation commands, (after a call to `sudo apt update` and `sudo apt upgrade`) :
-`sudo apt install build-essential cmake git gfortran flex bison zlib1g-dev nvidia-cuda-toolkit-gcc`
+`sudo apt install build-essential cmake git gfortran flex bison zlib1g-dev nvidia-cuda-toolkit-gcc libspooles-dev libyaml-cpp-dev`
 
 nvidia-cuda-toolkit-gcc ? liblapacke-dev ? 64 ?
 
-## Downloading CalculiX
+## Downloading CalculiX source
 
 Build scripts assume that CalculiX' source code is in `/usr/local`. Donwload it, extract it there and add read/write access to the folder.
 
@@ -94,7 +94,40 @@ This library will be put in a subfolder of the PaStiX folder.
 
 ## Building PaStiX
 
-TODO : CUDA ??
+```
+    git clone https://github.com/Dhondtguido/PaStiX4CalculiX 
+    mv PaStiX4CalculiX pastix_src
+    cd pastix_src
+    rm make_pastix.sh
+    cp /usr/local/CalculiX/ccx_2.17/src/make_pastix.sh .
+    ./make_pastix.sh
+
+```
+
+The github repository contains a `make_pastix.sh` file; be sure to use the one in the CalculiX folder and not this one !
+
+### Troubleshooting
+
+- On some occasions, a Python script called by CMake generates an incorrect Makefile because of errors in regular expressions. (The script being `cmake_modules/morse_cmake/modules/precision_generator/genDependencies.py`) This should be fixed by calling `pip install regex` (which requires installing the `python3-pip` Ubuntu package). You may also need to replace the `import re` line in that script by `import regex as re`, but the necessity seems to fluctuate among different machines.
+- Some parts of the code require older versions of the GNU compilers. You may have to replace `gcc` by `gcc-7` and similarly for `g++` and `gfortran` in the `make_pastix.sh` script. This requires installing the relevant Ubuntu packages.
+
+## Building ARPACK, a CalculiX dependency
+
+- PLAT=INTEL
+- FFLAGS : -fdefault-integer-8
+- Home path
+- Comment cg89 ?
+- UTIL/second.f
+- make lib
+
+## Building the adapter
+
+TODO : adapt makefile
+
+### Fixing the code
+
+### Updating shared libraries
+
 
 ## Start here
 

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -46,7 +46,6 @@ Clone OpenBLAS source code and build it with 8 bytes integers option.
     mv OpenBLAS ./OpenBLAS_i8
     cd OpenBLAS_i8 
     make -j 4 INTERFACE64=1 
-    mkdir ~/OpenBLAS_i8_install
     sudo make install
 
 ```
@@ -124,8 +123,8 @@ zcat patch.tar.gz    | tar -xvf -
 ```
 
 Before building the library, the following modifications are required : 
-+ In `ARmake.inc', change `PLAT` by the appropriate suffix (the adapter's makefile assumes INTEL)
-+ In `ARmake.inc', change the Fortran compilation flags to add `-fdefault-integer-8'. You may also need to remove the flag `-cg89'.
++ In `ARmake.inc`, change `PLAT` by the appropriate suffix (the adapter's makefile assumes INTEL)
++ In `ARmake.inc`, change the Fortran compilation flags to add `-fdefault-integer-8`. You may also need to remove the flag `-cg89`.
 + If you extracted the archive on another folder than your home repository, update `home` in `ARmake.inc` accordingly.
 + In the file `UTIL/second.f`, comment with a star the line containing `EXTERNAL ETIME`.
 


### PR DESCRIPTION
Since a few months, it has been reported (https://github.com/precice/calculix-adapter/issues/57) that building the CalculiX adapter with PaStiX (which is possible since CCX 2.17) is troublesome. After a long investigation and many attempts, I managed to do it and noted all the ways it could go wrong. This PR thus includes a new page (+ links to it) explaining in detail how to build the adapter with PaStiX.

- Some fixes to the adapter must be merged before this documentation makes sense, as the current adapter code doesn't support PaStiX. This PR has a twin PR on the adapter : https://github.com/precice/calculix-adapter/pull/71 . This PR shouldn't be merged until the adapter is updated.
- I refer to the use of `ldconfig` but I don't really master this tool. Feedback on that last section is welcome !
- This is my first change to the website. Please check that I did this the correct way. (Correct links, sidebar, ...)
It does look good on my local version of the website, so I'm optimistic.