### PR TITLE
Add OpenFOAM Journal article to literature guide

### DIFF
--- a/_includes/news_banner.html
+++ b/_includes/news_banner.html
@@ -8,14 +8,14 @@ For news visible on all pages use:
 
 {% endraw %}{% endcomment %}
 
-{% if false %}
+{% if include.onlanding %}
 
 <div class="background-light banner-container">
   <div class="container">
     <div class="row no-margin">
       <div class="col-lg-12 banner">
         <p class="no-margin">
-          A lot is happening at the <a href="precice-workshop-2023.html">preCICE Workshop 2023</a>!
+          New paper: <a href="https://doi.org/10.51560/ofj.v3.88">OpenFOAM-preCICE: Coupling OpenFOAM with external solvers for multi-physics simulations</a>, OpenFOAM® Journal
         </p>
       </div>
     </div>

--- a/assets/openfoam-precice.bib
+++ b/assets/openfoam-precice.bib
@@ -1,0 +1,11 @@
+@article{OpenFOAMpreCICE,
+  author = {Chourdakis, Gerasimos and Schneider, David and Uekermann, Benjamin},
+  title = {{OpenFOAM-preCICE}: Coupling {OpenFOAM} with external solvers for multi-physics simulations},
+  journal = {OpenFOAM® Journal},
+  volume = {3},
+  year = {2023},
+  month = {Feb},
+  pages = {1-25},
+  doi = {10.51560/ofj.v3.88},
+  url = {https://doi.org/10.51560/ofj.v3.88}
+}

--- a/collections/_publications/2023-OpenFOAM-preCICE.yml
+++ b/collections/_publications/2023-OpenFOAM-preCICE.yml
@@ -1,0 +1,13 @@
+---
+title: "OpenFOAM-preCICE: Coupling OpenFOAM with External Solvers for Multi-Physics Simulations"
+pub-url: https://doi.org/10.51560/ofj.v3.88
+year: 2023
+authors: "Gerasimos Chourdakis, David Schneider, and Benjamin Uekermann"
+bibtex: openfoam-precice.bib
+doi: 10.51560/ofj.v3.88
+journal:
+  name: OpenFOAM® Journal
+  volume: 3
+  pages: 1-25
+tag: openfoam-precice-adapter
+---

--- a/pages/docs/fundamentals/fundamentals-literature-guide.md
+++ b/pages/docs/fundamentals/fundamentals-literature-guide.md
@@ -54,6 +54,30 @@ Talking specifically about preCICE v1? Then keep citing the [preCICE v1 referenc
 Are you using any of the adapters? Then, please also read and cite the respective references. The following adapters currently have reference papers:
 
 {% for pub in site.publications %}
+{% if pub.title == "OpenFOAM-preCICE: Coupling OpenFOAM with External Solvers for Multi-Physics Simulations" %}
+<div class="row">
+<div class="col-md-10 col-md-offset-1">
+  <div class="panel panel-primary panel-precice">
+    <div class="panel-heading-precice">
+      <strong>{{ pub.title }}</strong>
+    </div>
+    <div class="panel-body">
+      <p>
+        <em>{{ pub.authors }}</em>,
+        {{ pub.journal.name }},
+        Volume {{ pub.journal.volume }},
+        {{ pub.year }}.
+      </p>
+      <a href="https://www.doi.org/{{pub.doi}}">Publisher's site</a>&nbsp;&nbsp;
+      <a href="assets/{{ pub.bibtex }}">Download BibTeX &nbsp;<i class="fas fa-download"></i></a>
+    </div>
+  </div>
+</div>
+</div>
+{% endif %}
+{% endfor %}
+
+{% for pub in site.publications %}
 {% if pub.title == "FEniCS–preCICE: Coupling FEniCS to other simulation software" %}
 <div class="row">
 <div class="col-md-10 col-md-offset-1">

--- a/pages/docs/fundamentals/fundamentals-literature-guide.md
+++ b/pages/docs/fundamentals/fundamentals-literature-guide.md
@@ -102,9 +102,7 @@ Are you using any of the adapters? Then, please also read and cite the respectiv
 {% endif %}
 {% endfor %}
 
-For the OpenFOAM adapter, a reference paper is under review.
-
-For the OpenFOAM, CalculiX, SU2, and code_aster adapters, as well as for the concept of an adapter, please read and cite this overview paper:
+For the CalculiX, SU2, and code_aster adapters, as well as for the concept of an adapter, please read and cite this overview paper:
 
 {% for pub in site.publications %}
 {% if pub.title == "Official preCICE Adapters for Standard Open-Source Solvers" %}


### PR DESCRIPTION
This updates the [literature guide](https://precice.org/fundamentals-literature-guide.html) page with our new OpenFOAM-preCICE paper:

![Screenshot from 2023-04-11 16-14-25](https://user-images.githubusercontent.com/4943683/231174836-27459113-ad39-4bcc-baea-fd188a3a8e68.png)

___

This includes a BibTeX file, which, when used in the OFJ template renders as:

![Screenshot from 2023-04-11 16-20-54](https://user-images.githubusercontent.com/4943683/231175827-2d163731-b251-4e47-9209-44f04cd17cf0.png)

___

It also adds a news banner for the landing page (only):

![Screenshot from 2023-04-11 16-14-43](https://user-images.githubusercontent.com/4943683/231174906-ba2f848b-b3ef-454f-9486-50c297f78e97.png)

___

@uekerman @davidscn anything else we need to update in the website repository? Does everything look as expected?