### PR TITLE
Add PKG_CONFIG_PATH setting to libxml2 paths

### DIFF
--- a/pages/docs/installation/installation-source-dependencies.md
+++ b/pages/docs/installation/installation-source-dependencies.md
@@ -197,6 +197,7 @@ Please double check if there are no system packages before attempting to build t
   export LIBRARY_PATH=<prefix>/lib:$LIBRARY_PATH
   export LD_LIBRARY_PATH=<prefix>/lib:$LD_LIBRARY_PATH
   export CPLUS_INCLUDE_PATH=<prefix>/include:$CPLUS_INCLUDE_PATH
+  export PKG_CONFIG_PATH=<prefix>/lib/pkgconfig:$PKG_CONFIG_PATH
   ```
 
 ### PETSc


### PR DESCRIPTION
I encountered this when I had to install libxml2 from source on a cluster. I needed to set the `PKG_CONFIG_PATH` for the CMake recipe to find libxml2.