### PR TITLE
Provide more information on preCICE and pyprecice version compatibility and installation

### DIFF
--- a/pages/docs/installation/installation-bindings-python.md
+++ b/pages/docs/installation/installation-bindings-python.md
@@ -13,7 +13,7 @@ Example: version `1` of the python bindings for preCICE version `2.2.0` is `2.2.
 
 ## Installation
 
-The python bindings for preCICE are [published on PyPI](https://pypi.org/project/pyprecice/) with the package `pyprecice`. You can use your python package manager for installing the language bindings. For example, `pip3 install --user pyprecice`. Note that preCICE and MPI have to be installed on your system.
+The python bindings for preCICE are [published on PyPI](https://pypi.org/project/pyprecice/) with the package `pyprecice`. You can use your python package manager for installing the language bindings. For example, `pip3 install --user pyprecice`. This will automatically install the latest version of the bindings. If you are using an older version, you have to explicitly tell pip to download the correct version (For example, `pip3 install --user pyprecice==2.2.0.2` for preCICE version `2.2.0`). See [the PyPI release history](https://pypi.org/project/pyprecice/#history) for a list of available version. Note that preCICE and MPI have to be installed on your system.
 
 ## Usage
 

--- a/pages/docs/installation/installation-bindings-python.md
+++ b/pages/docs/installation/installation-bindings-python.md
@@ -13,7 +13,7 @@ Example: version `1` of the python bindings for preCICE version `2.2.0` is `2.2.
 
 ## Installation
 
-The python bindings for preCICE are [published on PyPI](https://pypi.org/project/pyprecice/) with the package `pyprecice`. You can use your python package manager for installing the language bindings. For example, `pip3 install --user pyprecice`. This will automatically install the latest version of the bindings. If you are using an older version, you have to explicitly tell pip to download the correct version (For example, `pip3 install --user pyprecice==2.2.0.2` for preCICE version `2.2.0`). See [the PyPI release history](https://pypi.org/project/pyprecice/#history) for a list of available version. Note that preCICE and MPI have to be installed on your system.
+The python bindings for preCICE are [published on PyPI](https://pypi.org/project/pyprecice/) with the package `pyprecice`. You can use your python package manager for installing the language bindings. For example, `pip3 install --user pyprecice`. This will automatically install the latest version of the bindings compatible with the latest version of preCICE. If you are using an older version of preCICE, you have to explicitly tell pip to download the correct version (For example, `pip3 install --user pyprecice==2.2.0.2` for preCICE version `2.2.0`). See [the PyPI release history](https://pypi.org/project/pyprecice/#history) for a list of available version. Note that preCICE and MPI have to be installed on your system.
 
 ## Usage
 


### PR DESCRIPTION
We should add more information here, because compatibility problems can lead to confusing errors when trying to install the bindings. Latest example: preCICE 2.2.0 and pyprecice 2.3.0.1 are incompatible due to the recently added new API methods ([`setMeshAccessRegion`](https://github.com/precice/precice/blob/6e00e86c88c8020cc0b29c424a7714d86413724d/src/precice/SolverInterface.hpp#L855) etc.).