### PR TITLE
Add page on publication strategy

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -472,7 +472,11 @@ entries:
     - title: Release strategy
       url: /dev-docs-release-strategy.html
       output: web, pdf
-      
+
+    - title: Publication strategy
+      url: /dev-docs-publication-strategy.html
+      output: web, pdf
+
   - title: "Documentation meta"
     output: web
     folderitems:

--- a/pages/docs/dev-docs/dev-publications.md
+++ b/pages/docs/dev-docs/dev-publications.md
@@ -1,0 +1,19 @@
+---
+title: Publication strategy
+keywords: Publication, release, distribution, DaRUS
+permalink: dev-docs-publication-strategy.html
+---
+
+## Publication of distribution on DaRUS
+
+For every new (major) distribution release, we publish an archive of all included sources on [DaRUS](https://darus.uni-stuttgart.de/). As an example, see the [v2104.0 data set](https://doi.org/10.18419/darus-2125).
+
+### Authorship
+
+Authors of the data set are:
+
+- All current [main contributors](./community-contributors.html#main-contributors)
+- Everybody who significantly contributed to the delta between the last and this major distribution release. Significant contributions need to go beyond *good first issues*. Actively maintaining a component or significant reviewing does also qualify as significant contribution.
+- Supervisors who actively contributed ideas to the delta between the last and this major distribution release
+
+Order of authors: main contributors are listed first followed by everybody else, both in alphabetical order.


### PR DESCRIPTION
Long promised documentation of our discussion on who is an author of a DaRUS distribution publication.
Do we also want to add a link somewhere in the community part?
We could use this page also to document how authorships of reference or feature papers work (not in this PR probably).