### PR TITLE
Move link to box out of "how to use" section

### DIFF
--- a/pages/docs/installation/installation-vm.md
+++ b/pages/docs/installation/installation-vm.md
@@ -30,7 +30,7 @@ This contains all the solvers and adapters used in our tutorials, already built 
 
 ![Screnshot](images/docs/docs-installation-vm-screenshot.jpg)
 
-See [what is included](https://github.com/precice/vm/blob/main/README.md#what-is-included) in detail.
+See [what is included](https://github.com/precice/vm/blob/main/README.md#what-is-included) in detail. See [the box](https://app.vagrantup.com/precice/boxes/precice-vm) directly on vagrant.
 
 ## How to use this?
 
@@ -42,7 +42,7 @@ Note once more that this will consume a significant amount of storage and main m
 1. Install [Vagrant](https://www.vagrantup.com/) **and** [VirtualBox](https://www.virtualbox.org/) (6.0 or later).
 2. Start your terminal / command prompt and go to an empty directory.
 3. Run `vagrant init precice/precice-vm` to prepare the directory.
-4. Run `vagrant up` to download [the box](https://app.vagrantup.com/precice/boxes/precice-vm) (~4GB) and start the system.
+4. Run `vagrant up` to download the box (~4GB) and start the system.
 5. Open VirtualBox: A new virtual machine should be running. Double-click to open its window. The login password in `vagrant`.
 
 Alternatively, you can connect to the vm while being able to use graphical applications using `vagrant ssh -- -Y`.


### PR DESCRIPTION
In a lecture, a student directly clicked on the link, downloaded the box from the website and did then not know how to go on.
By removing the link, we could avoid this misunderstanding.

Not directly related: Another student reported that they ran into a firewall problem on windows similar to [this one](https://superuser.com/questions/1013019/vagrant-up-not-working-on-windows-7-behind-firewall) maybe. I do not have the error message.
@MakisH Have you seen this one already? Should we add somewhere a statement that maybe users have to tweak their firewall?
