### PR TITLE
Update petsc git and website

### DIFF
--- a/pages/docs/installation/installation-source-dependencies.md
+++ b/pages/docs/installation/installation-source-dependencies.md
@@ -213,11 +213,11 @@ We require at least version 3.12. For preCICE versions earlier than v2.1.0, PETS
 
 If you prefer to install the most recent version from source, do the following:
 
-1. [Download it](http://www.mcs.anl.gov/petsc/download/index.html) or get the repository using `git clone -b maint https://bitbucket.org/petsc/petsc petsc`
+1. [Download it](https://petsc.org/release/download) or get the repository using `git clone -b release https://gitlab.com/petsc/petsc.git petsc`
 2. Change into that directory and compile with or without debugging: `./configure --with-debugging=0` (disable debugging for optimal performance)
 3. Use the `make` command as the configure script proposes, e.g.
   `make PETSC_DIR=/path/to/petsc PETSC_ARCH=arch-linux2-c-opt all`
-  Further documentation see the [PETSc installation documentation](http://www.mcs.anl.gov/petsc/documentation/installation.html).
+  Further documentation see the [PETSc installation documentation](https://petsc.org/release/install/).
 4. Usage: You will need to add PETSc to your dynamic linker search path (`LD_LIBRARY_PATH` on Linux or `DYLD_LIBRARY_PATH` on macOS). You may also need to set the `$PETSC_ARCH`.
 
 Finally, in some cases you may need to have PETSc in your `CPATH`, `LIBRARY_PATH`, or `PYTHONPATH`. Here is an example:


### PR DESCRIPTION
I got an error during PETSc compilation and found that the links on the website were not up to date. On [BitBucket](https://bitbucket.org/petsc/petsc/src/maint/) where the current guide pulls from, it says:
> PETSc repository is moved to https://gitlab.com/petsc/petsc The bitbucket archive is at https://bitbucket.org/petsc/petsc-moved-to-gitlab This repository is primarily to preserve old URLs.

Since I don't get errors when following the guide on the new [PETSc website](https://petsc.org/release/download) which pulls from [GitLab](https://gitlab.com/petsc/petsc.git), it probably is time to update the links.

There is also a mention of the BitBucket adress in the [special-systems guide](https://precice.org/installation-special-systems.html#building-with-cmake) but I'm not sure if I should touch those.