### PR TITLE
Add precice.hpp and solver-interface changes to porting guide

### DIFF
--- a/pages/docs/couple-your-code/couple-your-code-porting-v2-3.md
+++ b/pages/docs/couple-your-code/couple-your-code-porting-v2-3.md
@@ -89,7 +89,7 @@ error: ‘class precice::SolverInterface’ has no member named ‘initializeDat
 
 ## preCICE configuration file
 
-- The XML tag `<solver-interface>` was removed and all underlying functionality was moved to the `<precice-configuration>` tag. Remove the lines including `<solver-interface>` and `</solver-interface>`, and move any attributes (such as `dimensions="3"` or `experimental`) from the `solver-interface` to the `precice-configuration` tag. 
+- The XML tag `<solver-interface>` was removed and all underlying functionality was moved to the `<precice-configuration>` tag. Remove the lines including `<solver-interface>` and `</solver-interface>`, and move any attributes (such as `dimensions="3"` or `experimental`) from the `solver-interface` to the `precice-configuration` tag.
 - Replace mapping constraint `scaled-consistent` with `scaled-consistent-surface`.
 - Replace `<use-mesh provide="true" ... />` with `<provide-mesh ... />`, and `<use-mesh provide="false" ... />` with `<receive-mesh ... />`.
 - Replace `<extraplation-order value="2" />` in `<coupling-scheme>` with `<extraplation-order value="1" />` or simply remove it.
@@ -142,7 +142,7 @@ A specific solver should only be configured if you want to force preCICE to use 
 
 The renaming of the preCICE API from `SolverInterface` to `preCICE` also applies to all language bindings. The C++ header change `precice/SolverInterface.hpp` to `precice/precice.hpp` becomes:
 
-- In C: Replace `#include "precice/SolverInterfaceC.h"` with `#include "precice/preciceC.h"` and ` precicec_createSolverInterface( ... )` with ` precicec_createParticipant( ... )`.
+- In C: Replace `#include "precice/SolverInterfaceC.h"` with `#include "precice/preciceC.h"` and `precicec_createSolverInterface( ... )`with ` precicec_createParticipant( ... )`.
 - In Julia: Replace `precicec_createSolverInterface( ... )` with `precicec_createParticipant_withCommunicator( ... )`.
 - In Matlab: Replace `SolverInterface` with `Participant` everywhere.
 - In Fortran, Python: You don't need to change anything.

--- a/pages/docs/couple-your-code/couple-your-code-porting-v2-3.md
+++ b/pages/docs/couple-your-code/couple-your-code-porting-v2-3.md
@@ -16,6 +16,11 @@ Please add breaking changes here when merged to the `develop` branch.
 
 ## preCICE API
 
+- The main preCICE header file was renamed. This means that you need to:
+  - Replace `#include "precice/SolverInterface.hpp"` with `#include "precice/precice.hpp"`.
+  - Where declaring a preCICE object, replace the `precice::SolverInterface` type with `precice::Participant`
+  - Where constructing a preCICE object, replace the `precice::SolverInterface( ... )` constructor with `precice::Participant( ... )`.
+  - Consider renaming your objects from, e.g., `interface` to `participant`, to better reflect the purpose and to be consistent with the rest of the changes.
 - Migrate connectivity information to the vertex-only API. All `setMeshX` methods take vertex IDs as input and return nothing.
   - Directly define face elements or cells of your coupling mesh available in your solver by passing their vectices to preCICE, which automatically handles edges of triangles etc. See [Mesh Connectivity](couple-your-code-defining-mesh-connectivity) for more information.
   - Rename `setMeshTriangleWithEdges` to `setMeshTriangle` and `setMeshQuadWithEdges` to `setMeshQuad`. The edge-based implementation was removed.
@@ -84,6 +89,7 @@ error: ‘class precice::SolverInterface’ has no member named ‘initializeDat
 
 ## preCICE configuration file
 
+- The XML tag `<solver-interface>` was removed and all underlying functionality was moved to the `<precice-configuration>` tag. Remove the lines including `<solver-interface>` and `</solver-interface>`, and move any attributes (such as `dimensions="3"` or `experimental`) from the `solver-interface` to the `precice-configuration` tag. 
 - Replace mapping constraint `scaled-consistent` with `scaled-consistent-surface`.
 - Replace `<use-mesh provide="true" ... />` with `<provide-mesh ... />`, and `<use-mesh provide="false" ... />` with `<receive-mesh ... />`.
 - Replace `<extraplation-order value="2" />` in `<coupling-scheme>` with `<extraplation-order value="1" />` or simply remove it.
@@ -133,6 +139,13 @@ A specific solver should only be configured if you want to force preCICE to use 
   - Removed timewindowsize from the `performAction` signature of `PythonAction`. The new signature is `performAction(time, data)`
 
 ## Language bindings
+
+The renaming of the preCICE API from `SolverInterface` to `preCICE` also applies to all language bindings. The C++ header change `precice/SolverInterface.hpp` to `precice/precice.hpp` becomes:
+
+- In C: Replace `#include "precice/SolverInterfaceC.h"` with `#include "precice/preciceC.h"` and ` precicec_createSolverInterface( ... )` with ` precicec_createParticipant( ... )`.
+- In Julia: Replace `precicec_createSolverInterface( ... )` with `precicec_createParticipant_withCommunicator( ... )`.
+- In Matlab: Replace `SolverInterface` with `Participant` everywhere.
+- In Fortran, Python: You don't need to change anything.
 
 <!--
 - Rename Fortran function `precicef_ongoing()` to `precicef_is_coupling_ongoing()`

--- a/pages/docs/couple-your-code/couple-your-code-porting-v2-3.md
+++ b/pages/docs/couple-your-code/couple-your-code-porting-v2-3.md
@@ -143,7 +143,7 @@ A specific solver should only be configured if you want to force preCICE to use 
 The renaming of the preCICE API from `SolverInterface` to `preCICE` also applies to all language bindings. The C++ header change `precice/SolverInterface.hpp` to `precice/precice.hpp` becomes:
 
 - In C: Replace `#include "precice/SolverInterfaceC.h"` with `#include "precice/preciceC.h"` and `precicec_createSolverInterface( ... )` with `precicec_createParticipant( ... )`.
-- In Julia: Replace `precicec_createSolverInterface( ... )` with `precicec_createParticipant_withCommunicator( ... )`.
+- In Julia: Replace `precicec_createSolverInterface( ... )` with `precicec_createParticipant( ... )`.
 - In Matlab: Replace `SolverInterface` with `Participant` everywhere.
 - In Fortran, Python: You don't need to change anything.
 

--- a/pages/docs/couple-your-code/couple-your-code-porting-v2-3.md
+++ b/pages/docs/couple-your-code/couple-your-code-porting-v2-3.md
@@ -142,7 +142,7 @@ A specific solver should only be configured if you want to force preCICE to use 
 
 The renaming of the preCICE API from `SolverInterface` to `preCICE` also applies to all language bindings. The C++ header change `precice/SolverInterface.hpp` to `precice/precice.hpp` becomes:
 
-- In C: Replace `#include "precice/SolverInterfaceC.h"` with `#include "precice/preciceC.h"` and `precicec_createSolverInterface( ... )`with ` precicec_createParticipant( ... )`.
+- In C: Replace `#include "precice/SolverInterfaceC.h"` with `#include "precice/preciceC.h"` and `precicec_createSolverInterface( ... )` with `precicec_createParticipant( ... )`.
 - In Julia: Replace `precicec_createSolverInterface( ... )` with `precicec_createParticipant_withCommunicator( ... )`.
 - In Matlab: Replace `SolverInterface` with `Participant` everywhere.
 - In Fortran, Python: You don't need to change anything.


### PR DESCRIPTION
Very late follow-up of the changes related to https://github.com/precice/precice/issues/1458.

The bindings may still need some updates, I would appreciate some feedback there.