### PR TITLE
Add table for community bindings, link to Rust

### DIFF
--- a/pages/docs/couple-your-code/couple-your-code-api.md
+++ b/pages/docs/couple-your-code/couple-your-code-api.md
@@ -27,6 +27,12 @@ Besides the C++ API, there are also bindings to other languages available:
 | Python         | [`precice/python-bindings`](https://github.com/precice/python-bindings)                     | [`pip3 install pyprecice`](installation-bindings-python.html)                 |
 | Matlab         | [`precice/matlab-bindings`](https://github.com/precice/matlab-bindings)                     | [installation script](installation-bindings-matlab.html)                      |
 
+The community is also working on the following bindings:
+
+| Language       | Location                                                                                    | Notes                                                                  |
+|----------------|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| Rust           | [`ajaust/rust-precice`](https://github.com/ajaust/rust-precice)                             | Experimental prototype / work in progress
+
 ## Minimal reference implementations
 
 For all languages, we provide minimal reference implementations, so called _solver dummies_. They can be a great source to copy from.


### PR DESCRIPTION
This adds a table with community-driven language bindings. I added Rust here, for now, not sure how many more languages we will get in the future, but I know that our community can create beyond our imagination.

FYI @ajaust 