### PR TITLE
Update Nutils versions and add more cases in docs

### DIFF
--- a/pages/docs/adapters/adapter-nutils.md
+++ b/pages/docs/adapters/adapter-nutils.md
@@ -10,6 +10,7 @@ The best way to learn how to couple a [Nutils](http://www.nutils.org/) applicati
 * [Two heat conduction scripts coupled to one another](https://github.com/precice/tutorials/blob/master/partitioned-heat-conduction/nutils/heat.py) (Nutils 7)
 * [A heat conduction script coupled to CFD for conjugate heat transfer](https://github.com/precice/tutorials/blob/master/flow-over-heated-plate/solid-nutils/solid.py) (Nutils 7)
 * [An ALE incompressible Navier-Stokes solver coupled to solid mechanics for fluid-structure interaction](https://github.com/precice/tutorials/blob/master/perpendicular-flap/fluid-nutils/fluid.py) (Nutils 6, [needs update](https://github.com/precice/tutorials/issues/217))
+* [A channel flow solver coupled to a transport problem solver](https://github.com/precice/tutorials/tree/master/channel-transport) (Nutils 7)
 * [A fracture mechanics solver volume-coupled to a dummy electro-chemistry corrosion model](https://github.com/uekerman/Coupled-Brittle-Fracture/blob/master/fracture.py) (Nutils 6)
 * [A 1D compressible fluid solver coupled to a 3D compressible fluid solver](https://gitlab.lrz.de/precice/ofw2019-experiments/-/blob/master/D/nutils/sonicLiquid.py) (uses deprecated version of Python bindings) (Nutils 5)
 

--- a/pages/docs/adapters/adapter-nutils.md
+++ b/pages/docs/adapters/adapter-nutils.md
@@ -5,12 +5,12 @@ keywords: FEM, adapter, heat conduction, finite element
 summary: "There is currently not really such a thing as a Nutils adapter. Coupling Nutils is so simple that directly calling the preCICE Python API from the application scripts is the way to go."
 ---
 
-The best way to learn how to couple a [Nutils](http://www.nutils.org/) application script is to look at some examples (unless stated otherwise, all [require Nutils 6](https://github.com/precice/tutorials/issues/217)):
+The best way to learn how to couple a [Nutils](http://www.nutils.org/) application script is to look at some examples:
 
-* [Two heat conduction scripts coupled to one another](https://github.com/precice/tutorials/blob/master/partitioned-heat-conduction/nutils/heat.py)
-* [A heat conduction script coupled to CFD for conjugate heat transfer](https://github.com/precice/tutorials/blob/master/flow-over-heated-plate/solid-nutils/solid.py)
-* [An ALE incompressible Navier-Stokes solver coupled to solid mechanics for fluid-structure interaction](https://github.com/precice/tutorials/blob/master/perpendicular-flap/fluid-nutils/fluid.py)
-* [A fracture mechanics solver volume-coupled to a dummy electro-chemistry corrosion model](https://github.com/uekerman/Coupled-Brittle-Fracture/blob/master/fracture.py)
-* [A 1D compressible fluid solver coupled to a 3D compressible fluid solver](https://gitlab.lrz.de/precice/ofw2019-experiments/-/blob/master/D/nutils/sonicLiquid.py) (uses deprecated version of Python bindings)
+* [Two heat conduction scripts coupled to one another](https://github.com/precice/tutorials/blob/master/partitioned-heat-conduction/nutils/heat.py) (Nutils 7)
+* [A heat conduction script coupled to CFD for conjugate heat transfer](https://github.com/precice/tutorials/blob/master/flow-over-heated-plate/solid-nutils/solid.py) (Nutils 7)
+* [An ALE incompressible Navier-Stokes solver coupled to solid mechanics for fluid-structure interaction](https://github.com/precice/tutorials/blob/master/perpendicular-flap/fluid-nutils/fluid.py) (Nutils 6, [needs update](https://github.com/precice/tutorials/issues/217))
+* [A fracture mechanics solver volume-coupled to a dummy electro-chemistry corrosion model](https://github.com/uekerman/Coupled-Brittle-Fracture/blob/master/fracture.py) (Nutils 6)
+* [A 1D compressible fluid solver coupled to a 3D compressible fluid solver](https://gitlab.lrz.de/precice/ofw2019-experiments/-/blob/master/D/nutils/sonicLiquid.py) (uses deprecated version of Python bindings) (Nutils 5)
 
 To install a specific version of Nutils use, for example: `pip3 install --user nutils==6.3`.

--- a/pages/docs/adapters/adapter-nutils.md
+++ b/pages/docs/adapters/adapter-nutils.md
@@ -7,7 +7,7 @@ summary: "There is currently not really such a thing as a Nutils adapter. Coupli
 
 The best way to learn how to couple a [Nutils](http://www.nutils.org/) application script is to look at some examples:
 
-* [Two heat conduction scripts coupled to one another](https://github.com/precice/tutorials/blob/master/partitioned-heat-conduction/nutils/heat.py) (Nutils 7)
+* [Two heat conduction scripts coupled to one another](https://github.com/precice/tutorials/blob/master/partitioned-heat-conduction/nutils/heat.py) (Nutils 6 and 7)
 * [A heat conduction script coupled to CFD for conjugate heat transfer](https://github.com/precice/tutorials/blob/master/flow-over-heated-plate/solid-nutils/solid.py) (Nutils 7)
 * [An ALE incompressible Navier-Stokes solver coupled to solid mechanics for fluid-structure interaction](https://github.com/precice/tutorials/blob/master/perpendicular-flap/fluid-nutils/fluid.py) (Nutils 6, [needs update](https://github.com/precice/tutorials/issues/217))
 * [A channel flow solver coupled to a transport problem solver](https://github.com/precice/tutorials/tree/master/channel-transport) (Nutils 7)


### PR DESCRIPTION
We are currently not consistent in the versions of Nutils we support. See https://github.com/precice/tutorials/issues/217, https://github.com/precice/vm/issues/52, and https://github.com/precice/vm/pull/56.

This updates the documentation to the current state, specifying the version for each example. It also adds the new channel-transport tutorial to the list.

I know it gets noisy writing the version next to every example, but I would trust this more than the "unless stated otherwise" (which was already outdated for one tutorial and for the OFW14 paper example cases).

@uekerman you probably have the best overview of versions here.