### PR TITLE
Add navtabs + Python to step-by-step description

### DIFF
--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -340,4 +340,14 @@ div#tg-sb-sidebar {
   div#tg-sb-sidebar  {
     position: static;
   }
+/* style navtabs */
+.post-content ol li, .post-content ul li {
+  margin: 0px;
+}
+div.tab-content {
+  padding: 0px;
+  background-color: white;
+  }
+div.tab-content div.tab-pane pre {
+  margin-top: 0px;
 }

--- a/css/printstyles.css
+++ b/css/printstyles.css
@@ -40,7 +40,7 @@ a[href^="http:"]::after, a[href^="https:"]::after, a[href^="ftp:"]::after {
 a[href] {
     color: #0A76BB !important;
 }
-a[href*="mailto"]::after, a[data-toggle="tooltip"]::after, a[href].noCrossRef::after {
+a[href*="mailto"]::after, a[data-toggle="tooltip"]::after, a[href].noCrossRef::after, a[data-toggle="tab"]::after {
     content: "";
 }
 
@@ -219,4 +219,55 @@ pre > code {
 h1[id], h2[id], h3[id], h4[id], h5[id], h6[id], dt[id] {
     padding-top: 1.5em;
     margin-top: -1em;
+}
+
+/* prepare nav tabs for printing */
+.nav > li.active > a, /* tab headers */
+.nav > li > a {
+    color: black;
+    background-color: white;
+    border: 1px solid #ccc;
+    border-radius: 4px 4px 0 0;
+}
+.tab-content > .tab-pane {
+    display: block !important; /* display non-active panes */
+    position: relative;
+}
+div.tab-content div.tab-pane pre {
+  margin-top: 1em;
+}
+/* create counters to link tab headers to tab contents */
+.post-content ul.nav.nav-tabs { 
+    counter-reset: tab_number; /* creates a new instance of counter with name tab_number */
+}
+.post-content .nav.nav-tabs li::after {
+    counter-increment: tab_number; /* increment counter */
+    content: counter(tab_number); /* display value in small bubble */
+    position: absolute;
+    top:  -1em;
+    left:  -1em;
+    padding: 2px 5px;
+    background-color: white;
+    color: black;
+    font-size: 0.65em;
+    border-radius: 50%;
+    border: 1px solid #ccc;
+    box-shadow: 1px 1px 1px grey;
+}
+div.tab-content { 
+  counter-reset: pane_number; 
+}
+div.tab-pane::after {
+    counter-increment: pane_number;
+    content: counter(pane_number);
+    position: absolute;
+    top: -1em;
+    left: -1em;
+    padding: 2px 5px;
+    background-color: white;
+    color: black;
+    font-size: 0.65em;
+    border-radius: 50%;
+    border: 1px solid #ccc;
+    box-shadow: 1px 1px 1px gray;
 }

--- a/pages/docs/couple-your-code/couple-your-code-preparing-your-solver.md
+++ b/pages/docs/couple-your-code/couple-your-code-preparing-your-solver.md
@@ -7,6 +7,13 @@ summary: "If you want to couple your own code you need to properly understand it
 
 Let's say you want to prepare a fluid solver for fluid-structure interaction and that your code looks like this:
 
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp" data-toggle="tab">C++</a></li>
+    <li><a href="#python" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="cpp" markdown="1">
+
 ```cpp
 turnOnSolver(); //e.g. setup and partition mesh
 
@@ -18,8 +25,25 @@ while (not simulationDone()){ // time loop
   endTimeStep(); // e.g. update variables, increment time
 }
 turnOffSolver();
+
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python" markdown="1">
+
+```python
+turn_on_solver() #e.g. setup and partition mesh
+
+while not simulation_done(): # time loop
+  dt = begin_time_step() #e.g compute adaptive dt
+  solve_time_step(dt)
+  end_time_step() #e.g. update variables, increment time
+
+turn_off_solver()
+```
+
+</div>
+</div>
 Probably most solvers have such a structures: something in the beginning (reading input, domain decomposition), a big time loop, and something in the end. Each time step also falls into three parts: some pre-computations (e.g. computing an adaptive time step size), the actual computation (solving a linear or non-linear equation system), and something in the end (updating variables, incrementing time). Try to identify these parts in the code you want to couple.
 
 In the following steps, we will slowly add more and more calls to the preCICE API in this code snippet. Some part of the preCICE API is briefly described in each step. More precisely (no pun intended :grin:), we use the native `C++` API of preCICE. The API is, however, also available in other scientific programming languages: plain `C`, `Fortran`, `Python`, `Matlab`, `Julia`, and `Rust` (see [Application Programming Interface](couple-your-code-api)).

--- a/pages/docs/couple-your-code/couple-your-code-steering-methods.md
+++ b/pages/docs/couple-your-code/couple-your-code-steering-methods.md
@@ -24,6 +24,13 @@ What do they do?
 
 The following function allows us to query the maximum allowed time step size from preCICE:
 
+
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp" data-toggle="tab">C++</a></li>
+    <li><a href="#python" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="cpp" markdown="1">
 ```cpp
 double getMaxTimeStepSize();
 ```
@@ -53,3 +60,29 @@ while (not simulationDone()){ // time loop
 precice.finalize(); // frees data structures and closes communication channels
 turnOffSolver();
 ```
+  </div>
+  <div role="tabpanel" class="tab-pane" id="python" markdown="1">
+```python
+import precice
+
+turn_on_solver()  # e.g. setup and partition mesh
+
+precice = precice.Interface(
+    "FluidSolver", "precice-config.xml", rank, size
+)
+precice_dt = precice.initialize()
+
+u = initialize_solution()
+
+while t < t_end:  # time loop
+    dt = compute_adaptive_dt()
+    dt = min(precice_dt, dt)  # more about this in Step 5
+    u = solve_time_step(dt, u)  # returns new solution
+    precice_dt = precice.advance(dt)
+    t = t + dt
+
+precice.finalize()  # frees data structures and closes communication channels
+```
+  </div>
+</div>
+

--- a/pages/docs/couple-your-code/couple-your-code-steering-methods.md
+++ b/pages/docs/couple-your-code/couple-your-code-steering-methods.md
@@ -9,6 +9,13 @@ summary: "In this step, you get to know the most important API functions of preC
 As a first preparation step, you need to include the preCICE library headers. In C++, you need to include the file [precice.hpp](https://github.com/precice/precice/blob/develop/src/precice/precice.hpp).
 The handle to the preCICE API is the class `precice::Participant`. Its constructor requires the participant's name, the preCICE configuration file's name and the `rank` and `size` of the current thread. Once the basic preCICE interface is set up, we can _steer_ the behaviour of preCICE. For that we need the following functions:
 
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-1" data-toggle="tab">C++</a></li>
+    <li><a href="#python-1" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="cpp-1" markdown="1">
+
 ```cpp
 Participant( String participantName, String configurationFileName, int rank, int size );
 void initialize();
@@ -16,6 +23,38 @@ void advance ( double computedTimeStepSize );
 void finalize();
 ```
 
+  </div>
+  <div role="tabpanel" class="tab-pane" id="python-1" markdown="1">
+
+```python
+"""
+  Parameters:
+  participant_name: string
+    Name of the solver
+  configuration_file_name: string
+    Name of preCICE config file
+  rank: int
+    Rank of the process
+  size: int
+    Size of the process
+"""
+participant = Participant(participant_name, configuration_file_name, rank, size)
+
+participant.initialize()
+
+"""
+  Parameters:
+  computed_timestep_size: double
+    Length of timestep used by solver
+"""
+participant.advance(computed_timestep_size)
+
+participant.finalize()
+
+```
+
+  </div>
+</div>
 What do they do?
 
 * `initialize` establishes communication channels and sets up data structures of preCICE.
@@ -23,14 +62,12 @@ What do they do?
 * `finalize` frees the preCICE data structures and closes communication channels.
 
 The following function allows us to query the maximum allowed time step size from preCICE:
-
-
 <ul id="apiTabs" class="nav nav-tabs">
-    <li class="active"><a href="#cpp" data-toggle="tab">C++</a></li>
-    <li><a href="#python" data-toggle="tab">Python</a></li>
+    <li class="active"><a href="#cpp-2" data-toggle="tab">C++</a></li>
+    <li><a href="#python-2" data-toggle="tab">Python</a></li>
 </ul>
 <div class="tab-content">
-  <div role="tabpanel" class="tab-pane active" id="cpp" markdown="1">
+  <div role="tabpanel" class="tab-pane active" id="cpp-2" markdown="1">
 ```cpp
 double getMaxTimeStepSize();
 ```
@@ -60,8 +97,10 @@ while (not simulationDone()){ // time loop
 precice.finalize(); // frees data structures and closes communication channels
 turnOffSolver();
 ```
+
   </div>
-  <div role="tabpanel" class="tab-pane" id="python" markdown="1">
+  <div role="tabpanel" class="tab-pane" id="python-2" markdown="1">
+
 ```python
 import precice
 
@@ -82,7 +121,8 @@ while t < t_end:  # time loop
     t = t + dt
 
 precice.finalize()  # frees data structures and closes communication channels
+
 ```
+
   </div>
 </div>
-


### PR DESCRIPTION
Apologies if we discussed this in the past already. I think it could be good to add Python code to the complete "couple your code" step-by-step descriptions. We could do this by using [Navtabs](https://idratherbewriting.com/documentation-theme-jekyll/mydoc_navtabs.html) for example.

Why?

- More and more users are using the Python bindings, not the C++ API, especially due to our course
- The Python API becomes searchable, e.g. `is_coupling_ongoing`

Let's not (directly) do this for all bindings. This could easily become a lot of work. And let's not make this a must for each docs page with code. Let's merely start with the step-by-step guide and then see.

Current state is meant as a discussion starter and example. If we agree to do this, we might want to fine-tune things. 


![Screenshot from 2022-10-15 17-47-23](https://user-images.githubusercontent.com/2901384/195995588-c7ee65e7-830e-4f7e-869e-ef791a9dae92.png)
