### PR TITLE
Add past events: ECCM-ECFD 2018 and COUPLED 2019

### DIFF
--- a/_data/sidebars/community_sidebar.yaml
+++ b/_data/sidebars/community_sidebar.yaml
@@ -66,3 +66,7 @@ entries:
     - title: preCICE Workshop 2020
       url: /precice-workshop-2020.html
       output: web
+    
+    - title: Coupled Problems 2019
+      url: /eccomas-coupled-2019.html
+      output: web

--- a/_data/sidebars/community_sidebar.yaml
+++ b/_data/sidebars/community_sidebar.yaml
@@ -70,3 +70,7 @@ entries:
     - title: Coupled Problems 2019
       url: /eccomas-coupled-2019.html
       output: web
+    
+    - title: ECCOMAS ECCM-ECFD 2018
+      url: /eccomas-eccm-ecfd-2018.html
+      output: web

--- a/pages/community/eccomas-coupled-2019.md
+++ b/pages/community/eccomas-coupled-2019.md
@@ -41,3 +41,7 @@ Session: [IS- Multi-physics Simulations with the Coupling Library preCICE III](h
 * **T. Reimann et al.:** [A One-Way Coupling Setup for the Efficient Simulation of Aeroacoustics Problems with Far-Field Propagation](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a332.pdf)
 * **Y. Luo et al.:** [A Fluid-Structure Interaction Solver for the Study of the Propulsion of a Passively Deformed Fish Fin](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a175.pdf)
 * **N. Ebrahimi Pour et al.:** [High Order Simulation of Rigid Body Motion Induced Aeroacoustics](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a35.pdf)
+
+## Related talks in other sessions
+
+* **B. Rüth et al.:** [A Quasi-Newton Accelerated Multirate Coupling Scheme for Partitioned Simulation](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a80.pdf)

--- a/pages/community/eccomas-coupled-2019.md
+++ b/pages/community/eccomas-coupled-2019.md
@@ -1,0 +1,43 @@
+---
+title: ECCOMAS Coupled Problems 2019
+keywords: 2019, ECCOMAS, COUPLED, event, events, minisymposium
+summary:
+permalink: eccomas-coupled-2019.html
+toc: false
+---
+
+The [ECCOMAS Coupled Problems 2019](https://congress.cimne.com/coupled2019/) took place in Sitges (Barcelona), Spain, between 3-5 June, 2019.
+
+We organized the minisymposium _Multi-physics Simulations with the Coupling Library preCICE_, which had three sessions.
+
+## Schedule of the Minisymposium
+
+### Wednesday, June 5, 11:30 - 13:30
+
+Session: [IS- Multi-physics Simulations with the Coupling Library preCICE I](https://congress.cimne.com/coupled2019/frontal/ProgramPrint.asp?id=WeM4)
+
+* **B. Uekermann et al.:** [Algorithms for Multi-Model Coupled Problems in preCICE](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a192.pdf)
+* **S. Scheiblhofer et al.:** [Coupling FEM and CFD Solvers for Continuous Casting Process Simulation Using preCICE](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a170.pdf)
+* **D. Cinquegrana et al.:** [Framework for Fluid-Structure Interaction Simulations with UZEN and PreCICE: Simulations Procedure and Validation](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a42.pdf)
+* **K. Davis et al.:** [Tuning Numerical Coupling Parameters for Heart Valve Simulations with OpenFOAM and CalculiX](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a109.pdf)
+* **D. Volland et al.:** [Parallel Coupling for TherMoS with preCICE](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a180.pdf)
+* **A. Monge et al.:** [Partitioned Multirate Domain Decomposition Waveform Relaxation Methods for the Heat Equation](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a196.pdf)
+
+### Wednesday, June 5, 14:30 - 16:30
+
+Session: [IS- Multi-physics Simulations with the Coupling Library preCICE II](https://congress.cimne.com/coupled2019/frontal/ProgramPrint.asp?id=WeA4)
+
+* **G. Chourdakis et al.:** [PreCICE for OpenFOAM: from CHT and FSI to a General-Purpose Plug-in](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a155.pdf)
+* **D. Risseeuw et al.:** [Fluid Structure Interaction Modelling of Flapping Wings](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a321.pdf)
+* **M. Camps Santasmasas et al.:** [Wind Around Buildings with a Two-Way Coupled Navier-Stokes (NS) and Lattice Boltzmann Solver (LB)](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a72.pdf)
+* **J. Seuffert et al.:** [Fluid Structure Interaction During the Resin Transfer Molding (RTM) Manufacturing Process for Continuous Fiber Reinforced Composites](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a17.pdf)
+* **M. Folkersma et al.:** [Fluid-Structure Interaction of Inflatable Wing Section](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a351.pdf)
+* **N. Abdollahi et al.:** [A Coupled Framework for Analysis and Optimization of an Aeroelastically Tailored Wing Skin](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a96.pdf)
+
+### Wednesday, June 5, 17:00 - 19:00
+
+Session: [IS- Multi-physics Simulations with the Coupling Library preCICE III](https://congress.cimne.com/coupled2019/frontal/ProgramPrint.asp?id=WeE3)
+
+* **T. Reimann et al.:** [A One-Way Coupling Setup for the Efficient Simulation of Aeroacoustics Problems with Far-Field Propagation](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a332.pdf)
+* **Y. Luo et al.:** [A Fluid-Structure Interaction Solver for the Study of the Propulsion of a Passively Deformed Fish Fin](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a175.pdf)
+* **N. Ebrahimi Pour et al.:** [High Order Simulation of Rigid Body Motion Induced Aeroacoustics](https://congress.cimne.com/coupled2019/admin/files/fileabstract/a35.pdf)

--- a/pages/community/eccomas-eccm-ecfd-2018.md
+++ b/pages/community/eccomas-eccm-ecfd-2018.md
@@ -1,0 +1,23 @@
+---
+title: ECCOMAS ECCM ECFD 2018
+keywords: 2018, ECCOMAS, event, events, minisymposium
+summary:
+permalink: eccomas-eccm-ecfd-2018.html
+toc: false
+---
+
+The [ECCOMAS ECCM-ECFD 2018](http://congress.cimne.com/eccm_ecfd2018/frontal/introduction.asp) took place in Glasgow, UK, between 11-15 June, 2018.
+
+We organized the minisymposium _Multi-Physics Simulations with the Coupling Library preCICE_, which had one session. This was the first preCICE-specific minisymposium at an ECCOMAS conference.
+
+## Schedule of the Minisymposium
+
+### Thursday, June 14, 16:30 - 18:30
+
+* **B. Uekermann et al.:** [An introduction to the coupling library preCICE](http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a1557.pdf)
+* **K. Davis et al.:** [Numerical modelling of heart valves using open-source software with preCICE](http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a1285.pdf)
+* **G. Chourdakis et al.:** [Can my OpenFOAM solver easily be coupled with preCICE?](http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a1943.pdf)
+* **T. Reimann et al.:** [Multifield coupling of a fluid-structure-acoustics interaction problem in low-Mach number turbulent flow](http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a1799.pdf)
+* **N. Ebrahimi Pour et al.:** [Error investigation in coupled simulations using discontinuous galerkin method for discretisation](http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a372.pdf)
+* **D. Cinquegrana et al.:** [Fluid Structure Interaction Problems with CIRA Structured CFD solver](http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a1493.pdf)
+* **B. Rüth et al.:** [Time stepping algorithms for partitioned multi-scale multi-physics in preCICE](http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a1640.pdf)


### PR DESCRIPTION
These were the only "official" preCICE minisymposia missing from the list. It is often very useful to find the abstracts of old talks.

Closes #22 and #23.

@IshaanDesai could you please have a quick sanity check?