### PR TITLE
Fix build artifacts path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: site
-          path: build/
+          path: jekyll_build/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: site
-          path: /github/jekyll_build/
+          path: ${GITHUB_WORKSPACE}/../jekyll_build
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
           submodules: true
           lfs: true
       - name: Install bundler
-        run: apt install bundler
+        run: sudo apt update -y && sudo apt install -y bundler
       - name: Restore cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,4 @@ jobs:
         with:
           name: site
           path: /github/jekyll_build/
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,13 @@ jobs:
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-new-gems-${{ hashFiles('**/Gemfile.lock') }}
+      - name: Install dependencies
+        run: bundle install
       - name: Build site
-        uses:  helaili/jekyll-action@v2
-        with:
-          build_only: true
-      - run: ls -l
-      - run: ls -l ..
-      - run: ls -l ../jekyll_build
+        run: bundle exec jekyll build
       - name: Upload site
         uses: actions/upload-artifact@v2
         with:
           name: site
-          path: /github/jekyll_build
+          path: _site
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: site
-          path: jekyll_build/
+          path: /github/jekyll_build/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
           path: vendor/bundle
           key: ${{ runner.os }}-new-gems-${{ hashFiles('**/Gemfile.lock') }}
       - name: Install dependencies
-        run: bundle install
+        run: |
+          bundle config path "$PWD/vendor/bundle"
+          bundle install
       - name: Build site
         run: bundle exec jekyll build
       - name: Upload site

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
         uses:  helaili/jekyll-action@v2
         with:
           build_only: true
+      - run: ls -l
+      - run: ls -l /github
+      - run: ls -l /github/jekyll_build
       - name: Upload site
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
         with:
           submodules: true
           lfs: true
+      - name: Install bundler
+        run: apt install bundler
       - name: Restore cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: site
-          path: ${GITHUB_WORKSPACE}/../jekyll_build
+          path: /github/jekyll_build
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           build_only: true
       - run: ls -l
-      - run: ls -l /github
-      - run: ls -l /github/jekyll_build
+      - run: ls -l ..
+      - run: ls -l ../jekyll_build
       - name: Upload site
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
The current workflow tries to find the built website in `build/`, but the correct directory seems to be `jekyll_build/`.