### PR TITLE
Fix static_file duplication in subprojects

### DIFF
--- a/_plugins/subprojects.rb
+++ b/_plugins/subprojects.rb
@@ -1,3 +1,4 @@
+require 'set'
 module Jekyll
   class SubprojectGenerator < Generator
     safe true
@@ -65,15 +66,9 @@ module Jekyll
         end
       end
 
-      # Prevent duplication of refisterred static files
-      site.static_files.delete_if do |static_file|
-        if new_static_files.any? { |sf| sf.relative_path == static_file.relative_path } then 
-          Jekyll.logger.debug("Removing:", "Duplicate static #{static_file.relative_path}")
-          true
-        else 
-          false
-        end
-      end
+      # Reject all existing statics
+      existing_statics =site.static_files.map { |sf| sf.relative_path.delete_prefix('/') }.to_set
+      new_static_files.reject! { |static_file| existing_statics.include?(static_file.relative_path) }
 
       # Register all statics
       site.static_files += new_static_files

--- a/_plugins/subprojects.rb
+++ b/_plugins/subprojects.rb
@@ -17,7 +17,7 @@ module Jekyll
         Jekyll.logger.info("Subproject:", "#{location}")
 
         # Make sure the tutorial directory and README exist
-        if not File.directory?(site.in_source_dir(location)) then
+        unless File.directory?(site.in_source_dir(location))
           message ="No subproject found at #{location}"
           Jekyll.logger.error("Tutorials:", message)
           raise RuntimeError, message
@@ -28,7 +28,7 @@ module Jekyll
           Dir.foreach(".").reject{ |f| File.directory?(f) || f.end_with?(".") }.select{ |f| Utils.has_yaml_header?(site.in_source_dir(File.join(location, f))) }
         end
 
-        if not pages.empty?() then
+        unless pages.empty?()
           Jekyll.logger.info("Adding pages:", pages.join(", "))
           pages.each do |file|
             site.pages << Page.new(site, site.source, location, file)
@@ -38,36 +38,36 @@ module Jekyll
         # Copy all images to images/
         images = File.join(location, 'images')
 
-        if File.directory?(site.in_source_dir(images)) then
-          static_files = Dir.foreach(images).reject{ |f| File.directory?(f) || f.end_with?(".")}
-          static_files.each do |image|
-            from = File.join(images, image)
-            to = File.join(image_dest, image)
-            Jekyll.logger.debug("Registering:", "#{from}")
+        next unless File.directory?(site.in_source_dir(images))
 
-            # Check for 
-            if static_filenames.include?(image)
-              message = "#{image} was already added by subproject #{static_filenames[image]}!"
-              Jekyll.logger.error("Collision detected:", message)
-              raise RuntimeError, message
-            else
-              static_filenames[image] = location
-            end
+        static_files = Dir.foreach(images).reject{ |f| File.directory?(f) || f.end_with?(".")}
+        static_files.each do |image|
+          from = File.join(images, image)
+          to = File.join(image_dest, image)
+          Jekyll.logger.debug("Registering:", "#{from}")
 
-            # Skip the copy if the file already exists. This solves endless rebuild loops.
-            if not File.exist?(site.in_source_dir(to)) then
-              Jekyll.logger.debug("Writing:", "#{to}")
-              FileUtils.cp(site.in_source_dir(from), site.in_source_dir(to))
-            end
-
-            # Save this static file for later
-            new_static_files << StaticFile.new(site, site.source, image_dest, image)
+          # Check for 
+          if static_filenames.include?(image)
+            message = "#{image} was already added by subproject #{static_filenames[image]}!"
+            Jekyll.logger.error("Collision detected:", message)
+            raise message
+          else
+            static_filenames[image] = location
           end
+
+          # Skip the copy if the file already exists. This solves endless rebuild loops.
+          unless File.exist?(site.in_source_dir(to))
+            Jekyll.logger.debug("Writing:", "#{to}")
+            FileUtils.cp(site.in_source_dir(from), site.in_source_dir(to))
+          end
+
+          # Save this static file for later
+          new_static_files << StaticFile.new(site, site.source, image_dest, image)
         end
       end
 
       # Reject all existing statics
-      existing_statics =site.static_files.map { |sf| sf.relative_path.delete_prefix('/') }.to_set
+      existing_statics = site.static_files.map { |sf| sf.relative_path.delete_prefix('/') }.to_set
       new_static_files.reject! { |static_file| existing_statics.include?(static_file.relative_path) }
 
       # Register all statics


### PR DESCRIPTION
This PR corrects the filter which avoids duplicate static_files for static_files in imported folders.
