### PR TITLE
Add a page for previous versions

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -39,6 +39,10 @@ entries:
     - title: Roadmap
       url: /fundamentals-roadmap.html
       output: web, pdf
+    
+    - title: Previous versions
+      url: /fundamentals-previous-versions.html
+      output: web, pdf
 
   - title: Installation
     output: web, pdf

--- a/pages/docs/fundamentals/fundamentals-previous-versions.md
+++ b/pages/docs/fundamentals/fundamentals-previous-versions.md
@@ -7,6 +7,6 @@ summary: "Archives of this documentation"
 
 In regular intervals, we archive PDF exports of this documentation. Refer to those when you are looking for information regarding previous versions. These are part of the [preCICE Distribution](./installation-distribution.html). Alternatively, you can build [previous states of this website](https://github.com/precice/precice.github.io).
 
-- [preCICE v2.x](https://github.com/precice/precice.github.io/releases/download/v202211.0.0/libprecice2_2.2.5_docs_v202211.0.0.pdf)
+- For preCICE v2.x: [libprecice2_2.2.5_docs_v202211.0.0.pdf](https://github.com/precice/precice.github.io/releases/download/v202211.0.0/libprecice2_2.2.5_docs_v202211.0.0.pdf)
 
 Before preCICE v2.x, the documentation was hosted in a [GitHub Wiki](https://github.com/precice/precice/wiki). See previous revisions of the respective page.

--- a/pages/docs/fundamentals/fundamentals-previous-versions.md
+++ b/pages/docs/fundamentals/fundamentals-previous-versions.md
@@ -1,0 +1,12 @@
+---
+title: Previous versions
+permalink: fundamentals-previous-versions.html
+keywords: pdf, export, v1, v2
+summary: "Archives of this documentation"
+---
+
+In regular intervals, we archive PDF exports of this documentation. Refer to those when you are looking for information regarding previous versions. These are part of the [preCICE Distribution](./installation-distribution.html). Alternatively, you can build [previous states of this website](https://github.com/precice/precice.github.io).
+
+- [preCICE v2.x](https://github.com/precice/precice.github.io/releases/download/v202211.0.0/libprecice2_2.2.5_docs_v202211.0.0.pdf)
+
+Before preCICE v2.x, the documentation was hosted in a [GitHub Wiki](https://github.com/precice/precice/wiki). See previous revisions of the respective page.


### PR DESCRIPTION
This adds a short page `Previous versions` below the `Roadmap`, which looks like this:

![Screenshot from 2023-04-24 13-16-50](https://user-images.githubusercontent.com/4943683/233969295-1d1eb65e-d83b-418d-a608-0a31620a0af0.png)

Motivation for some decisions:

- It's not a button below the sidebar, as this would be more complicated to implement, especially in a responsive way. It would, however, be more discoverable.
- It is under "Fundamentals" and next to the Roadmap, because is it the past (vs future of roadmap) and it shows up when first going to the docs.
- It is a complete page, aiming to later have entries for v3, v4, etc.
- It does not point to every feature release, as we don't have a PDF for every feature release and we generally keep the docs applicable to all feature releases of a major version.
- Linking to a previous revision of the GitHub Wiki does not really help, as every URL from the home page will lead again to the latest version.

Ideally, I would put links to each major version to the footer, which we don't have yet. #46 