### PR TITLE
Add porting section

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -445,9 +445,21 @@ entries:
           url: /couple-your-code-waveform.html
           output: web, pdf
 
-    - title: Porting adapters from preCICE 1.x to 2.x
-      url: /couple-your-code-porting-adapters.html
-      output: web, pdf
+      - title: Porting guides for major versions
+        output: web, pdf
+        subfolderitems:
+
+        - title: Porting adapters in general
+          url: /couple-your-code-porting-overview.html
+          output: web, pdf
+
+        - title: Porting from 1.x to 2.x
+          url: /couple-your-code-porting-v1-2.html
+          output: web, pdf
+
+        - title: Porting from 2.x to 3.x
+          url: /couple-your-code-porting-v2-3.html
+          output: web, pdf
 
   - title: Running simulations
     output: web, pdf

--- a/pages/docs/couple-your-code/couple-your-code-porting-overview.md
+++ b/pages/docs/couple-your-code/couple-your-code-porting-overview.md
@@ -1,0 +1,8 @@
+---
+title: Porting adapters between breaking releases
+permalink: couple-your-code-porting-overview.html
+keywords: api, adapter, version, porting, major, breaking
+---
+
+We use [semantic versioning](https://semver.org/) for preCICE, which means that you can extract useful information from the version number. If the first digit (major version) does not change, this means that you don't need to update your adapter or (usually) your preCICE configuration file. However, when the major version number increases, this means that you need to update your code as well (we plan for a major version change once every 2-3 years).
+We recommend using the latest stable versions of preCICE and the corresponding bindings and adapters.

--- a/pages/docs/couple-your-code/couple-your-code-porting-v1-2.md
+++ b/pages/docs/couple-your-code/couple-your-code-porting-v1-2.md
@@ -1,14 +1,10 @@
 ---
-title: Porting adapters from preCICE 1.x to 2.x
-permalink: couple-your-code-porting-adapters.html
+title: Porting from 1.x to 2.x
+permalink: couple-your-code-porting-v1-2.html
 keywords: api, adapter, version, timestep, action
-summary: "This guide helps you to upgrade from preCICE 1.x to preCICE 2.x.
-"
+summary: "This guide helps you to upgrade from preCICE 1.x to preCICE 2.x."
+redirect_from: couple-your-code-porting-adapters.html
 ---
-
-
-We use [semantic versioning](https://semver.org/) for preCICE, which means that you can extract useful information from the version number. If the first digit (major version) does not change, this means that you don't need to update your adapter or (usually) your preCICE configuration file. However, when the major version number increases, this means that you need to update your code as well (we plan for a major version change once every 2-3 years).
-We recommend using the latest stable versions of preCICE and the corresponding bindings and adapters.
 
 ## preCICE API
 

--- a/pages/docs/couple-your-code/couple-your-code-porting-v2-3.md
+++ b/pages/docs/couple-your-code/couple-your-code-porting-v2-3.md
@@ -1,0 +1,51 @@
+---
+title: Porting from 2.x to 3.x
+permalink: couple-your-code-porting-v2-3.html
+keywords: api, adapter, version, timestep, action
+summary: "This guide helps you to upgrade from preCICE 2.x to preCICE 3.x."
+---
+
+<!--
+Missing:
+#1352
+-->
+
+## preCICE API
+
+- Migrate connectivity information to the vertex-only API.
+  - `setMeshEdges`, `setMeshTriangles`, `setMeshQuads`, `setMeshTetrahedron` now require vertices only and don't return ids.
+  - Replace `setMeshXWithEdges` with `setMeshX` calls for `Triangle` and `Quads`
+  - Only define the primitives you actually need. There is no need to define edges of triangles separately.
+- Remove `mapWriteDataFrom()` and `mapReadDataTo()`
+- Remove `initializeData()` and initialize the data after defining the mesh and before calling `initialize()`.
+- preCICE does not reset your write data to `0` any longer.
+
+## Language bindings
+
+- Rename Fortran function `precicef_ongoing()` to `precicef_is_coupling_ongoing()`
+<!--
+- Removed `precicef_write_data_required()`, `precicef_read_data_available()`, `precicef_action_required()`.
+-->
+
+## Actions
+
+- Removed ScaleByDtAction
+- Removed `isReadDataAvailable` and `isWriteDataRequired`.
+- Removed timewindowsize from the `performAction` signature. The new signature is `performAction(time, data)`.
+
+
+## preCICE configuration file
+
+- Remove actions `scale-by-computed-dt-part-ratio` and `scale-by-computed-dt-ratio`.
+- Remove mapping timing `on-demand`
+- Replace mapping constraint `scaled-consistent` by `scaled-consistent-surface`.
+- Add `<profiling mode="all" />` after the `<log>` tag if you need profiling data.
+- Replace `<export:vtk />` for parallel participants with `<export:vtu />` or `<export:vtp />`.
+
+## Profiling
+
+- New modes for profiling data: `none`, `fundamental` (default), `all`.
+
+## Side-changes
+
+-

--- a/pages/docs/couple-your-code/couple-your-code-porting-v2-3.md
+++ b/pages/docs/couple-your-code/couple-your-code-porting-v2-3.md
@@ -10,8 +10,13 @@ Missing:
 #1352
 -->
 
+{% note %}
+Please add breaking changes here when merged to the `develop` branch.
+{% endnote %}
+
 ## preCICE API
 
+<!--
 - Migrate connectivity information to the vertex-only API.
   - `setMeshEdges`, `setMeshTriangles`, `setMeshQuads`, `setMeshTetrahedron` now require vertices only and don't return ids.
   - Replace `setMeshXWithEdges` with `setMeshX` calls for `Triangle` and `Quads`
@@ -19,33 +24,35 @@ Missing:
 - Remove `mapWriteDataFrom()` and `mapReadDataTo()`
 - Remove `initializeData()` and initialize the data after defining the mesh and before calling `initialize()`.
 - preCICE does not reset your write data to `0` any longer.
-
-## Language bindings
-
-- Rename Fortran function `precicef_ongoing()` to `precicef_is_coupling_ongoing()`
-<!--
-- Removed `precicef_write_data_required()`, `precicef_read_data_available()`, `precicef_action_required()`.
 -->
-
-## Actions
-
-- Removed ScaleByDtAction
-- Removed `isReadDataAvailable` and `isWriteDataRequired`.
-- Removed timewindowsize from the `performAction` signature. The new signature is `performAction(time, data)`.
-
 
 ## preCICE configuration file
 
+<!--
 - Remove actions `scale-by-computed-dt-part-ratio` and `scale-by-computed-dt-ratio`.
 - Remove mapping timing `on-demand`
 - Replace mapping constraint `scaled-consistent` by `scaled-consistent-surface`.
 - Add `<profiling mode="all" />` after the `<log>` tag if you need profiling data.
 - Replace `<export:vtk />` for parallel participants with `<export:vtu />` or `<export:vtp />`.
+-->
+
+## Language bindings
+
+<!--
+- Rename Fortran function `precicef_ongoing()` to `precicef_is_coupling_ongoing()`
+- Removed `precicef_write_data_required()`, `precicef_read_data_available()`, `precicef_action_required()`.
+-->
+
+## Actions
+
+<!--
+- Removed ScaleByDtAction
+- Removed `isReadDataAvailable` and `isWriteDataRequired`.
+- Removed timewindowsize from the `performAction` signature. The new signature is `performAction(time, data)`.
+-->
 
 ## Profiling
 
+<!--
 - New modes for profiling data: `none`, `fundamental` (default), `all`.
-
-## Side-changes
-
--
+-->


### PR DESCRIPTION
This PR:

- adds a porting group to the coupling my code docs
- moves the porting guide for 1->2 to the section
- creates a stub porting guide for 2->3