### PR TITLE
Fix some outdated solver-interface and dimensions

### DIFF
--- a/pages/docs/configuration/configuration-basics.md
+++ b/pages/docs/configuration/configuration-basics.md
@@ -11,13 +11,11 @@ The configuration consists, in general, of the following five parts:
 
 ```xml
 <precice-configuration>
-  <solver-interface dimensions="3">
-   <data .../>
-   <mesh .../>
-   <participant .../>
-   <m2n .../>
-   <coupling-scheme .../>
- </solver-interface>
+  <data .../>
+  <mesh .../>
+  <participant .../>
+  <m2n .../>
+  <coupling-scheme .../>
 </precice-configuration>
 ```
 
@@ -30,10 +28,6 @@ Visualizing the configuration helps a lot in understanding the connections betwe
 {% note %}
 On this page, you also find references to the preCICE API. If you are only using (and not developing) an adapter, don't panic: you can use these references to get a better understanding, but you don't need to change anything in your adapter.
 {% endnote %}
-
-## 0. Dimensions
-
-The value `dimensions` needs to match the physical dimension of your simulation, i.e. the number of coordinates a vertex has in `setMeshVertex`, etc. Some solvers only support 3D simulation, such as OpenFOAM or CalculiX. In this case the adapter maps from 3D to 2D if the preCICE dimension is 2D. This, of course, only works if you simulate a quasi-2D scenario with one layer of cells in z direction.  
 
 ## 1. Coupling data
 
@@ -56,11 +50,13 @@ int temperatureID = precice.getDataID("Temperature", meshID);
 Next, you can define the interface coupling meshes.
 
 ```xml
-<mesh name="MyMesh1"> 
+<mesh name="MyMesh1" dimensions="3"> 
   <use-data name="Temperature"/> 
   <use-data name="Forces"/> 
 </mesh> 
 ```
+
+The value `dimensions` needs to match the physical dimension of your simulation, i.e. the number of coordinates a vertex has in `setMeshVertex`, etc. Some solvers only support 3D simulation, such as OpenFOAM or CalculiX. In this case the adapter maps from 3D to 2D if the preCICE dimension is 2D. This, of course, only works if you simulate a quasi-2D scenario with one layer of cells in z direction.  
 
 With the preCICE API, you get an ID for each mesh:
 

--- a/pages/docs/configuration/configuration-export.md
+++ b/pages/docs/configuration/configuration-export.md
@@ -130,7 +130,7 @@ The following example shows what the header of the CSV file looks like:
 <data:scalar name="Temperature"/>
 <data:vector name="Forces"/>
 
-<mesh name="MyMesh1">
+<mesh name="MyMesh1" dimensions="3">
   <use-data name="Temperature"/>
   <use-data name="Forces"/>
 </mesh>

--- a/pages/docs/configuration/configuration-logging.md
+++ b/pages/docs/configuration/configuration-logging.md
@@ -20,7 +20,6 @@ In principle, to modify the logging, you configure your own logging in the preCI
           filter="%Severity% > debug"  enabled="true" />
     <sink type="file" output="debug.log" filter="" enabled="false" />
   </log>
-  <solver-interface dimensions="3">
 ... 
 ```
 

--- a/pages/docs/configuration/configuration-watchpoint.md
+++ b/pages/docs/configuration/configuration-watchpoint.md
@@ -18,7 +18,7 @@ This will create a logging file `precice-MySolver1-watchpoint-MyWatchPoint.log` 
 
 * Only a participant that provides the respective mesh can set a watchpoint on that mesh.
 * You can freely choose the name `MyWatchPoint`.
-* Please note the format of `coordinate`. Here, values at (x,y)=(0.6,0.2) are tracked. The dimensions need to match the overall preCICE `dimensions` in the `solver-interface` tag, cf. the [configuration overview](Basic-Configuration#0-dimensions).
+* Please note the format of `coordinate`. Here, values at (x,y)=(0.6,0.2) are tracked. The dimensions need to match the overall preCICE `dimensions` in the `mesh` tag of your preCICE configuration.
 * If (0.6, 0.2) is not explicitly a vertex of `MyMesh1`, the nearest neighbor is chosen (resp. nearest projection if mesh connectivity is defined, cf. the [mapping configuration](configuration-mapping.html)).
 * The dimensions of the watchpoint need to match the dimensions of the interface (2D vs. 3D).
 

--- a/pages/docs/couple-your-code/couple-your-code-gradient-data.md
+++ b/pages/docs/couple-your-code/couple-your-code-gradient-data.md
@@ -81,20 +81,17 @@ For the example, you can use the following `precice-config.xml` (note the versio
 ```xml
 <?xml version="1.0"?>
 
-<precice-configuration>
-
-  <solver-interface dimensions="3" experimental="on">
-
+<precice-configuration experimental="on">
     <!-- the gradient flag here is only required vor preCICE version 2.4.0 -->
     <data:vector name="Stress" gradient="on"/>
     <data:vector name="Displacements" />
 
-    <mesh name="FluidMesh">
+    <mesh name="FluidMesh" dimensions="3">
       <use-data name="Stress"/>
       <use-data name="Displacements"/>
     </mesh>
 
-    <mesh name="StructureMesh">
+    <mesh name="StructureMesh" dimensions="3">
       <use-data name="Stress"/>
       <use-data name="Displacements"/>
     </mesh>
@@ -110,6 +107,5 @@ For the example, you can use the following `precice-config.xml` (note the versio
                                 to="FluidMesh" constraint="consistent"/>
     </participant>
     [...]
-  </solver-interface>
 </precice-configuration>
 ```

--- a/pages/docs/couple-your-code/couple-your-code-gradient-data.md
+++ b/pages/docs/couple-your-code/couple-your-code-gradient-data.md
@@ -81,7 +81,7 @@ For the example, you can use the following `precice-config.xml` (note the versio
 ```xml
 <?xml version="1.0"?>
 
-<precice-configuration experimental="on">
+<precice-configuration experimental="true">
     <!-- the gradient flag here is only required vor preCICE version 2.4.0 -->
     <data:vector name="Stress" gradient="on"/>
     <data:vector name="Displacements" />

--- a/pages/docs/couple-your-code/couple-your-code-mesh-and-data-access.md
+++ b/pages/docs/couple-your-code/couple-your-code-mesh-and-data-access.md
@@ -87,18 +87,15 @@ You can use the following `precice-config.xml`:
 <?xml version="1.0"?>
 
 <precice-configuration>
-
-  <solver-interface dimensions="3">
-
     <data:vector name="Forces"/>
     <data:vector name="Displacements"/>
 
-    <mesh name="FluidMesh">
+    <mesh name="FluidMesh" dimensions="3">
       <use-data name="Forces"/>
       <use-data name="Displacements"/>
     </mesh>
 
-    <mesh name="StructureMesh">
+    <mesh name="StructureMesh" dimensions="3">
       <use-data name="Forces"/>
       <use-data name="Displacements"/>
     </mesh>
@@ -129,8 +126,5 @@ You can use the following `precice-config.xml`:
       <exchange data="Forces" mesh="StructureMesh" from="FluidSolver" to="SolidSolver"/>
       <exchange data="Displacements" mesh="StructureMesh" from="SolidSolver" to="FluidSolver"/>
     </coupling-scheme:serial-explicit>
-
-  </solver-interface>
-
 </precice-configuration>
 ```

--- a/pages/docs/couple-your-code/couple-your-code-waveform.md
+++ b/pages/docs/couple-your-code/couple-your-code-waveform.md
@@ -60,7 +60,7 @@ If we choose to use a smaller time step size `dt < preciceDt`, we apply subcycli
 The experimental API has to be activated in the configuration file via the `experimental` attribute. This allows us to define the order of the interpolant in the `read-data` tag of the corresponding `participant`. Currently, we support two interpolation schemes: constant and linear interpolation. The interpolant is always constructed using data from the beginning and the end of the window. The default is constant interpolation (`waveform-order="0"`). The following example uses `waveform-order="1"` and, therefore, linear interpolation:
 
 ```xml
-<solver-interface experimental="true" ... >
+<precice-configuration experimental="true" ... >
 ...
     <participant name="FluidSolver">
         <use-mesh name="FluidMesh" provide="yes"/>
@@ -68,7 +68,7 @@ The experimental API has to be activated in the configuration file via the `expe
         <read-data name="Displacements" mesh="FluidMesh" waveform-order="1"/>
     </participant>
 ...
-</solver-interface>
+</precice-configuration>
 ```
 
 ## Usage example


### PR DESCRIPTION
I hope I have covered everything in the `pages/` directory in terms of:

- Removing `<solver-interface>`
- Moving the `dimensions` from the `solver-interface` to each `mesh`
- Checking that each `mesh` has a `dimensions`