### PR TITLE
Add parameter study tool in new section

### DIFF
--- a/pages/docs/tooling/tooling-overview.md
+++ b/pages/docs/tooling/tooling-overview.md
@@ -13,3 +13,9 @@ Here you will find a few tools to:
 - [Visualize the preCICE configuration file](tooling-config-visualization.html) to understand if you are really asking preCICE to do what you meant to.
 - [Analyze the performance of the coupled simulation](tooling-performance-analysis.html) to understand where the runtime comes from.
 - [Compute parameters for the RBF mapping configuration](tooling-rbf-shape.html) to optimize the accuracy and performance of your RBF mapping.
+
+## Tools from the preCICE community
+
+The following tools are made with ❤️ by the preCICE community (add your own):
+
+- [`ajaust/parameter-study-precice`](https://github.com/ajaust/parameter-study-precice): Scripts for easy generation of preCICE configuration files for parameter studies


### PR DESCRIPTION
This mainly adds https://github.com/ajaust/parameter-study-precice in a subsection of the [Tooling overview page](https://precice.org/tooling-overview.html):

I did not add a new page as this currently feels very empty. Unless we want to explain how to use each tool.

FYI @ajaust

![Screenshot from 2022-08-09 08-43-01](https://user-images.githubusercontent.com/4943683/183582314-afd6d953-1b6a-4231-a34b-83eb3acd9a2f.png)
 