### PR TITLE
Add Event schema data for workshop 2024

### DIFF
--- a/pages/community/precice-workshop-2024.md
+++ b/pages/community/precice-workshop-2024.md
@@ -18,7 +18,7 @@ Keep watching this space for updates on registration, the workshop program, and 
       "@context": "https://schema.org",
       "@type": "Event",
       "name": "preCICE Workshop 2024",
-      "description": "The preCICE workshop offers a platform for researchers and industry professionals to exchange insights, experiences, and expertise on leveraging preCICE. It includes an introductory course, user and developer presentations, interactive training sessions, and feedback rounds. Attendees can network with the dynamic community and consult developers on application strategies, use cases, and requirements.",
+      "description": "The preCICE workshop offers a platform for researchers and industry professionals to exchange insights, experiences, and expertise on leveraging preCICE. It includes an introductory course, user and developer presentations, interactive support sessions, and feedback rounds. Attendees can network with the dynamic community and consult developers on application strategies, use cases, and requirements.",
       "image": "https://precice.org/images/events/precice2024.svg",
       "startDate": "2024-09-24",
       "endDate": "2024-09-27",

--- a/pages/community/precice-workshop-2024.md
+++ b/pages/community/precice-workshop-2024.md
@@ -12,3 +12,38 @@ redirect_from: /preCICE2024/
 The 5th preCICE Workshop will be held at the [University of Stuttgart](https://www.uni-stuttgart.de/), together with [SimTech](https://www.simtech.uni-stuttgart.de/), on September 24-27, 2024. The workshop is a coming together of the preCICE community to share ideas, experiences and knowledge about using preCICE, and to learn from others in the process. Like always, we plan to have user and developer talks, hands-on training sessions, discussions with the developers on your applications and use cases, and plenty of opportunities for networking.
 
 Keep watching this space for updates on registration, the workshop program, and more.
+
+<script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Event",
+      "name": "preCICE Workshop 2024",
+      "description": "The preCICE workshop is a coming together of the preCICE community to share ideas, experiences and knowledge about using preCICE. Expect user and developer talks, hands-on training sessions, discussions with the developers on your applications and use cases, feedback rounds, and plenty of opportunities to network with the rest of our vibrant community.",
+      "image": "https://precice.org/images/events/precice2024.svg",
+      "startDate": "2024-09-24",
+      "endDate": "2024-09-27",
+      "eventStatus": "https://schema.org/EventScheduled",
+      "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+      "location": {  
+        "@type": "Place",
+        "name": "University of Stuttgart",
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "",
+          "addressLocality": "Stuttgart",
+          "postalCode": "",
+          "addressCountry": "DE"
+        }
+      },
+      "organizer": {
+        "@type": "Organization",
+        "name": "University of Stuttgart",
+        "url": "https://www.uni-stuttgart.de/"
+      },
+      "funder": {
+        "@type": "Organization",
+        "name": "SimTech",
+        "url": "https://www.simtech.uni-stuttgart.de/"
+      }
+    }
+</script>

--- a/pages/community/precice-workshop-2024.md
+++ b/pages/community/precice-workshop-2024.md
@@ -18,7 +18,7 @@ Keep watching this space for updates on registration, the workshop program, and 
       "@context": "https://schema.org",
       "@type": "Event",
       "name": "preCICE Workshop 2024",
-      "description": "The preCICE workshop is a coming together of the preCICE community to share ideas, experiences and knowledge about using preCICE. Expect user and developer talks, hands-on training sessions, discussions with the developers on your applications and use cases, feedback rounds, and plenty of opportunities to network with the rest of our vibrant community.",
+      "description": "The preCICE workshop offers a platform for researchers and industry professionals to exchange insights, experiences, and expertise on leveraging preCICE. It includes an introductory course, user and developer presentations, interactive training sessions, and feedback rounds. Attendees can network with the dynamic community and consult developers on application strategies, use cases, and requirements.",
       "image": "https://precice.org/images/events/precice2024.svg",
       "startDate": "2024-09-24",
       "endDate": "2024-09-27",


### PR DESCRIPTION
This PR adds [scheme.org Event data](https://schema.org/Event) for the Workshop 2024, which should make the Workshop discoverable by search engines as an Event.

Possible additions:
* `maximumAttendeeCapacity` 
* [`performers`](https://schema.org/performer): maybe interesting for the keynote speaker
* [`offers`](https://schema.org/performer): various tickets at different prices. Maybe too complicated.
