### PR TITLE
Include FMI runner in Tooling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,7 @@
 	path = imported/micro-manager
 	url = https://github.com/precice/micro-manager.git
 	branch = develop
+[submodule "imported/fmi-runner"]
+	path = imported/fmi-runner
+	url = https://github.com/precice/fmi-runner.git
+	branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,5 +16,5 @@
 	branch = develop
 [submodule "imported/fmi-runner"]
 	path = imported/fmi-runner
-	url = https://github.com/precice/fmi-runner.git
+	url = https://github.com/precice/fmi-runner
 	branch = develop

--- a/_config.yml
+++ b/_config.yml
@@ -162,7 +162,7 @@ defaults:
       toc: true
       github_editme_path: https://github.com/precice/micro-manager/edit/develop/ # ends in /
   -
-      scope:
+    scope:
       path: "imported/fmi-runner/"
       type: "pages"
     values:

--- a/_config.yml
+++ b/_config.yml
@@ -162,6 +162,18 @@ defaults:
       toc: true
       github_editme_path: https://github.com/precice/micro-manager/edit/develop/ # ends in /
   -
+      scope:
+      path: "imported/fmi-runner/"
+      type: "pages"
+    values:
+      layout: "page"
+      comments: false
+      search: true
+      sidebar: docs_sidebar
+      topnav: topnav
+      toc: true
+      github_editme_path: https://github.com/precice/fmi-runner/edit/develop/ # ends in /
+  -
     scope:
       path: "pages/community"
       type: "pages"
@@ -229,6 +241,7 @@ subprojects:
   - imported/tutorials/aste-turbine
   - imported/openfoam-adapter/docs
   - imported/micro-manager/docs
+  - imported/fmi-runner/docs
   - imported/aste/docs
 
 # We use these versions to centrally update links

--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -232,6 +232,10 @@ entries:
     - title: Config visualization
       url: /tooling-config-visualization.html
       output: web, pdf
+      
+    - title: FMI runner
+      url: /tooling-fmi-runner.html
+      output: web, pdf
 
       subfolders:
       - title: Micro Manager
@@ -257,10 +261,6 @@ entries:
         - title: Running
           url: /tooling-micro-manager-running.html
           output: web, pdf
-
-    - title: FMI runner
-      url: /tooling-fmi-runner.html
-      output: web, pdf
     
     - title: Performance analysis
       url: /tooling-performance-analysis.html

--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -258,6 +258,10 @@ entries:
           url: /tooling-micro-manager-running.html
           output: web, pdf
 
+    - title: FMI runner
+      url: /tooling-fmi-runner.html
+      output: web, pdf
+    
     - title: Performance analysis
       url: /tooling-performance-analysis.html
       output: web, pdf

--- a/pages/docs/tooling/tooling-overview.md
+++ b/pages/docs/tooling/tooling-overview.md
@@ -12,6 +12,7 @@ Here you will find a few tools to:
 - [Simulate and replay coupled simulations in an artificial environment](tooling-aste.html) without actual solvers and adapters.
 - [Check your configuration file](tooling-builtin.html) without starting a whole simulation.
 - [Visualize the preCICE configuration file](tooling-config-visualization.html) to understand if you are really asking preCICE to do what you meant to.
+- [Couple your simulation to FMU models](tooling-fmi-runner.html) following the FMI standard
 - [Analyze the performance of the coupled simulation](tooling-performance-analysis.html) to understand where the runtime comes from.
 - [Compute parameters for the RBF mapping configuration](tooling-rbf-shape.html) to optimize the accuracy and performance of your RBF mapping.
 


### PR DESCRIPTION
Add instructions on the FMI runner on precice.org in the Tooling section

In combination with changes in the FMI runner repo: https://github.com/precice/fmi-runner/pull/6