### PR TITLE
Update website for calculix v2.20

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -218,8 +218,8 @@ subprojects:
 # We use these versions to centrally update links
 # and other version-specific information.
 precice_version: 2.5.0
-calculix_version: 2.19
-calculix_adapter_version: 2.19.0
+calculix_version: 2.20
+calculix_adapter_version: 2.20.0
 
 # Latest known number of Google scholar citations, used as fallback
 precice_citations: 222

--- a/pages/docs/installation/installation-distribution.md
+++ b/pages/docs/installation/installation-distribution.md
@@ -28,7 +28,7 @@ It comprises of the following components:
   - Matlab bindings: [v2.3.0.1](https://github.com/precice/matlab-bindings/releases/tag/v2.3.0.1)
   - Python bindings: [v2.3.0.1](https://github.com/precice/python-bindings/releases/tag/v2.3.0.1)
 - Adapters:
-  - CalculiX adapter: [v2.19.0](https://github.com/precice/calculix-adapter/releases/tag/v2.20.0) (second tagged release)
+  - CalculiX adapter: [v2.19.0](https://github.com/precice/calculix-adapter/releases/tag/v2.19.0) (first tagged release)
   - code_aster adapter: commit [ce995e0](https://github.com/precice/code_aster-adapter/tree/ce995e0c41b26fe891ce04fd47fd52cbeff854e9) (same as in v2104.0)
   - deal.II adapter: commit [005933d](https://github.com/precice/dealii-adapter/tree/005933d6b45f885a64aee7ce597a3d7d81d54aff)
   - DUNE adapter: commit [5f2364d](https://github.com/precice/dune-adapter/tree/5f2364d57b517698914cb1d5f9979efe692d9254) (new and experimental)

--- a/pages/docs/installation/installation-distribution.md
+++ b/pages/docs/installation/installation-distribution.md
@@ -28,7 +28,7 @@ It comprises of the following components:
   - Matlab bindings: [v2.3.0.1](https://github.com/precice/matlab-bindings/releases/tag/v2.3.0.1)
   - Python bindings: [v2.3.0.1](https://github.com/precice/python-bindings/releases/tag/v2.3.0.1)
 - Adapters:
-  - CalculiX adapter: [v2.20.0](https://github.com/precice/calculix-adapter/releases/tag/v2.20.0) (second tagged release)
+  - CalculiX adapter: [v2.19.0](https://github.com/precice/calculix-adapter/releases/tag/v2.20.0) (second tagged release)
   - code_aster adapter: commit [ce995e0](https://github.com/precice/code_aster-adapter/tree/ce995e0c41b26fe891ce04fd47fd52cbeff854e9) (same as in v2104.0)
   - deal.II adapter: commit [005933d](https://github.com/precice/dealii-adapter/tree/005933d6b45f885a64aee7ce597a3d7d81d54aff)
   - DUNE adapter: commit [5f2364d](https://github.com/precice/dune-adapter/tree/5f2364d57b517698914cb1d5f9979efe692d9254) (new and experimental)

--- a/pages/docs/installation/installation-distribution.md
+++ b/pages/docs/installation/installation-distribution.md
@@ -28,7 +28,7 @@ It comprises of the following components:
   - Matlab bindings: [v2.3.0.1](https://github.com/precice/matlab-bindings/releases/tag/v2.3.0.1)
   - Python bindings: [v2.3.0.1](https://github.com/precice/python-bindings/releases/tag/v2.3.0.1)
 - Adapters:
-  - CalculiX adapter: [v2.19.0](https://github.com/precice/calculix-adapter/releases/tag/v2.19.0) (first tagged release)
+  - CalculiX adapter: [v2.20.0](https://github.com/precice/calculix-adapter/releases/tag/v2.20.0) (second tagged release)
   - code_aster adapter: commit [ce995e0](https://github.com/precice/code_aster-adapter/tree/ce995e0c41b26fe891ce04fd47fd52cbeff854e9) (same as in v2104.0)
   - deal.II adapter: commit [005933d](https://github.com/precice/dealii-adapter/tree/005933d6b45f885a64aee7ce597a3d7d81d54aff)
   - DUNE adapter: commit [5f2364d](https://github.com/precice/dune-adapter/tree/5f2364d57b517698914cb1d5f9979efe692d9254) (new and experimental)


### PR DESCRIPTION
This PR updates the website once the CalculiX-adapter v2.20 is released. 