### PR TITLE
Add adapter-X redirects to overview pages

### DIFF
--- a/pages/docs/adapters/calculix/adapter-calculix-overview.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-overview.md
@@ -1,9 +1,7 @@
 ---
 title: The CalculiX adapter
 permalink: adapter-calculix-overview.html
-redirect_from:
-  - adapter-calculix.html
-  - adapter-ccx.html
+redirect_from: adapter-calculix.html
 keywords: adapter, calculix
 summary: "The CalculiX adapter can be used to couple CalculiX to CFD solvers for FSI or CHT application or even to couple CalculiX to itself."
 ---

--- a/pages/docs/adapters/calculix/adapter-calculix-overview.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-overview.md
@@ -1,6 +1,9 @@
 ---
 title: The CalculiX adapter
 permalink: adapter-calculix-overview.html
+redirect_from:
+  - adapter-calculix.html
+  - adapter-ccx.html
 keywords: adapter, calculix
 summary: "The CalculiX adapter can be used to couple CalculiX to CFD solvers for FSI or CHT application or even to couple CalculiX to itself."
 ---

--- a/pages/docs/adapters/deal.II/adapter-dealii-overview.md
+++ b/pages/docs/adapters/deal.II/adapter-dealii-overview.md
@@ -1,6 +1,9 @@
 ---
 title: The deal.II adapter
 permalink: adapter-dealii-overview.html
+redirect_from:
+  - adapter-dealii.html
+  - adapter-deal.ii.html
 keywords: adapter, deal.II
 summary: "Coupled structural solver written with the C++ finite element library deal.II"
 ---

--- a/pages/docs/adapters/deal.II/adapter-dealii-overview.md
+++ b/pages/docs/adapters/deal.II/adapter-dealii-overview.md
@@ -1,9 +1,7 @@
 ---
 title: The deal.II adapter
 permalink: adapter-dealii-overview.html
-redirect_from:
-  - adapter-dealii.html
-  - adapter-deal.ii.html
+redirect_from: adapter-dealii.html
 keywords: adapter, deal.II
 summary: "Coupled structural solver written with the C++ finite element library deal.II"
 ---

--- a/pages/docs/adapters/su2/adapter-su2-overiew.md
+++ b/pages/docs/adapters/su2/adapter-su2-overiew.md
@@ -1,6 +1,7 @@
 ---
 title: The SU2 adapter
 permalink: adapter-su2-overview.html
+redirect_from: adapter-su2.html
 keywords: adapter, su2, development, modules
 summary: "Modify native SU2 files to couple with other solvers or SU2 itself"
 ---


### PR DESCRIPTION
This adds redirects for the pages `/adapter-X` for X in { calculix, deal.ii, su2 } adapters to their overview pages.

I also added common synonyms `deal.ii` and `ccx`.

Closes #79 