### PR TITLE
Add community Conda packages

### DIFF
--- a/pages/docs/installation/installation-packages.md
+++ b/pages/docs/installation/installation-packages.md
@@ -40,3 +40,4 @@ However, we appreciate the effort and you may be able to contribute to them.
 - [MSYS2](https://packages.msys2.org/base/mingw-w64-precice) (for Windows, built with MinGW), [thread on our forum](https://precice.discourse.group/t/precice-and-mingw-packages/382)
 - [Nix / NixOS](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&query=precice)
 - [EasyBuild](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/p/preCICE)
+- [Conda](https://anaconda.org/conda-forge/precice) (see also packages [pyprecice](https://anaconda.org/conda-forge/pyprecice) and [fenicsprecice](https://anaconda.org/conda-forge/fenicsprecice)

--- a/pages/docs/installation/installation-packages.md
+++ b/pages/docs/installation/installation-packages.md
@@ -40,4 +40,4 @@ However, we appreciate the effort and you may be able to contribute to them.
 - [MSYS2](https://packages.msys2.org/base/mingw-w64-precice) (for Windows, built with MinGW), [thread on our forum](https://precice.discourse.group/t/precice-and-mingw-packages/382)
 - [Nix / NixOS](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&query=precice)
 - [EasyBuild](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/p/preCICE)
-- [Conda](https://anaconda.org/conda-forge/precice) (see also packages [pyprecice](https://anaconda.org/conda-forge/pyprecice) and [fenicsprecice](https://anaconda.org/conda-forge/fenicsprecice)
+- [Conda](https://anaconda.org/conda-forge/precice) (see also packages [pyprecice](https://anaconda.org/conda-forge/pyprecice) and [fenicsprecice](https://anaconda.org/conda-forge/fenicsprecice))


### PR DESCRIPTION
This adds the Conda packages [precice](https://anaconda.org/conda-forge/precice) and [pyprecice](https://anaconda.org/conda-forge/pyprecice), as well as the upcoming `fenicsprecice` (needs that https://github.com/conda-forge/staged-recipes/pull/16960 gets merged first). Thanks a lot to @jan-janssen for creating the packages!

I had a bit of trouble in the past supporting users with installation issues after mixing package managers and Conda was often in the mix (e.g., installing a different compiler or MPI version). This is of course a responsibility of the user to know what they have done on their system, but new users often do all kinds of strange things semi-unintentionally. This set of packages should be fine, but I would hesitate advertising (any) Conda packages as one of the main options to try. I think adding these here is perfect for people that already know what they are doing and we should not need any warning.

@jan-janssen did you maybe already experience any incompatibilities between these and other packages?