### PR TITLE
Build: Disable fetching Git LFS in submodules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-          lfs: true
+          lfs: false
           path: website
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-          lfs: true
+          lfs: false
           path: website
 
       - name: Fetch - precice develop


### PR DESCRIPTION
Fixes #294 (hopefully).

@fsimonis any particular reason you explicitly enabled this in https://github.com/precice/precice.github.io/pull/117 ? We don't seem to have any LFS objects that are relevant for building the website.