### PR TITLE
Add heat-exchanger-simplified to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -199,6 +199,7 @@ subprojects:
   - imported/tutorials/flow-over-heated-plate-nearest-projection
   - imported/tutorials/flow-over-heated-plate-two-meshes
   - imported/tutorials/heat-exchanger
+  - imported/tutorials/heat-exchanger-simplified
   - imported/tutorials/multiple-perpendicular-flaps
   - imported/tutorials/partitioned-elastic-beam
   - imported/tutorials/partitioned-heat-conduction


### PR DESCRIPTION
In https://github.com/precice/precice.github.io/pull/221, the case heat-exchange-simplified was not added to `_config.yml`, which led to a broken link. The case is now added.