### PR TITLE
Add documentation of binprecice

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -213,6 +213,10 @@ entries:
       url: /tooling-overview.html
       output: web, pdf
 
+    - title: Built-in tooling
+      url: /tooling-builtin.html
+      output: web, pdf
+
     - title: Config visualization
       url: /tooling-config-visualization.html
       output: web, pdf

--- a/pages/docs/tooling/tooling-builtin.md
+++ b/pages/docs/tooling/tooling-builtin.md
@@ -9,6 +9,7 @@ Part of a preCICE installation is the tool `binprecice`.
 It provides an easy-to-use interface to tooling API of the preCICE library.
 
 With `binprecice`, you can get the installed preCICE version, generate a reference of all available configuration options, as well as check your configuration file for basic configuration issues.
+
 ## XML reference
 
 ```bash

--- a/pages/docs/tooling/tooling-builtin.md
+++ b/pages/docs/tooling/tooling-builtin.md
@@ -72,7 +72,7 @@ binprecice check FILE [ PARTICIPANT [ COMMSIZE ] ]
 The `check` runs the preCICE configuration parsing and checking logic on the given configuration file.
 This will find the majority of the configuration mistakes without having to start a simulation.
 These checks include wrong tags and attribute values, and more elaborate naming checks.
-More intricate logic, such as checks if all necessary data are exchanged in a Coupling Schemes, are not covered.
+More advanced logic, such as checks if all necessary data are exchanged in a coupling scheme, are not covered.
 
 The basic usage is to simply check a configuration file:
 

--- a/pages/docs/tooling/tooling-builtin.md
+++ b/pages/docs/tooling/tooling-builtin.md
@@ -10,10 +10,10 @@ It provides an easy-to-use interface to tooling API of the preCICE library.
 
 ## XML reference
 
-```
-$ binprecice md
-$ binprecice xml
-$ binprecice dtd
+```bash
+binprecice md
+binprecice xml
+binprecice dtd
 ```
 
 This prints the XML reference to the console in various flavours.
@@ -26,8 +26,8 @@ You can find the reference of the latest release [on the website](configuration-
 It is possible to generate a local version of the reference by rendering the Markdown to HTML using the `markdown` command.
 Be aware that this version does not contain styling, LaTeX rendering, and functioning links.
 
-```
-$ binprecice md | markdown > reference.html
+```bash
+binprecice md | markdown > reference.html
 ```
 
 ### `xml`
@@ -44,8 +44,8 @@ This prints the DTD information, which can be used to validate the XML configura
 This feature is available since version 2.4.0.
 {% endversion %}
 
-```
-$ binprecice version
+```bash
+binprecice version
 ```
 
 This prints the version information of preCICE, which consists of multiple semicolon-separated parts.
@@ -57,15 +57,14 @@ This prints the version information of preCICE, which consists of multiple semic
 3. Configuration options for MPI, PETSc, Python and some more.
 4. Compilation and linker flags used to build preCICE
 
-
 ## Configuration check
 
 {% version 2.4.0 %}
 This feature is available since version 2.4.0.
 {% endversion %}
 
-```
-$ binprecice check FILE [ PARTICIPANT [ COMMSIZE ] ]
+```bash
+binprecice check FILE [ PARTICIPANT [ COMMSIZE ] ]
 ```
 
 The `check` runs the preCICE configuration parsing and checking logic on the given configuration file.
@@ -73,21 +72,20 @@ This will find the majority of the configuration mistakes without having to star
 
 The basic usage is to simply check a configuration file.
 
-```
-$ binprecice check precice.xml
+```bash
+binprecice check precice.xml
 ```
 
 To enable more checks, additionally pass the name of one participant.
 This should be repeated for every defined participant in the simulation.
 
-```
-$ binprecice check precice.xml Fluid
+```bash
+binprecice check precice.xml Fluid
 ```
 
 To enable all available checks, you may additionally pass the communicator size of the Participant.
 This enables some niche checks, which should not be necessary in the vast majority of cases.
 
+```bash
+binprecice check precice.xml Fluid 2
 ```
-$ binprecice check precice.xml Fluid 2
-```
-

--- a/pages/docs/tooling/tooling-builtin.md
+++ b/pages/docs/tooling/tooling-builtin.md
@@ -83,7 +83,7 @@ This should be repeated for every defined participant in the simulation.
 binprecice check precice.xml Fluid
 ```
 
-To enable all available checks, you may additionally pass the communicator size of the Participant.
+To enable all available checks, you may additionally pass the communicator size of the participant.
 This enables some niche checks, which should not be necessary in the vast majority of cases.
 
 ```bash

--- a/pages/docs/tooling/tooling-builtin.md
+++ b/pages/docs/tooling/tooling-builtin.md
@@ -1,0 +1,93 @@
+---
+title: Built-in tooling
+permalink: tooling-builtin.html
+keywords: tooling, xml, configuration, version
+summary: "Built-in tooling is always installed alongside preCICE and provides some basic functionality."
+---
+
+Part of a preCICE installation is the tool `binprecice`.
+It provides an easy-to-use interface to tooling API of the preCICE library.
+
+## XML reference
+
+```
+$ binprecice md
+$ binprecice xml
+$ binprecice dtd
+```
+
+This prints the XML reference to the console in various flavours.
+
+### `md`
+
+This prints the XML configuration in Markdown format.
+You can find the reference of the latest release [on the website](configuration-xml-reference.html).
+
+It is possible to generate a local version of the reference by rendering the Markdown to HTML using the `markdown` command.
+Be aware that this version does not contain styling, LaTeX rendering, and functioning links.
+
+```
+$ binprecice md | markdown > reference.html
+```
+
+### `xml`
+
+This prints the XML configuration with in-lined annotations of tags and attributes.
+
+### `dtd`
+
+This prints the DTD information, which can be used to validate the XML configuration file.
+
+## preCICE version
+
+{% version 2.4.0 %}
+This feature is available since version 2.4.0.
+{% endversion %}
+
+```
+$ binprecice version
+```
+
+This prints the version information of preCICE, which consists of multiple semicolon-separated parts.
+
+1. the version of preCICE e.g. `2.3.0`.
+2. the git revision of this version e.g. `v2.3.0-87-g04ee7308-dirty`.
+   This is interesting for development versions of preCICE.
+   It is not available if the library wasn't build using the git repository.
+3. Configuration options for MPI, PETSc, Python and some more.
+4. Compilation and linker flags used to build preCICE
+
+
+## Configuration check
+
+{% version 2.4.0 %}
+This feature is available since version 2.4.0.
+{% endversion %}
+
+```
+$ binprecice check FILE [ PARTICIPANT [ COMMSIZE ] ]
+```
+
+The `check` runs the preCICE configuration parsing and checking logic on the given configuration file.
+This will find the majority of the configuration mistakes without having to start a simulation.
+
+The basic usage is to simply check a configuration file.
+
+```
+$ binprecice check precice.xml
+```
+
+To enable more checks, additionally pass the name of one participant.
+This should be repeated for every defined participant in the simulation.
+
+```
+$ binprecice check precice.xml Fluid
+```
+
+To enable all available checks, you may additionally pass the communicator size of the Participant.
+This enables some niche checks, which should not be necessary in the vast majority of cases.
+
+```
+$ binprecice check precice.xml Fluid 2
+```
+

--- a/pages/docs/tooling/tooling-builtin.md
+++ b/pages/docs/tooling/tooling-builtin.md
@@ -8,6 +8,7 @@ summary: "Built-in tooling is always installed alongside preCICE and provides so
 Part of a preCICE installation is the tool `binprecice`.
 It provides an easy-to-use interface to tooling API of the preCICE library.
 
+With `binprecice`, you can get the installed preCICE version, generate a reference of all available configuration options, as well as check your configuration file for basic configuration issues.
 ## XML reference
 
 ```bash

--- a/pages/docs/tooling/tooling-builtin.md
+++ b/pages/docs/tooling/tooling-builtin.md
@@ -112,6 +112,6 @@ You may additionally pass the communicator size of the participant.
 This enables some checks regarding user-defined intra-participant communication, which should not be necessary in the vast majority of cases.
 
 ```bash
-binprecice check precice.xml Fluid
-binprecice check precice.xml Fluid 2
+binprecice check precice-config.xml Fluid
+binprecice check precice-config.xml Fluid 2
 ```

--- a/pages/docs/tooling/tooling-builtin.md
+++ b/pages/docs/tooling/tooling-builtin.md
@@ -16,7 +16,7 @@ binprecice xml
 binprecice dtd
 ```
 
-This prints the XML reference to the console in various flavours.
+This prints the XML reference to the console in various flavors.
 
 ### `md`
 

--- a/pages/docs/tooling/tooling-builtin.md
+++ b/pages/docs/tooling/tooling-builtin.md
@@ -71,23 +71,47 @@ binprecice check FILE [ PARTICIPANT [ COMMSIZE ] ]
 
 The `check` runs the preCICE configuration parsing and checking logic on the given configuration file.
 This will find the majority of the configuration mistakes without having to start a simulation.
+These checks include wrong tags and attribute values, and more elaborate naming checks.
+More intricate logic, such as checks if all necessary data are exchanged in a Coupling Schemes, are not covered.
 
-The basic usage is to simply check a configuration file.
+The basic usage is to simply check a configuration file:
 
 ```bash
 binprecice check precice.xml
 ```
 
-To enable more checks, additionally pass the name of one participant.
-This should be repeated for every defined participant in the simulation.
+Some example errors handled by the checker:
+
+* Misspelled tags (should be `data:vector` instead)
+
+  ```log
+  ERROR: The configuration contains an unknown tag <data:vektor>.
+  ```
+
+* Misspelled data names (should be `Forces` instead)
+
+  ```log
+  ERROR: Data with name "forces" used by mesh "Solid" is not defined. Please define a data tag with name="forces".
+  ```
+
+* Incorrect attribute combinations (mesh provided and received at the same time)
+
+  ```log
+  ERROR: Participant "SolverOne" cannot receive and provide mesh "Test-Square" at the same time. Please remove all but one of the "from" and "provide" attributes in the <use-mesh name="Test-Square"/> node of SolverOne.
+  ```
+
+* Incorrect meshes used in mapping definitions (`MeshTwo` doesn't exist)
+
+  ```log
+  ERROR: Mesh "MeshTwo" was not found while creating a mapping. Please correct the to="MeshTwo" attribute.
+  ```
+
+To enable more niche checks, additionally pass the name of one participant.
+This participant is assumed to run on a single rank.
+You may additionally pass the communicator size of the participant.
+This enables some checks regarding user-defined intra-participant communication, which should not be necessary in the vast majority of cases.
 
 ```bash
 binprecice check precice.xml Fluid
-```
-
-To enable all available checks, you may additionally pass the communicator size of the participant.
-This enables some niche checks, which should not be necessary in the vast majority of cases.
-
-```bash
 binprecice check precice.xml Fluid 2
 ```

--- a/pages/docs/tooling/tooling-builtin.md
+++ b/pages/docs/tooling/tooling-builtin.md
@@ -77,7 +77,7 @@ More advanced logic, such as checks if all necessary data are exchanged in a cou
 The basic usage is to simply check a configuration file:
 
 ```bash
-binprecice check precice.xml
+binprecice check precice-config.xml
 ```
 
 Some example errors handled by the checker:

--- a/pages/docs/tooling/tooling-overview.md
+++ b/pages/docs/tooling/tooling-overview.md
@@ -9,6 +9,7 @@ There are probably a few common tasks that could use some automation for.
 
 Here you will find a few tools to:
 
+- [Check your configuration file](tooling-builtin.html) without starting a whole simulation.
 - [Visualize the preCICE configuration file](tooling-config-visualization.html) to understand if you are really asking preCICE to do what you meant to.
 - [Analyze the performance of the coupled simulation](tooling-performance-analysis.html) to understand where the runtime comes from.
 - [Compute parameters for the RBF mapping configuration](tooling-rbf-shape.html) to optimize the accuracy and performance of your RBF mapping.


### PR DESCRIPTION
This PR adds documentation for binprecice.
I called the page `builtin`, as we may rename the binary in the future.

Closes #99 