### PR TITLE
Add issue form for user stories

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -21,16 +21,16 @@ body:
       label: Your story
       description: In 1-2 paragraphs, describe your project
       placeholder: Motivated by X, we simulate Y. We couple solvers A and B with preCICE, and in particular use features foo and bar. Because of using preCICE, we were able to achieve many great goals.
-  - type: textarea
+  - type: input
     id: url
     attributes:
       label: More info
-      description: Where can one read more? Ideally, a link to some paper / video / website.
+      description: Where can one read more? Ideally, a link to some paper / video / website / post on Discourse.
   - type: checkboxes
     id: image
     attributes:
       label: Image
-      description: Check to upload an image
+      description: Remember to upload an image
       options:
         - label: I will upload an image to be published on the website directly after opening this issue, or send it via email to @MakisH.
           required: true

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -12,7 +12,7 @@ body:
   - type: input
     id: contact
     attributes:
-      label: Contact Details
+      label: Contact details
       description: Where can we contact you? This will be temporarily published in a GitHub issue, but not on the website.
       placeholder: ex. email@example.com
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Your story is very important to us: apart from helping you advertise your work, it helps us argue in funding proposals and other occasions that preCICE is useful.
+        Your story is very important to us: apart from helping you advertise your work, it helps us argue in funding proposals and other occasions that preCICE is useful. And don't worry: it is already good enough, you can always update it later!
   - type: input
     id: contact
     attributes:

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -25,7 +25,8 @@ body:
     id: url
     attributes:
       label: More info
-      description: Where can one read more? Ideally, a link to some paper / video / website / post on Discourse.
+      description: Where can one read more? Ideally, a link to some paper / video / website / post on Discourse. You can always ask to update this later.
+      placeholder: https://example.com/my-project
   - type: checkboxes
     id: image
     attributes:

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -1,0 +1,36 @@
+name: Your story
+description: Tell us your story and get it published on https://precice.org/community-projects.html
+title: "[Sotry]: "
+labels: ["content"]
+assignees:
+  - MakisH
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Your story is very important to us: apart from helping you advertise your work, it helps us argue in funding proposals and other occasions that preCICE is useful.
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: Where can we contact you? This will be temporarily published in a GitHub issue, but not on the website.
+      placeholder: ex. email@example.com
+  - type: textarea
+    id: description
+    attributes:
+      label: Your story
+      description: In 1-2 paragraphs, describe your project
+      placeholder: Motivated by X, we simulate Y. We couple solvers A and B with preCICE, and in particular use features foo and bar. Because of using preCICE, we were able to achieve many great goals.
+  - type: textarea
+    id: url
+    attributes:
+      label: More info
+      description: Where can one read more? Ideally, a link to some paper / video / website.
+  - type: checkboxes
+    id: image
+    attributes:
+      label: Image
+      description: Check to upload an image
+      options:
+        - label: I will upload an image to be published on the website directly after opening this issue, or send it via email to @MakisH.
+          required: true

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -10,16 +10,33 @@ body:
       value: |
         Your story is very important to us: apart from helping you advertise your work, it helps us argue in funding proposals and other occasions that preCICE is useful. And don't worry: it is already good enough, you can always update it later!
   - type: input
+    id: name
+    attributes:
+      label: Your name
+      description: Who is writing this story?
+      placeholder: Doc Brown, PhD
+  - type: input
+    id: affiliation
+    attributes:
+      label: Affiliation
+      description: University of the Universe
+  - type: input
     id: contact
     attributes:
       label: Contact details
       description: Where can we contact you? This will be temporarily published in a GitHub issue, but not on the website.
-      placeholder: ex. email@example.com
+      placeholder: email@example.com
+  - type: input
+    id: title
+    attributes:
+      label: Title
+      description: Ideally related to your application/ your research, not the coupled codes etc.
+      placeholder: My cool project with preCICE
   - type: textarea
     id: description
     attributes:
       label: Your story
-      description: In 1-2 paragraphs, describe your project
+      description: In 1-2 paragraphs, describe your project. Which solvers have you coupled to simulate which application? Why have you used preCICE?
       placeholder: Motivated by X, we simulate Y. We couple solvers A and B with preCICE, and in particular use features foo and bar. Because of using preCICE, we were able to achieve many great goals.
   - type: input
     id: url

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -13,13 +13,13 @@ body:
     id: name
     attributes:
       label: Your name
-      description: Who is writing this story?
+      description: Who is writing this story? You can later link a paper to credit everyone involved.
       placeholder: Doc Brown, PhD
   - type: input
     id: affiliation
     attributes:
       label: Affiliation
-      description: University of the Universe
+      placeholder: University of the Universe
   - type: input
     id: contact
     attributes:
@@ -31,7 +31,7 @@ body:
     attributes:
       label: Title
       description: Ideally related to your application/ your research, not the coupled codes etc.
-      placeholder: My cool project with preCICE
+      placeholder: My amazing preCICE project
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
Closes #283 #134 #33.

Looks approximately like this:

![Screenshot from 2023-08-08 20-15-12](https://github.com/precice/precice.github.io/assets/4943683/5f961de9-7fc9-45b6-b744-6bc916b229b2)

After merging (to understand what form the link will have), I will also update the note on the [community projects page](https://precice.org/community-projects.html).

Unfortunately, issue forms do not support images at the moment, but I assume one could attach them in a follow-up comment. One probably needs a GitHub account anyway, but does not need to know how to open a PR and which files to change.

@uekerman is this all we need for now?