### PR TITLE
Add page regarding content guidelines

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -595,6 +595,10 @@ entries:
       url: /docs-meta-migration-guide.html
       output: web
 
+    - title: Content guidelines
+      url: /docs-meta-content-guidelines.html
+      output: web
+
     - title: Cheatsheet
       url: /docs-meta-cheatsheet.html
       output: web

--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -591,10 +591,6 @@ entries:
       url: /docs-meta-overview.html
       output: web
 
-    - title: Migration guide
-      url: /docs-meta-migration-guide.html
-      output: web
-
     - title: Content guidelines
       url: /docs-meta-content-guidelines.html
       output: web
@@ -618,4 +614,9 @@ entries:
     - title: Search
       url: /docs-meta-search.html
       output: web
+
+    - title: Migration guide
+      url: /docs-meta-migration-guide.html
+      output: web
+
 

--- a/pages/docs/docs-meta/docs-meta-content-guidelines.md
+++ b/pages/docs/docs-meta/docs-meta-content-guidelines.md
@@ -39,7 +39,9 @@ See full [snippet and meta-description guide from Google](https://developers.goo
 ## Images
 
 - Always specify a textual description using the full Markdown syntax: `![DESCRIPTION](LINK TO IMAGE)`. This is important both for crawlers and for screen readers.
-- Stick to common image formats BMP, GIF, JPEG, PNG, WebP, and SVG
+- For rasterized graphics use PNG or [`WebP`](https://repology.org/project/libwebp/versions). For the latter, convert images using [`img2webp`](https://developers.google.com/speed/webp/docs/img2webp) with `img2webp image.png -o image.webp`.
+- For animations use [`WebP`](https://repology.org/project/libwebp/versions). Convert exisiting GIFs using [`gif2webp`](https://developers.google.com/speed/webp/docs/gif2webp) or create new animations with `ffmpeg -i image%d.png -loop 0 output.webp`.
+- For vectorized graphics use SVG. Make sure text renders correctly outside your browser by using common fonts or converting text to paths. In case of the latter, also add the original SVG to simplify future modifications.
 - Choose a descriptive filename
 
 See full [image best practices from Google](https://developers.google.com/search/docs/appearance/google-images).

--- a/pages/docs/docs-meta/docs-meta-content-guidelines.md
+++ b/pages/docs/docs-meta/docs-meta-content-guidelines.md
@@ -15,6 +15,7 @@ As we recently (December 2020) migrated our documentation from multiple sources 
 - Incomplete/imperfect documentation is better than no documentation: try to contribute anything you can, and we can always improve it.
 - We use `Sentence case for headings`, not `Title Case for Headings`. The reason is that we find that it is visually clearer, easier to keep it consistent, and we do not need to mix content with style.
 - Descriptive links: avoid forms such as `you can find the documentation [here](target)`, prefer forms such as `see the [documentation](target)`.
+- We use American English.
 
 ## Titles
 

--- a/pages/docs/docs-meta/docs-meta-content-guidelines.md
+++ b/pages/docs/docs-meta/docs-meta-content-guidelines.md
@@ -1,7 +1,7 @@
 ---
 title: Content guidelines
 permalink: docs-meta-content-guidelines.html
-keywords: pages, migration, guideline, content, best practises
+keywords: pages, migration, guideline, content, best practices, style guide
 summary: "Learn which style to follow when writing documentation and to choose good titles, content and page summaries."
 ---
 

--- a/pages/docs/docs-meta/docs-meta-content-guidelines.md
+++ b/pages/docs/docs-meta/docs-meta-content-guidelines.md
@@ -1,0 +1,51 @@
+---
+title: Content guidelines
+permalink: docs-meta-content-guidelines.html
+keywords: pages, migration, guideline, content, best practises
+summary: "Learn which style to follow when writing documentation and to choose good titles, content and page summaries."
+---
+
+## Language & style
+
+As we recently (December 2020) migrated our documentation from multiple sources to this website, you may find different styles and inconsistencies among different pages. However, here is what we aim for:
+
+- Target group: scientists & engineers with some but limited experience with programming and with Linux, but extended experience with simulations.
+- Informal style and active voice: imagine you are explaining each concept to a colleague over coffee.
+- Concise, yet complete: short pages are completely fine and even preferred, as long as all the important information is there.
+- Incomplete/imperfect documentation is better than no documentation: try to contribute anything you can, and we can always improve it.
+- We use `Sentence case for headings`, not `Title Case for Headings`. The reason is that we find that it is visually clearer, easier to keep it consistent, and we do not need to mix content with style.
+- Descriptive links: avoid forms such as `you can find the documentation [here](target)`, prefer forms such as `see the [documentation](target)`.
+
+## Titles
+
+- Always specify a `title:`
+- Keep it short, specific, and avoid boilerplate.
+- Avoid duplicate titles.
+- Don't include navigational context such as `preCICE.org |`, `preCICE Documentaion -`. Jekyll does this automatically.
+
+More information on the [title link guide from Google](https://developers.google.com/search/docs/appearance/title-link#page-titles).
+
+## Page summary
+
+- Always specify a `summary:`
+- This text may be chosen as the preview text under a search result.
+- Write a flowing text. Multiple sentences are fine.
+- Summarize the whole page and be specific.
+- Include important information like dates.
+
+See full [snippet and meta-description guide from Google](https://developers.google.com/search/docs/appearance/snippet#meta-descriptions)
+
+## Images
+
+- Always specify a textual description using the full Markdown syntax: `![DESCRIPTION](LINK TO IMAGE)`
+- Stick to common image formats BMP, GIF, JPEG, PNG, WebP, and SVG
+- Choose a descriptive filename
+
+See full [image best practices from Google](https://developers.google.com/search/docs/appearance/google-images).
+
+## General content
+
+- Avoid boilerplate content and get to the point as quickly as possible.
+- If content already exists on another side, prefer linking to it unless you can add some value.
+- Don't copy external content.
+- Follow the guide on [creating helpful, reliable, people-first content by Google](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)

--- a/pages/docs/docs-meta/docs-meta-content-guidelines.md
+++ b/pages/docs/docs-meta/docs-meta-content-guidelines.md
@@ -49,6 +49,5 @@ See full [image best practices from Google](https://developers.google.com/search
 ## General content
 
 - Avoid boilerplate content and get to the point as quickly as possible.
-- If content already exists on another side, prefer linking to it unless you can add some value.
-- Don't copy external content.
+- If content already exists on another side, prefer linking to it. Simplifying, customizing, or summarizing external content is fine. Don't copy chunks of documentation.
 - Follow the guide on [creating helpful, reliable, people-first content by Google](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)

--- a/pages/docs/docs-meta/docs-meta-content-guidelines.md
+++ b/pages/docs/docs-meta/docs-meta-content-guidelines.md
@@ -2,12 +2,12 @@
 title: Content guidelines
 permalink: docs-meta-content-guidelines.html
 keywords: pages, migration, guideline, content, best practices, style guide
-summary: "Learn which style to follow when writing documentation and to choose good titles, content and page summaries."
+summary: "Learn which style to follow when writing documentation and how to write good titles, content, and page summaries."
 ---
 
 ## Language & style
 
-As we recently (December 2020) migrated our documentation from multiple sources to this website, you may find different styles and inconsistencies among different pages. However, here is what we aim for:
+This is the style we aim for, even if not all documentation pages are currently ticking all the boxes (nice opportunity for [contributing](community-contribute-to-precice.html)):
 
 - Target group: scientists & engineers with some but limited experience with programming and with Linux, but extended experience with simulations.
 - Informal style and active voice: imagine you are explaining each concept to a colleague over coffee.
@@ -38,7 +38,7 @@ See full [snippet and meta-description guide from Google](https://developers.goo
 
 ## Images
 
-- Always specify a textual description using the full Markdown syntax: `![DESCRIPTION](LINK TO IMAGE)`
+- Always specify a textual description using the full Markdown syntax: `![DESCRIPTION](LINK TO IMAGE)`. This is important both for crawlers and for screen readers.
 - Stick to common image formats BMP, GIF, JPEG, PNG, WebP, and SVG
 - Choose a descriptive filename
 

--- a/pages/docs/docs-meta/docs-meta-overview.md
+++ b/pages/docs/docs-meta/docs-meta-overview.md
@@ -5,6 +5,10 @@ summary: "This page is an introduction to the development of the preCICE documen
 permalink: docs-meta-overview.html
 ---
 
+## About the content
+
+This majority of this documentation focuses on the technical side of writing content. See [our content guidelines](docs-meta-content-guidelines.html) to learn what the content should look like.
+
 ## About the theme
 
 This site is based on a jekyll theme by technical writer Tom Joht called [documentation-theme-jekyll](https://github.com/tomjoht/documentation-theme-jekyll). At the time of writing this theme was the second most popular documentation-style jekyll theme on [jamstackthemes.dev](https://jamstackthemes.dev/#ssg=jekyll) and has been selected for its rich feature set and clean, functional design out of the box.
@@ -122,17 +126,6 @@ summary: "preCICE needs to be configured at runtime via an `xml` file, typically
 The `permalink` has to be the full file name ending in `.html` with no leading slash `\`. During the build process jekyll processes the frontmatter and places the file at `permalink` value, i.e. in the root directory (by default is `_site`).
 
 The [Migration Guide](docs-meta-migration-guide.html) contains more information on how to migrate preCICE documentation pages from the preCICE Github Wiki.
-
-## Language & style
-
-As we recently (December 2020) migrated our documentation from multiple sources to this website, you may find different styles and inconsistencies among different pages. However, here is what we aim for:
-
-- Target group: scientists & engineers with some but limited experience with programming and with Linux, but extended experience with simulations.
-- Informal style and active voice: imagine you are explaining each concept to a colleague over coffee.
-- Concise, yet complete: short pages are completely fine and even preferred, as long as all the important information is there.
-- Incomplete/imperfect documentation is better than no documentation: try to contribute anything you can and we can always improve it.
-- We use `Sentence case for headings`, not `Title Case for Headings`. The reason is that we find that it is visually clearer, easier to keep it consistent, and we do not need to mix content with style.
-- Descriptive links: avoid forms such as `you can find the documentation [here](target)`, prefer forms such as `see the [documentation](target)`.
 
 ## Rendering content from external repositories
 


### PR DESCRIPTION
This PR adds a separate page in the docs-meta-docs regarding content guidelines.

In addition to the existing language and style, I added a bunch of best practices from the Google search docs.
