### PR TITLE
Refer to `precice.hpp` instead of `Participant.hpp`

### DIFF
--- a/pages/docs/couple-your-code/couple-your-code-steering-methods.md
+++ b/pages/docs/couple-your-code/couple-your-code-steering-methods.md
@@ -6,7 +6,7 @@ summary: "In this step, you get to know the most important API functions of preC
 ---
 
 
-As a first preparation step, you need to include the preCICE library headers. In C++, you need to include the file [Participant.hpp](https://github.com/precice/precice/blob/develop/src/precice/Participant.hpp).
+As a first preparation step, you need to include the preCICE library headers. In C++, you need to include the file [precice.hpp](https://github.com/precice/precice/blob/develop/src/precice/precice.hpp).
 The handle to the preCICE API is the class `precice::Participant`. Its constructor requires the participant's name, the preCICE configuration file's name and the `rank` and `size` of the current thread. Once the basic preCICE interface is set up, we can _steer_ the behaviour of preCICE. For that we need the following functions:
 
 ```cpp
@@ -31,7 +31,7 @@ double getMaxTimeStepSize();
 But let's ignore the details of time step sizes for the moment. This will be the topic of [Step 5](couple-your-code-time-step-sizes.html). We can now extend the code of our fluid solver:
 
 ```cpp
-#include "precice/Participant.hpp"
+#include <precice/precice.hpp>
 
 turnOnSolver(); //e.g. setup and partition mesh
 

--- a/pages/docs/installation/installation-linking.md
+++ b/pages/docs/installation/installation-linking.md
@@ -121,7 +121,7 @@ Depending on the configuration of `ld` it might look by default into `/usr/local
 
 ### `precice/Version.h` cannot be found
 
-Version 2.5 introduces the `precice/Version.h` header and includes it by default in `Participant.hpp` and `SolverInterfaceC.h`.
+Version 2.5 introduces the `precice/Version.h` header and includes it by default in `precice.hpp` and `SolverInterfaceC.h`.
 This file is generated during the preCICE build and not part of the sources.
 
 If you are using preCICE directly from the build directory without the help of pkg-config nor CMake, then you are likely missing an include-directory.


### PR DESCRIPTION
do we want to make the `Participant.hpp` accessible at all (@fsimonis )? Users should use `precice.hpp`