### PR TITLE
Move computation of adaptive dt before read

### DIFF
--- a/pages/docs/couple-your-code/couple-your-code-implicit-coupling.md
+++ b/pages/docs/couple-your-code/couple-your-code-implicit-coupling.md
@@ -55,10 +55,10 @@ while (precice.isCouplingOngoing()){
     saveOldState(); // save checkpoint
     precice.markActionFulfilled(cowic);
   }
-  precice.readBlockVectorData(displID, vertexSize, vertexIDs, displacements);
-  setDisplacements(displacements);
   solverDt = beginTimeStep(); // e.g. compute adaptive dt
   dt = min(preciceDt, solverDt);
+  precice.readBlockVectorData(displID, vertexSize, vertexIDs, displacements);
+  setDisplacements(displacements);
   solveTimeStep(dt);
   computeForces(forces);
   precice.writeBlockVectorData(forceID, vertexSize, vertexIDs, forces);

--- a/pages/docs/couple-your-code/couple-your-code-mesh-and-data-access.md
+++ b/pages/docs/couple-your-code/couple-your-code-mesh-and-data-access.md
@@ -66,10 +66,10 @@ double dt; // actual time step size
 
 preciceDt = precice.initialize();
 while (not simulationDone()){ // time loop
-        precice.readBlockVectorData(displID, vertexSize, vertexIDs, displacements);
-  setDisplacements(displacements);
   solverDt = beginTimeStep(); // e.g. compute adaptive dt
   dt = min(preciceDt, solverDt);
+  precice.readBlockVectorData(displID, vertexSize, vertexIDs, displacements);
+  setDisplacements(displacements);
   solveTimeStep(dt);
   computeForces(forces);
   precice.writeBlockVectorData(forceID, vertexSize, vertexIDs, forces);

--- a/pages/docs/couple-your-code/couple-your-code-timestep-sizes.md
+++ b/pages/docs/couple-your-code/couple-your-code-timestep-sizes.md
@@ -83,12 +83,12 @@ You can use them as follows:
 
 ```c++
 while (not simulationDone()){ // time loop
+  solverDt = beginTimeStep(); // e.g. compute adaptive dt
+  dt = min(preciceDt, solverDt);
   if (precice.isReadDataAvailable()){
     precice.readBlockVectorData(displID, vertexSize, vertexIDs, displacements);
     setDisplacements(displacements);
   }
-  solverDt = beginTimeStep(); // e.g. compute adaptive dt
-  dt = min(preciceDt, solverDt);
   solveTimeStep(dt);
   if (precice.isWriteDataRequired(dt)){
     computeForces(forces);


### PR DESCRIPTION
Currently, the computation of the adaptive `solverDt` happens after the read. I would argue that it should happen before the read. I guess the original idea here was that the computation of the `solverDt` depends on the quantity that was read. However, I think this does not make sense for the following two reasons:

1) If we use waveforms, we need the `dt` before reading, not after. See also #257 
2) If the adaptive `solverDt` depends on the quantity read from preCICE, then we need to read that quantity also at the right location in time. This leads somehow to a deadlock, that we could, for example, solve by iterating:

```cpp
bool solverDtChanging = true;
solverDt = beginTimeStep(displacements); // e.g. compute adaptive dt that depends on displacements
while(solverDtChanging) {
  dt = min(preciceDt, solverDt);
  precice.readBlockVectorData(displID, vertexSize, vertexIDs, dt, displacements);
  oldSolverDt = solverDt;
  solverDt = beginTimeStep(displacements);
  solverDtChanging = check(solverDt, oldSolverDt, tol);
}
```