### PR TITLE
Update ARPACK links in the CalculiX adapter documentation

### DIFF
--- a/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
@@ -73,7 +73,7 @@ make lib
 <details markdown="1"><summary>If you cannot get a binary for ARPACK, try these instructions.</summary>
 
 {% note %}
-Till 2022, ARPACK was hosted at https://www.caam.rice.edu/software/ARPACK, a page which does not exist anymore. The project <a href="https://github.com/opencollab/arpack-ng">arpack-ng</a> aims to continue the development, and the CalculiX website links to that. See also a <a href="https://calculix.discourse.group/t/build-ccx-with-arpack-ng/1544">related discussion on the CalculiX forum</a>. If you have tried building CalculiX with arpack-ng, please edit this page. Otherwise, you can get the original ARPACK from the <a href="https://web.archive.org/web/20220121182321/https://www.caam.rice.edu/software/ARPACK/index.html">Wayback machine</a> and follow these instructions.
+Till 2022, ARPACK was hosted by the <a href="https://www.caam.rice.edu/software/ARPACK">Rice University</a>, but the page which does not exist anymore. The project <a href="https://github.com/opencollab/arpack-ng">arpack-ng</a> aims to continue the development, and the CalculiX website links to that. See also a <a href="https://calculix.discourse.group/t/build-ccx-with-arpack-ng/1544">related discussion on the CalculiX forum</a>. If you have tried building CalculiX with arpack-ng, please edit this page. Otherwise, you can get the original ARPACK from the <a href="https://web.archive.org/web/20220121182321/https://www.caam.rice.edu/software/ARPACK/index.html">Wayback machine</a> and follow these instructions.
 {% endnote %}
 
 Download Arpack and patch:

--- a/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-calculix.md
@@ -72,11 +72,15 @@ make lib
 
 <details markdown="1"><summary>If you cannot get a binary for ARPACK, try these instructions.</summary>
 
+{% note %}
+Till 2022, ARPACK was hosted at https://www.caam.rice.edu/software/ARPACK, a page which does not exist anymore. The project <a href="https://github.com/opencollab/arpack-ng">arpack-ng</a> aims to continue the development, and the CalculiX website links to that. See also a <a href="https://calculix.discourse.group/t/build-ccx-with-arpack-ng/1544">related discussion on the CalculiX forum</a>. If you have tried building CalculiX with arpack-ng, please edit this page. Otherwise, you can get the original ARPACK from the <a href="https://web.archive.org/web/20220121182321/https://www.caam.rice.edu/software/ARPACK/index.html">Wayback machine</a> and follow these instructions.
+{% endnote %}
+
 Download Arpack and patch:
 
 ```bash
-wget https://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz 
-wget https://www.caam.rice.edu/software/ARPACK/SRC/patch.tar.gz 
+wget https://web.archive.org/web/20220526222500fw_/https://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz
+wget https://web.archive.org/web/20220526222500fw_/https://www.caam.rice.edu/software/ARPACK/SRC/patch.tar.gz 
 ```
 
 Unpack them (they will be unpacked in the newly created directory `ARPACK`)

--- a/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-pastix-build.md
@@ -123,8 +123,8 @@ Calculix relies on ARPACK, and when built with PaStiX, we cannot rely on standar
 
 ```bash
 cd ~
-wget https://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz
-wget https://www.caam.rice.edu/software/ARPACK/SRC/patch.tar.gz
+wget https://web.archive.org/web/20220526222500fw_/https://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz
+wget https://web.archive.org/web/20220526222500fw_/https://www.caam.rice.edu/software/ARPACK/SRC/patch.tar.gz
 zcat arpack96.tar.gz | tar -xvf -
 zcat patch.tar.gz    | tar -xvf -
 


### PR DESCRIPTION
Closes #244, referring to the latest snapshot of the [Wayback machine](https://web.archive.org/web/20220121182321/https://www.caam.rice.edu/software/ARPACK/index.html).

I did not want to get in the process of trying out arpack-ng, since this would probably take a while, and it is not really on our desk. This should be the most minimally-invasive solution.