### PR TITLE
Add distribution v2202.0

### DIFF
--- a/pages/docs/installation/installation-distribution.md
+++ b/pages/docs/installation/installation-distribution.md
@@ -35,7 +35,7 @@ It comprises of the following components:
   - SU2 adapter: commit [ab84387](https://github.com/precice/su2-adapter/tree/ab843878c1d43302a4f0c66e25dcb364b7787478) (same as in v2104.0)
 - Tutorials: [v202202.0](https://github.com/precice/tutorials/releases/tag/v202202.0)
 - vm: [v202202.0.0](https://github.com/precice/vm/releases/tag/v202202.0.0)
-- Website and documentation: commit TODO
+- Website and documentation: [v202202.0.0](https://github.com/precice/precice.github.io/releases/tag/v202202.0.0)
 
 ## v2104.0
 

--- a/pages/docs/installation/installation-distribution.md
+++ b/pages/docs/installation/installation-distribution.md
@@ -39,6 +39,8 @@ It comprises of the following components:
 
 ## v2104.0
 
+[![preCICE distribution v2104.0](https://img.shields.io/badge/doi-10.18419%2Fdarus--2125-d45815.svg)](https://doi.org/10.18419/darus-2125)
+
 This is the first preCICE distribution version, coming after the restructuring of our tutorials.
 
 It comprises of the following components:

--- a/pages/docs/installation/installation-distribution.md
+++ b/pages/docs/installation/installation-distribution.md
@@ -12,6 +12,31 @@ language bindings, adapters for popular solvers, tutorials, and more. We know th
 can be difficult to figure out which versions to install, therefore we will be
 publishing here lists of known-to-work versions.
 
+Releases of the preCICE distribution are irregular. The version of each distribution is `yymm.r`, reflecting the year, the month, and the revision (bugfixes) of the distribution. Bindings versions reflect compatibility with a specific preCICE version, while adapters use a completely independent versioning scheme. The tutorials follow a `yyyymm.r` scheme and are targetting the released versions of each component. The VM version is based on the tutorials version, followed by the VM revision. While the distribution uses two year digits for convenience, the tutorials and the VM use four digits to allow version comparisons with previous releases that already used four digits.
+
+## v2202.0
+
+This is a scheduled release in the context of the [preCICE Workshop 2022](precice-workshop-2022.html).
+
+It comprises of the following components:
+
+- preCICE: [v2.3.0](https://github.com/precice/precice/releases/tag/v2.3.0)
+- Bindings:
+  - Fortran module: commit [38fe542](https://github.com/precice/fortran-module/tree/38fe54233754fde53ceeddb19d4ae4cb1828d0a9)
+  - Matlab bindings: [v2.3.0.1](https://github.com/precice/matlab-bindings/releases/tag/v2.3.0.1)
+  - Python bindings: [v2.3.0.1](https://github.com/precice/python-bindings/releases/tag/v2.3.0.1)
+- Adapters:
+  - CalculiX adapter: [v2.19.0](https://github.com/precice/calculix-adapter/releases/tag/v2.19.0) (first tagged release)
+  - code_aster adapter: commit [ce995e0](https://github.com/precice/code_aster-adapter/tree/  ce995e0c41b26fe891ce04fd47fd52cbeff854e9) (same as in v2104.0)
+  - deal.II adapter: commit [005933d](https://github.com/precice/dealii-adapter/tree/005933d6b45f885a64aee7ce597a3d7d81d54aff)
+  - DUNE adapter: commit [5f2364d](https://github.com/precice/dune-adapter/tree/5f2364d57b517698914cb1d5f9979efe692d9254) (new and experimental)
+  - FEniCS adapter: [v1.3.0](https://github.com/precice/fenics-adapter/releases/tag/v1.3.0)
+  - OpenFOAM adapter: [v1.1.0](https://github.com/precice/openfoam-adapter/releases/tag/v1.1.0)
+  - SU2 adapter: commit [ab84387](https://github.com/precice/su2-adapter/tree/ab843878c1d43302a4f0c66e25dcb364b7787478) (same as in v2104.0)
+- Tutorials: [v202202.0](https://github.com/precice/tutorials/releases/tag/v202202.0)
+- vm: [v202202.0.0](https://github.com/precice/vm/releases/tag/v202202.0.0)
+- Website and documentation: commit TODO
+
 ## v2104.0
 
 This is the first preCICE distribution version, coming after the restructuring of our tutorials.

--- a/pages/docs/installation/installation-distribution.md
+++ b/pages/docs/installation/installation-distribution.md
@@ -27,7 +27,7 @@ It comprises of the following components:
   - Python bindings: [v2.3.0.1](https://github.com/precice/python-bindings/releases/tag/v2.3.0.1)
 - Adapters:
   - CalculiX adapter: [v2.19.0](https://github.com/precice/calculix-adapter/releases/tag/v2.19.0) (first tagged release)
-  - code_aster adapter: commit [ce995e0](https://github.com/precice/code_aster-adapter/tree/  ce995e0c41b26fe891ce04fd47fd52cbeff854e9) (same as in v2104.0)
+  - code_aster adapter: commit [ce995e0](https://github.com/precice/code_aster-adapter/tree/ce995e0c41b26fe891ce04fd47fd52cbeff854e9) (same as in v2104.0)
   - deal.II adapter: commit [005933d](https://github.com/precice/dealii-adapter/tree/005933d6b45f885a64aee7ce597a3d7d81d54aff)
   - DUNE adapter: commit [5f2364d](https://github.com/precice/dune-adapter/tree/5f2364d57b517698914cb1d5f9979efe692d9254) (new and experimental)
   - FEniCS adapter: [v1.3.0](https://github.com/precice/fenics-adapter/releases/tag/v1.3.0)


### PR DESCRIPTION
This explains the different versioning systems and adds the preCICE Distribution v2202.0.

I am not sure how to handle the commit of the website itself at the moment, I guess we should also have releases here, with the same versioning system as in the VM. @uekerman your opinion?

I assume we should also add DaRUS badges and maybe something regarding citing. (related: https://github.com/precice/precice/pull/1101)