### PR TITLE
Render the system tests docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -239,6 +239,7 @@ subprojects:
   - imported/tutorials/channel-transport
   - imported/tutorials/channel-transport-reaction
   - imported/tutorials/aste-turbine
+  - imported/tutorials/tools/tests
   - imported/openfoam-adapter/docs
   - imported/micro-manager/docs
   - imported/fmi-runner/docs

--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -566,6 +566,10 @@ entries:
     - title: Running and writing tests
       url: /dev-docs-dev-testing.html
       output: web, pdf
+    
+    - title: System tests
+      url: /dev-docs-system-tests.html
+      output: web, pdf
 
     - title: Tooling
       url: /dev-docs-dev-tooling.html


### PR DESCRIPTION
Depends on https://github.com/precice/tutorials/pull/398

Adds a page "Dev docs > System tests" in the Docs sidebar.

See also https://precice.org/docs-meta-overview.html#rendering-content-from-external-repositories