### PR TITLE
Make native doxygen website more visible

### DIFF
--- a/pages/docs/couple-your-code/couple-your-code-api.md
+++ b/pages/docs/couple-your-code/couple-your-code-api.md
@@ -15,8 +15,6 @@ The definite documentation of the C++ API is available on [the preCICE doxygen p
 |----------------|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
 | C++            | [`precice/precice/tree/master/src/precice/SolverInterface.hpp`](https://github.com/precice/precice)       | Automatically included                                          |
 
-
-
 ## Bindings
 
 Besides the C++ API, there are also bindings to other languages available:

--- a/pages/docs/couple-your-code/couple-your-code-api.md
+++ b/pages/docs/couple-your-code/couple-your-code-api.md
@@ -9,7 +9,7 @@ preCICE is written in C++. Thus, the native API language of preCICE is C++ as we
 
 ## Native API
 
-The definite documentation of the C++ API is available on [the preCICE C++ API website](https://precice.org/doxygen/master/classprecice_1_1SolverInterface.html).
+The definite documentation of the C++ API is available on [the preCICE doxygen pages](https://precice.org/doxygen/master/classprecice_1_1SolverInterface.html).
 
 | Language       | Location                                                                                    | Installation                                                                  |
 |----------------|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|

--- a/pages/docs/couple-your-code/couple-your-code-api.md
+++ b/pages/docs/couple-your-code/couple-your-code-api.md
@@ -5,7 +5,17 @@ keywords: api, adapter, library, bindings, SolverInterface
 summary: "This page gives an overview on available preCICE APIs and minimal reference implementations."
 ---
 
-preCICE is written in C++. Thus, the native API language of preCICE is C++ as well. Its definite documentation is available on [the preCICE doxygen](https://precice.org/doxygen/master/classprecice_1_1SolverInterface.html). If you are new to the preCICE API, however, we recommended that you first follow the [step-by-step guide](couple-your-code-preparing-your-solver.html).
+preCICE is written in C++. Thus, the native API language of preCICE is C++ as well. If you are new to the preCICE API, however, we recommended that you first follow the [step-by-step guide](couple-your-code-preparing-your-solver.html).
+
+## Native API
+
+The definite documentation of the C++ API is available on [the preCICE C++ API website](https://precice.org/doxygen/master/classprecice_1_1SolverInterface.html).
+
+| Language       | Location                                                                                    | Installation                                                                  |
+|----------------|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| C++            | [`precice/precice/tree/master/src/precice/SolverInterface.hpp`](https://github.com/precice/precice)       | Automatically included                                          |
+
+
 
 ## Bindings
 

--- a/pages/docs/couple-your-code/couple-your-code-api.md
+++ b/pages/docs/couple-your-code/couple-your-code-api.md
@@ -5,7 +5,7 @@ keywords: api, adapter, library, bindings, SolverInterface
 summary: "This page gives an overview on available preCICE APIs and minimal reference implementations."
 ---
 
-preCICE is written in C++. Thus, the native API language of preCICE is C++ as well. If you are new to the preCICE API, however, we recommended that you first follow the [step-by-step guide](couple-your-code-preparing-your-solver.html).
+preCICE is written in C++. Thus, the native API language of preCICE is C++ as well. If you are new to the preCICE API, we recommended that you first follow the [step-by-step guide](couple-your-code-preparing-your-solver.html).
 
 ## Native API
 


### PR DESCRIPTION
This adds an additional section referring to the native C++ API and moves the Doxygen link there. This should make the API documentation more visible and easier to find as not everyone might know Doxygen. Before, the link to the API documentation was hidden in the running text. The change also makes the representation of available APIs more consistent as all APIs are represented by a tables now.