### PR TITLE
Add documentation on importing submodules

### DIFF
--- a/pages/docs/docs-meta/docs-meta-overview.md
+++ b/pages/docs/docs-meta/docs-meta-overview.md
@@ -133,3 +133,25 @@ As we recently (December 2020) migrated our documentation from multiple sources 
 - Incomplete/imperfect documentation is better than no documentation: try to contribute anything you can and we can always improve it.
 - We use `Sentence case for headings`, not `Title Case for Headings`. The reason is that we find that it is visually clearer, easier to keep it consistent, and we do not need to mix content with style.
 - Descriptive links: avoid forms such as `you can find the documentation [here](target)`, prefer forms such as `see the [documentation](target)`.
+
+## Rendering content from external repositories
+
+While the main content of this website is sourced from the same [repository](https://github.com/precice/precice.github.io) that hosts the mechanics of it, some content is sourced from separate repositories. The main reason is to keep the documentation next to the respective code, so that developers can view it without looking at the website and update it in the same contribution, while users can find everything in the same place. Read more about this concept in the [preCICE v2 reference paper](https://doi.org/10.12688/openreseurope.14445.2). This practice is not yet uniformly adopted, but we are working on migrating more content.
+
+External repositories are included as Git submodules, specified in the [`.gitmodules`](https://github.com/precice/precice.github.io/blob/master/.gitmodules) file. One example is the [tutorias](tutorials), which is covered by [additional documentation for adding new tutorials](https://precice.org/community-contribute-to-precice.html#adding-a-new-tutorial-to-the-website).
+
+To fetch content from an external repository/project (replace the `my-*` with the actual names):
+
+1. Specify the new module: `git submodule add https://github.com/precice/my-project imported/my-project`.
+2. Set the branch to track, if not the default: `git submodule set-branch --default my-branch imported/my-project`. This is particularly useful in case you are adding new documentation via a pull request. However, remember to reset the branch after merging.
+3. The above commands should have modified the `.gitmodules` file and staged changes. Commit the result and push.
+4. Update all submodules with `git submodule update --remote --merge`. If successful, you should see your new project in the `imported/` directory.
+5. In your GitHub pull request to the website, at the "files changed" view, you should see a submodule with a Git reference to your new project in the `imported/` directory.
+
+To render the fetched content on the website:
+
+1. In the file [`_config.yml`](https://github.com/precice/precice.github.io/blob/master/_config.yml), specify the newly imported directory in the list of `subprojects:`.
+2. In the same file, add an entry under the `defaults:` list, associating the subproject with some layout, sidebar, a path for the "Edit me" button, and more features.
+3. Remember to make the new pages discoverable, e.g., by adding them to some [sidebar](https://github.com/precice/precice.github.io/tree/master/_data/sidebars), or linking from another page.
+
+To update the content, push to your repository and then [manually trigger the "update submodules" workflow](https://github.com/precice/precice.github.io/actions/workflows/update-submodules.yml). Alternatively, add a GitHub Actions workflows to your repository, to [update the website automatically](https://github.com/precice/tutorials/blob/master/.github/workflows/update-website.yml).


### PR DESCRIPTION
closes #37 by adding a section at the bottom of the [documentation meta overview page](https://precice.org/docs-meta-overview.html).

@IshaanDesai @LeonardWilleke is this all the information you used in your latest contributions adding the FMI Runner and the Micro Manager? Anything missing?

Preview:

___

![Screenshot from 2023-08-08 19-30-07](https://github.com/precice/precice.github.io/assets/4943683/fd0d1b7b-16f4-45f4-9ebb-a741f8328421)
