### PR TITLE
Make news global

### DIFF
--- a/_includes/news_banner.html
+++ b/_includes/news_banner.html
@@ -10,7 +10,7 @@ For news visible on all pages use:
 
 {% if true %}
 
-<div class="background-light">
+<div class="background-light banner-container">
   <div class="container">
     <div class="row no-margin">
       <div class="col-lg-12 banner">

--- a/_includes/news_banner.html
+++ b/_includes/news_banner.html
@@ -1,0 +1,25 @@
+{% comment %}{% raw %}
+
+For landing-only news use:
+{% if include.onlanding %}
+
+For news visible on all pages use:
+{% if true %}.
+
+{% endraw %}{% endcomment %}
+
+{% if true %}
+
+<div class="background-light">
+  <div class="container">
+    <div class="row no-margin">
+      <div class="col-lg-12 banner">
+        <p class="no-margin">
+          Submit your talk abstract to the <a href="precice-workshop-2023.html">preCICE Workshop 2023</a> till December 16. Join us in Munich in February 13-16 for user & dev talks, preCICE courses, and more.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -84,6 +84,8 @@
         {% include topnav.html %}
     </header>
     <main>
+          <!-- News banner -->
+          {% include news_banner.html onlanding=false %}
         <!-- Page Content -->
         <div class="container">
             <div id="main">

--- a/_layouts/landing_page.html
+++ b/_layouts/landing_page.html
@@ -9,6 +9,9 @@
 	</header>
 
 	<main>
+		<!-- News banner -->
+    {% include news_banner.html onlanding=true %}
+
 		<!-- Page Content -->
 		{{content}}
 	</main>

--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -4,7 +4,7 @@
 body {
     font-size: 16px;
     font-family: Roboto,"Helvetica Neue",Helvetica,Arial,sans-serif;
-    padding-top: 70px;      /* https://getbootstrap.com/docs/3.4/components/#navbar-fixed-top */
+    padding-top: 50px;      /* https://getbootstrap.com/docs/3.4/components/#navbar-fixed-top */
 }
 main {
     /*margin-top:-20px;*/

--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -4,10 +4,14 @@
 body {
     font-size: 16px;
     font-family: Roboto,"Helvetica Neue",Helvetica,Arial,sans-serif;
-    padding-top: 50px;      /* https://getbootstrap.com/docs/3.4/components/#navbar-fixed-top */
+    padding-top: 70px;      /* https://getbootstrap.com/docs/3.4/components/#navbar-fixed-top */
 }
 main {
-    /*margin-top:-20px;*/
+    /* margin-top:-20px; */
+}
+.banner-container {
+  margin-top:-20px;
+  /* margin-bottom:10px; */
 }
 a.navbar-brand {
     padding-top: 12px;

--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -7,7 +7,7 @@ body {
     padding-top: 70px;      /* https://getbootstrap.com/docs/3.4/components/#navbar-fixed-top */
 }
 main {
-    /* margin-top:-20px; */
+    /*margin-top:-20px;*/
 }
 .banner-container {
   margin-top:-20px;

--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -11,7 +11,6 @@ main {
 }
 .banner-container {
   margin-top:-20px;
-  /* margin-bottom:10px; */
 }
 a.navbar-brand {
     padding-top: 12px;

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1209,3 +1209,8 @@ h4.panel-title {
         display:block !important;
     }
 }
+
+/* News banner on pages other than the landing page */
+.banner {
+  padding: 15px 0;
+}

--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -5,7 +5,7 @@
 /* idea is to not touch the docs part of the website, but start from a clear state */
 
 main { /* fixed topnav takes up 50 + 20 px */
-  margin-top: -20px;
+  /* margin-top: -20px; */
 }
 h1[id], h2[id], h3[id], h4[id], h5[id], h6[id],
 dt[id] {

--- a/pages/index.html
+++ b/pages/index.html
@@ -7,21 +7,6 @@ hide_sidebar: true
 layout: landing_page
 ---
 
-<!-- Jumbotron for news -->
-<!-- Comment out whole block when no news -->
-
-<div class="background-light">
-  <div class="container">
-    <div class="row no-margin">
-      <div class="col-lg-12 banner">
-        <p class="no-margin">
-          Submit your talk abstract to the <a href="precice-workshop-2023.html">preCICE Workshop 2023</a> till December 16. Join us in Munich in February 13-16 for user & dev talks, preCICE courses, and more.
-        </p>
-      </div>
-    </div>
-  </div>
-</div>
-
 <!-- Lead stage -->
 
 <div class="container">


### PR DESCRIPTION
This PR moves the news banner html to its own `_include/news-banner.html`.

It is included in every page, use the boolean `include.onlanding` inside to determine where to show the banner.
I needed to add a `.banner { padding: 15px 0; }`  to the `customstyles.css` to make this look decent on non-landing pages.
