### PR TITLE
Fix Markdown linting issues in dev docs

### DIFF
--- a/pages/docs/dev-docs/dev-logging.md
+++ b/pages/docs/dev-docs/dev-logging.md
@@ -20,7 +20,6 @@ Info | always on primary rank | Logger | Notifies about the state of the program
 Debug | in debug builds | Logger | Low-level information useful for developping and bug-search.
 Trace | in debug builds | Logger | Function invokation information. Last resort before using a debugger. Sometimes debugging may also not be an option.
 
-
 ## Debug output and checks
 
 Before using any of debugging/logging methods below you should set `PRECICE_TRACE()` at the beginning of the function.
@@ -40,20 +39,22 @@ Not based on a logger:
 ## Message style
 
 We attempt to follow a git-like style with some extras:
-* One line only _to prevent interleaved logs_
-* Name actors and objects as best as possible, but don't provide internals such as IDs.
-* For errors
-  * What has happened?
-  * Why is this a problem?
-  * What can the user do to solve this issue?
+- One line only _to prevent interleaved logs_
+- Name actors and objects as best as possible, but don't provide internals such as IDs.
+- For errors
+  - What has happened?
+  - Why is this a problem?
+  - What can the user do to solve this issue?
 
 Examples of errors:
+
 ```
 Data with name "DaTTa" used by mesh "MyCloud" is not defined. Please define a data tag with name="DaTTa".
 No coupling scheme defined for participant "LonelyWolf". Please make sure to provide at least one <coupling-scheme:TYPE> in your precice-config.xml that couples this participant using the <participants .../> tag.
 ```
 
 Examples of wanings:
+
 ```
 3D Mesh "MyCloud" does not contain triangles. Nearest projection mapping will map to primitives of lower dimension.
 The relative convergence limit="1e-8" is close to the hard-coded numerical resolution="1e-9" of preCICE. This may lead to instabilities. The minimum relative convergence limit should be > "1e-9".  
@@ -80,7 +81,6 @@ PRECICE_INFO("This message is long, but may not contain breaks. "
     "The compiler will merge these string literals together for me. "
     "No worries");
 ```
-
 
 ## Enabling logging in a class
 

--- a/pages/docs/dev-docs/dev-logging.md
+++ b/pages/docs/dev-docs/dev-logging.md
@@ -39,6 +39,7 @@ Not based on a logger:
 ## Message style
 
 We attempt to follow a git-like style with some extras:
+
 - One line only _to prevent interleaved logs_
 - Name actors and objects as best as possible, but don't provide internals such as IDs.
 - For errors
@@ -48,14 +49,14 @@ We attempt to follow a git-like style with some extras:
 
 Examples of errors:
 
-```
+```text
 Data with name "DaTTa" used by mesh "MyCloud" is not defined. Please define a data tag with name="DaTTa".
 No coupling scheme defined for participant "LonelyWolf". Please make sure to provide at least one <coupling-scheme:TYPE> in your precice-config.xml that couples this participant using the <participants .../> tag.
 ```
 
 Examples of wanings:
 
-```
+```text
 3D Mesh "MyCloud" does not contain triangles. Nearest projection mapping will map to primitives of lower dimension.
 The relative convergence limit="1e-8" is close to the hard-coded numerical resolution="1e-9" of preCICE. This may lead to instabilities. The minimum relative convergence limit should be > "1e-9".  
 ```

--- a/pages/docs/dev-docs/dev-testing.md
+++ b/pages/docs/dev-docs/dev-testing.md
@@ -15,7 +15,7 @@ Component | What it does | How to run it
 CTest | Runs pre-defined tests | `make test` or `ctest`
 MPI | Executes the test framework in parallel | `mpirun -n4 ./testprecice`
 Boost.test | The framework used to implement the tests | `./testprecice --list_content`
-TestContext | The code extension used to express test parallelism | 
+TestContext | The code extension used to express test parallelism |
 
 There are generally three kinds of tests:
 
@@ -35,7 +35,7 @@ Some important options for `ctest` are:
 - `--output-on-failure` show the test output only if a test fails
 
 To run individual tests, use `./testprecice --list_content` to list all tests, then run the test directly using `mpirun -np 4 ./testprecice`.
-Use `-t TestSuite/Test` to run a specific test, or `-t TestSuite` to run all tests of a TestSuite. 
+Use `-t TestSuite/Test` to run a specific test, or `-t TestSuite` to run all tests of a TestSuite.
 
 Some important options for `./testprecice` are:
 
@@ -62,7 +62,6 @@ This can be used to control the log level of tests run by CTest.
 export export BOOST_TEST_LOG_LEVEL=all
 ctest -VV -R mapping
 ```
-
 
 ## Writing
 

--- a/pages/docs/dev-docs/dev-tooling.md
+++ b/pages/docs/dev-docs/dev-tooling.md
@@ -15,7 +15,7 @@ This will also run all pre-commit hooks before each commit, preventing dirty com
 
 Custom pre-commit hooks for preCICE are included in the repository [precice/precice-pre-commit-hooks](https://github.com/precice/precice-pre-commit-hooks).
 This currently provides a stand-alone hook for the precice config formatter.
-The repository provides tags in the form `X.Y` where `X` is the major preCICE version and `Y` is the version of the hook repo. 
+The repository provides tags in the form `X.Y` where `X` is the major preCICE version and `Y` is the version of the hook repo.
 
 ## Formatting the code
 


### PR DESCRIPTION
Fix some Markdown linting issues in the developers' documentation.