### PR TITLE
Add statement on supporting Ukraine

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -15,7 +15,7 @@ layout: landing_page
     <div class="row no-margin">
       <div class="col-lg-12 banner">
         <p class="no-margin">
-          <strong>preCICE workshop is live from February 21-24, 2022</strong>. <a href="precice-workshop-2022.html">Show agenda</a>.
+          <strong>preCICE stands with Ukraine</strong> 🇺🇦. See the statements of the <a href="https://www.uni-stuttgart.de/en/university/news/all/United-against-Putins-war/">University of Stuttgart</a> and <a href="https://www.tum.de/en/about-tum/news/press-releases/details/37216">Technical University of Munich</a>.
         </p>
       </div>
     </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -15,7 +15,7 @@ layout: landing_page
     <div class="row no-margin">
       <div class="col-lg-12 banner">
         <p class="no-margin">
-          <strong>preCICE stands with Ukraine </strong> 🇺🇦 alongside the <a href="https://www.uni-stuttgart.de/en/university/news/all/United-against-Putins-war/">University of Stuttgart</a> and the <a href="https://www.tum.de/en/about-tum/news/press-releases/details/37216">Technical University of Munich</a>.
+          Join the Technical University of Munich in <a href="https://www.tum.de/en/about-tum/news/press-releases/details/37216">helping students and researchers affected by the war in Ukraine</a> 🇺🇦.
         </p>
       </div>
     </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -15,7 +15,7 @@ layout: landing_page
     <div class="row no-margin">
       <div class="col-lg-12 banner">
         <p class="no-margin">
-          <strong>preCICE stands with Ukraine </strong> 🇺🇦 alongside the <a href="https://www.uni-stuttgart.de/en/university/news/all/United-against-Putins-war/">University of Stuttgart</a> and <a href="https://www.tum.de/en/about-tum/news/press-releases/details/37216">Technical University of Munich</a>.	
+          <strong>preCICE stands with Ukraine </strong> 🇺🇦 alongside the <a href="https://www.uni-stuttgart.de/en/university/news/all/United-against-Putins-war/">University of Stuttgart</a> and the <a href="https://www.tum.de/en/about-tum/news/press-releases/details/37216">Technical University of Munich</a>.
         </p>
       </div>
     </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -15,7 +15,7 @@ layout: landing_page
     <div class="row no-margin">
       <div class="col-lg-12 banner">
         <p class="no-margin">
-          <strong>preCICE stands with Ukraine</strong> 🇺🇦. See the statements of the <a href="https://www.uni-stuttgart.de/en/university/news/all/United-against-Putins-war/">University of Stuttgart</a> and <a href="https://www.tum.de/en/about-tum/news/press-releases/details/37216">Technical University of Munich</a>.
+          <strong>preCICE stands with Ukraine </strong> 🇺🇦 alongside the <a href="https://www.uni-stuttgart.de/en/university/news/all/United-against-Putins-war/">University of Stuttgart</a> and <a href="https://www.tum.de/en/about-tum/news/press-releases/details/37216">Technical University of Munich</a>.	
         </p>
       </div>
     </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -15,7 +15,7 @@ layout: landing_page
     <div class="row no-margin">
       <div class="col-lg-12 banner">
         <p class="no-margin">
-          Join the Technical University of Munich in <a href="https://www.tum.de/en/about-tum/news/press-releases/details/37216">helping students and researchers affected by the war in Ukraine</a> 🇺🇦.
+          🇺🇦 Join the Technical University of Munich in <a href="https://www.tum.de/en/about-tum/news/press-releases/details/37216">helping students and researchers affected by the war in Ukraine</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
@BenjaminRodenberg suggested that we add a banner calling for action on stopping the war on Ukraine. This replaces the previous banner about the workshop with the following statement, which links to the [page of TUM](https://www.tum.de/en/about-tum/news/press-releases/details/37216):

![Screenshot from 2022-03-03 19-55-56](https://user-images.githubusercontent.com/4943683/156633191-e972db73-45b7-4822-92cd-a7c5134154f4.png)

