### PR TITLE
Add missing tutorials in the sidebar and overview

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -230,6 +230,7 @@ subprojects:
   - imported/tutorials/partitioned-heat-conduction
   - imported/tutorials/partitioned-heat-conduction-complex
   - imported/tutorials/partitioned-heat-conduction-direct
+  - imported/tutorials/partitioned-heat-conduction-overlap
   - imported/tutorials/oscillator
   - imported/tutorials/oscillator-overlap
   - imported/tutorials/perpendicular-flap

--- a/_config.yml
+++ b/_config.yml
@@ -240,6 +240,7 @@ subprojects:
   - imported/tutorials/partitioned-backwards-facing-step
   - imported/tutorials/flow-over-heated-plate-partitioned-flow
   - imported/tutorials/volume-coupled-diffusion
+  - imported/tutorials/volume-coupled-flow
   - imported/tutorials/channel-transport
   - imported/tutorials/channel-transport-reaction
   - imported/tutorials/aste-turbine

--- a/_config.yml
+++ b/_config.yml
@@ -231,6 +231,7 @@ subprojects:
   - imported/tutorials/partitioned-heat-conduction-complex
   - imported/tutorials/partitioned-heat-conduction-direct
   - imported/tutorials/oscillator
+  - imported/tutorials/oscillator-overlap
   - imported/tutorials/perpendicular-flap
   - imported/tutorials/turek-hron-fsi3
   - imported/tutorials/partitioned-pipe

--- a/_config.yml
+++ b/_config.yml
@@ -234,6 +234,7 @@ subprojects:
   - imported/tutorials/perpendicular-flap
   - imported/tutorials/turek-hron-fsi3
   - imported/tutorials/partitioned-pipe
+  - imported/tutorials/partitioned-pipe-two-phase
   - imported/tutorials/partitioned-backwards-facing-step
   - imported/tutorials/flow-over-heated-plate-partitioned-flow
   - imported/tutorials/volume-coupled-diffusion

--- a/_config.yml
+++ b/_config.yml
@@ -244,6 +244,7 @@ subprojects:
   - imported/tutorials/channel-transport
   - imported/tutorials/channel-transport-reaction
   - imported/tutorials/aste-turbine
+  - imported/tutorials/two-scale-heat-conduction
   - imported/tutorials/tools/tests
   - imported/openfoam-adapter/docs
   - imported/micro-manager/docs

--- a/_data/sidebars/tutorial_sidebar.yml
+++ b/_data/sidebars/tutorial_sidebar.yml
@@ -121,3 +121,7 @@ entries:
     - title: Channel transport reaction
       url: /tutorials-channel-transport-reaction.html
       output: web
+
+    - title: Two-scale heat conduction
+      url: /tutorials-two-scale-heat-conduction.html
+      output: web

--- a/_data/sidebars/tutorial_sidebar.yml
+++ b/_data/sidebars/tutorial_sidebar.yml
@@ -94,6 +94,10 @@ entries:
       url: /tutorials-oscillator.html
       output: web
 
+    - title: Oscillator overlap
+      url: /tutorials-oscillator-overlap.html
+      output: web
+
     - title: ASTE turbine
       url: /tutorials-aste-turbine.html
       output: web

--- a/_data/sidebars/tutorial_sidebar.yml
+++ b/_data/sidebars/tutorial_sidebar.yml
@@ -70,6 +70,10 @@ entries:
       url: /tutorials-partitioned-heat-conduction-direct.html
       output: web
 
+    - title: Partitioned heat conduction overlap
+      url: /tutorials-partitioned-heat-conduction-overlap.html
+      output: web
+
     - title: Partitioned elastic beam
       url: /tutorials-partitioned-elastic-beam.html
       output: web

--- a/_data/sidebars/tutorial_sidebar.yml
+++ b/_data/sidebars/tutorial_sidebar.yml
@@ -78,6 +78,10 @@ entries:
       url: /tutorials-partitioned-pipe.html
       output: web
 
+    - title: Partitioned pipe two-phase
+      url: /tutorials-partitioned-pipe-two-phase.html
+      output: web
+
     - title: Partitioned flow over a step
       url: /tutorials-partitioned-backwards-facing-step.html
       output: web

--- a/_data/sidebars/tutorial_sidebar.yml
+++ b/_data/sidebars/tutorial_sidebar.yml
@@ -110,6 +110,10 @@ entries:
       url: /tutorials-volume-coupled-diffusion.html
       output: web
 
+    - title: Volume-coupled flow 
+      url: /tutorials-volume-coupled-flow.html
+      output: web
+
     - title: Channel transport
       url: /tutorials-channel-transport.html
       output: web

--- a/pages/tutorials/tutorials.md
+++ b/pages/tutorials/tutorials.md
@@ -46,7 +46,7 @@ In the following cases, you can explore different aspects of preCICE:
 - [Heat exchanger: simplified](tutorials-heat-exchanger-simplified.html): A simplified version of the heat exchanger tutorial. Apart from a simpler geometry, that case is transient and using the implicit multi-coupling scheme, with Dirichlet-Neumann coupling..
 - [Partitioned heat conduction: complex setup](tutorials-partitioned-heat-conduction-complex.html): A partitioned heat conduction case with FEniCS, showcasing advanced features and geometries.
 - [Partitioned heat conduction: direct access](tutorials-partitioned-heat-conduction-direct.html): A partitioned heat conduction case with Nutils, showcasing the direct mesh access feature.
-- [Partitioned heat conduction: direct access](tutorials-partitioned-heat-conduction-direct.html): An overlapping Schwartz method of the partitioned heat conduction case, coupling two Dirichlet participants.
+- [Partitioned heat conduction: overlapping Schwarz](tutorials-partitioned-heat-conduction-overlap.html): An overlapping Schwarz method of the partitioned heat conduction case, coupling two Dirichlet participants.
 - [Partitioned elastic beam](tutorials-partitioned-elastic-beam.html): An experimental structure-structure coupling scenario, with two CalculiX solvers.
 - [Partitioned pipe](tutorials-partitioned-pipe.html): A fluid-fluid coupling scenario, with two OpenFOAM solvers.
 - [Partitioned pipe two-phae](tutorials-partitioned-pipe-two-phase.html): A two-phase variant of the partitioned pipe tutorial.

--- a/pages/tutorials/tutorials.md
+++ b/pages/tutorials/tutorials.md
@@ -52,6 +52,7 @@ In the following cases, you can explore different aspects of preCICE:
 - [Partitioned flow over a backwards-facing step](tutorials-partitioned-backwards-facing-step.html): A fluid-fluid coupling scenario, demonstrating inlet-outlet boundary conditions in OpenFOAM.
 - [Partitioned flow over a heated plate](tutorials-flow-over-heated-plate-partitioned-flow.html): A three-participant case, similar to the flow over a heated plate with OpenFOAM solvers, but with a partitioned channel flow.
 - [Oscillator](tutorials-oscillator.html): A simple mass-spring oscillator with two masses, coupling two instances of a Python solver.
+- [Oscillator overlap](tutorials-oscillator-overlap.html): An overlapping Schwartz method variant of the Oscillator tutorial, coupling two Dirichlet participants.
 - [Volume-coupled diffusion](tutorials-volume-coupled-diffusion.html): An experimental volume coupling scenario, with two FEniCS solvers.
 - [ASTE turbine](tutorials-aste-turbine.html): An example case for ASTE to investigate different preCICE mappings using a turbine geometry.
 - [Channel transport](tutorials-channel-transport.html): A channel flow coupled to a transport (of, e.g., a chemistry species) in a uni-directional way, with Nutils.

--- a/pages/tutorials/tutorials.md
+++ b/pages/tutorials/tutorials.md
@@ -48,6 +48,7 @@ In the following cases, you can explore different aspects of preCICE:
 - [Partitioned heat conduction: direct access](tutorials-partitioned-heat-conduction-direct.html): A partitioned heat conduction case with Nutils, showcasing the direct mesh access feature.
 - [Partitioned elastic beam](tutorials-partitioned-elastic-beam.html): An experimental structure-structure coupling scenario, with two CalculiX solvers.
 - [Partitioned pipe](tutorials-partitioned-pipe.html): A fluid-fluid coupling scenario, with two OpenFOAM solvers.
+- [Partitioned pipe two-phae](tutorials-partitioned-pipe-two-phase.html): A two-phase variant of the partitioned pipe tutorial.
 - [Partitioned flow over a backwards-facing step](tutorials-partitioned-backwards-facing-step.html): A fluid-fluid coupling scenario, demonstrating inlet-outlet boundary conditions in OpenFOAM.
 - [Partitioned flow over a heated plate](tutorials-flow-over-heated-plate-partitioned-flow.html): A three-participant case, similar to the flow over a heated plate with OpenFOAM solvers, but with a partitioned channel flow.
 - [Oscillator](tutorials-oscillator.html): A simple mass-spring oscillator with two masses, coupling two instances of a Python solver.

--- a/pages/tutorials/tutorials.md
+++ b/pages/tutorials/tutorials.md
@@ -59,6 +59,7 @@ In the following cases, you can explore different aspects of preCICE:
 - [ASTE turbine](tutorials-aste-turbine.html): An example case for ASTE to investigate different preCICE mappings using a turbine geometry.
 - [Channel transport](tutorials-channel-transport.html): A channel flow coupled to a transport (of, e.g., a chemistry species) in a uni-directional way, with Nutils.
 - [Channel transport reaction](tutorials-channel-transport-reaction.html): A channel flow coupled to a transport of a chemical species with reaction in a uni-directional way, with FEniCS.
+- [Two-scale heat conduction](tutorials-two-scale-heat-conduction.html): A heat conduction scenario which has an underlying micro-structure.
 
 ## Community projects
 

--- a/pages/tutorials/tutorials.md
+++ b/pages/tutorials/tutorials.md
@@ -46,6 +46,7 @@ In the following cases, you can explore different aspects of preCICE:
 - [Heat exchanger: simplified](tutorials-heat-exchanger-simplified.html): A simplified version of the heat exchanger tutorial. Apart from a simpler geometry, that case is transient and using the implicit multi-coupling scheme, with Dirichlet-Neumann coupling..
 - [Partitioned heat conduction: complex setup](tutorials-partitioned-heat-conduction-complex.html): A partitioned heat conduction case with FEniCS, showcasing advanced features and geometries.
 - [Partitioned heat conduction: direct access](tutorials-partitioned-heat-conduction-direct.html): A partitioned heat conduction case with Nutils, showcasing the direct mesh access feature.
+- [Partitioned heat conduction: direct access](tutorials-partitioned-heat-conduction-direct.html): An overlapping Schwartz method of the partitioned heat conduction case, coupling two Dirichlet participants.
 - [Partitioned elastic beam](tutorials-partitioned-elastic-beam.html): An experimental structure-structure coupling scenario, with two CalculiX solvers.
 - [Partitioned pipe](tutorials-partitioned-pipe.html): A fluid-fluid coupling scenario, with two OpenFOAM solvers.
 - [Partitioned pipe two-phae](tutorials-partitioned-pipe-two-phase.html): A two-phase variant of the partitioned pipe tutorial.

--- a/pages/tutorials/tutorials.md
+++ b/pages/tutorials/tutorials.md
@@ -55,6 +55,7 @@ In the following cases, you can explore different aspects of preCICE:
 - [Oscillator](tutorials-oscillator.html): A simple mass-spring oscillator with two masses, coupling two instances of a Python solver.
 - [Oscillator overlap](tutorials-oscillator-overlap.html): An overlapping Schwartz method variant of the Oscillator tutorial, coupling two Dirichlet participants.
 - [Volume-coupled diffusion](tutorials-volume-coupled-diffusion.html): An experimental volume coupling scenario, with two FEniCS solvers.
+- [Volume-coupled flow](tutorials-volume-coupled-flow.html): An experimental volume coupling scenario, coupling a source term coded in Nutils with a flow in OpenFOAM.
 - [ASTE turbine](tutorials-aste-turbine.html): An example case for ASTE to investigate different preCICE mappings using a turbine geometry.
 - [Channel transport](tutorials-channel-transport.html): A channel flow coupled to a transport (of, e.g., a chemistry species) in a uni-directional way, with Nutils.
 - [Channel transport reaction](tutorials-channel-transport-reaction.html): A channel flow coupled to a transport of a chemical species with reaction in a uni-directional way, with FEniCS.

--- a/pages/tutorials/tutorials.md
+++ b/pages/tutorials/tutorials.md
@@ -59,7 +59,7 @@ In the following cases, you can explore different aspects of preCICE:
 - [ASTE turbine](tutorials-aste-turbine.html): An example case for ASTE to investigate different preCICE mappings using a turbine geometry.
 - [Channel transport](tutorials-channel-transport.html): A channel flow coupled to a transport (of, e.g., a chemistry species) in a uni-directional way, with Nutils.
 - [Channel transport reaction](tutorials-channel-transport-reaction.html): A channel flow coupled to a transport of a chemical species with reaction in a uni-directional way, with FEniCS.
-- [Two-scale heat conduction](tutorials-two-scale-heat-conduction.html): A heat conduction scenario which has an underlying micro-structure.
+- [Two-scale heat conduction](tutorials-two-scale-heat-conduction.html): A heat conduction scenario with an underlying micro-structure which is resolved to get the constitutive properties on the macro scale.
 
 ## Community projects
 


### PR DESCRIPTION
I checked all of our tutorials and added five missing tutorials to the sidebar and the overview page.

I have not checked whether we added new participants in each tutorial (which is mentioned in the overview page).

The website builds and the links work on my machine.

Closes https://github.com/precice/tutorials/issues/453