### PR TITLE
Update adapter-calculix-get-calculix.md

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -218,9 +218,10 @@ subprojects:
 
 # We use these versions to centrally update links
 # and other version-specific information.
+# Note that Jekyll cuts off trailing zeros: https://stackoverflow.com/questions/37862167/trailing-zeros-in-jekyll-liquid
 precice_version: 2.5.0
-calculix_version: 2.20
-calculix_adapter_version: 2.20.0
+calculix_version: "2.20"
+calculix_adapter_version: "2.20.0"
 
 # Latest known number of Google scholar citations, used as fallback
 precice_citations: 222

--- a/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
@@ -135,15 +135,15 @@ After building, make sure that you make yaml-cpp discoverable by setting e.g. yo
 
 ### Get the source
 
-Once the libraries are installed, you can finally install Calculix with preCICE adapter. Note that the adapter version needs to be the same as the CalculiX version (replace `2.20` below).
+Once the libraries are installed, you can finally install Calculix with preCICE adapter. Note that the adapter version needs to be the same as the CalculiX version (replace `{{site.calculix_version}}` below).
 
 ```bash
 cd ~
-wget http://www.dhondt.de/ccx_2.20.src.tar.bz2
-tar xvjf ccx_2.20.src.tar.bz2 
+wget http://www.dhondt.de/ccx_{{site.calculix_version}}.src.tar.bz2
+tar xvjf ccx_{{site.calculix_version}}.src.tar.bz2
 ```
 
-The source code is now in the `~/CalculiX/ccx_2.20/src` directory. The adapter's [`Makefile`](https://github.com/precice/calculix-adapter/blob/master/Makefile) is looking for CCX in this directory by default, so modify it if needed.
+The source code is now in the `~/CalculiX/ccx_{{site.calculix_version}}/src` directory. The adapter's [`Makefile`](https://github.com/precice/calculix-adapter/blob/master/Makefile) is looking for CCX in this directory by default, so modify it if needed.
 
 ### Building the "vanilla" CalculiX (optional)
 

--- a/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
@@ -2,7 +2,7 @@
 title: Get CalculiX
 permalink: adapter-calculix-get-calculix.html
 keywords: adapter, calculix, building, spooles, arpack, yaml-cpp
-summary: "Building CalculiX itself can already be quite a challenges. That's why we collected here some recipe."
+summary: "Building CalculiX itself can already be quite a challenge. That's why we collected here some recipe."
 ---
 
 The CalculiX adapter for preCICE directly modifies the source code of CalculiX and produces an alternative executable `ccx_preCICE`. Therefore, we first need to get and (optionally) build CalculiX from source.
@@ -135,15 +135,15 @@ After building, make sure that you make yaml-cpp discoverable by setting e.g. yo
 
 ### Get the source
 
-Once the libraries are installed, you can finally install Calculix with preCICE adapter. Note that the adapter version needs to be the same as the CalculiX version (replace `{{site.calculix_version}}` below).
+Once the libraries are installed, you can finally install Calculix with preCICE adapter. Note that the adapter version needs to be the same as the CalculiX version (replace `2.20` below).
 
 ```bash
 cd ~
-wget http://www.dhondt.de/ccx_{{site.calculix_version}}.src.tar.bz2
-tar xvjf ccx_{{site.calculix_version}}.src.tar.bz2 
+wget http://www.dhondt.de/ccx_2.20.src.tar.bz2
+tar xvjf ccx_2.20.src.tar.bz2 
 ```
 
-The source code is now in the `~/CalculiX/ccx_{{site.calculix_version}}/src` directory. The adapter's [`Makefile`](https://github.com/precice/calculix-adapter/blob/master/Makefile) is looking for CCX in this directory by default, so modify it if needed.
+The source code is now in the `~/CalculiX/ccx_2.20/src` directory. The adapter's [`Makefile`](https://github.com/precice/calculix-adapter/blob/master/Makefile) is looking for CCX in this directory by default, so modify it if needed.
 
 ### Building the "vanilla" CalculiX (optional)
 


### PR DESCRIPTION
At the time of writing this, {{site.calculix_version}} points to 2.2 which is wrong and makes the links broken. If it points to 2.20 then there will be no problem. For the time being I change {{site.calculix_version}} to 2.20 which is not the smartest thing to do but solves the issue anyway.  Also there is typo in "Summary". I changed "challenges" to "challenge".