### PR TITLE
Reworking Micro Manager documentation

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -246,7 +246,7 @@ entries:
           url: /tooling-micro-manager-installation.html
           output: web, pdf
         
-        - title: Preparing micro simulations
+        - title: Preparing micro simulation
           url: /tooling-micro-manager-prepare-micro-simulation.html
           output: web, pdf
 

--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -233,14 +233,6 @@ entries:
       url: /tooling-config-visualization.html
       output: web, pdf
 
-    - title: Performance analysis
-      url: /tooling-performance-analysis.html
-      output: web, pdf
-
-    - title: RBF shape calculator
-      url: /tooling-rbf-shape.html
-      output: web, pdf
-
       subfolders:
       - title: Micro Manager
         output: web, pdf
@@ -250,12 +242,12 @@ entries:
           url: /tooling-micro-manager-overview.html
           output: web, pdf
 
-        - title: Installation
+        - title: Get the Micro Manager
           url: /tooling-micro-manager-installation.html
           output: web, pdf
         
-        - title: Convert Your Micro Simulation to Library
-          url: /tooling-micro-manager-micro-simulation-callable-library.html
+        - title: Preparing micro simulations
+          url: /tooling-micro-manager-prepare-micro-simulation.html
           output: web, pdf
 
         - title: Configuration
@@ -265,6 +257,14 @@ entries:
         - title: Running
           url: /tooling-micro-manager-running.html
           output: web, pdf
+
+    - title: Performance analysis
+      url: /tooling-performance-analysis.html
+      output: web, pdf
+
+    - title: RBF shape calculator
+      url: /tooling-rbf-shape.html
+      output: web, pdf
 
   - title: Provided adapters
     output: web, pdf


### PR DESCRIPTION
Restructuring and reworking of documentation of the tool Micro Manager. To be merged after https://github.com/precice/micro-manager/pull/50