### PR TITLE
Sort adapters alphabetically in sidebar and oveview

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -284,28 +284,45 @@ entries:
       type: homepage
 
       subfolders:
-      - title: OpenFOAM
+      - title: CalculiX
         output: web, pdf
         subfolderitems:
 
         - title: Overview
-          url: /adapter-openfoam-overview.html
+          url: /adapter-calculix-overview.html
+          output: web, pdf
+
+        - title: Get CalculiX
+          url: /adapter-calculix-get-calculix.html
           output: web, pdf
 
         - title: Get the adapter
-          url: /adapter-openfoam-get.html
+          url: /adapter-calculix-get-adapter.html
+          output: web, pdf
+
+        - title: Build the adapter with PaStiX
+          url: /adapter-calculix-pastix-build.html
           output: web, pdf
 
         - title: Configuration
-          url: /adapter-openfoam-config.html
+          url: /adapter-calculix-config.html
           output: web, pdf
 
-        - title: Extending
-          url: /adapter-openfoam-extend.html
+        - title: Troubleshooting
+          url: /adapter-calculix-troubleshooting.html
           output: web, pdf
 
-        - title: OpenFOAM support
-          url: /adapter-openfoam-support.html
+        - title: Building on SuperMUC
+          url: /adapter-calculix-supermuc.html
+          output: web, pdf
+
+      - title: code_aster
+        url: /adapter-code_aster.html
+        output: web, pdf
+        subfolderitems:
+
+        - title: Overview
+          url: /adapter-code_aster.html
           output: web, pdf
 
       - title: deal.II
@@ -340,52 +357,28 @@ entries:
           url: /adapter-dealii-coupling-meshes.html
           output: web, pdf
 
-      - title: CalculiX
+      - title: DuMuX
         output: web, pdf
         subfolderitems:
 
         - title: Overview
-          url: /adapter-calculix-overview.html
-          output: web, pdf
-
-        - title: Get CalculiX
-          url: /adapter-calculix-get-calculix.html
+          url: /adapter-dumux.html 
           output: web, pdf
 
         - title: Get the adapter
-          url: /adapter-calculix-get-adapter.html
+          url: /adapter-dumux-get.html 
           output: web, pdf
 
-        - title: Build the adapter with PaStiX
-          url: /adapter-calculix-pastix-build.html
+        - title: Use the adapter
+          url: /adapter-dumux-use.html 
           output: web, pdf
 
-        - title: Configuration
-          url: /adapter-calculix-config.html
-          output: web, pdf
-
-        - title: Troubleshooting
-          url: /adapter-calculix-troubleshooting.html
-          output: web, pdf
-
-        - title: Building on SuperMUC
-          url: /adapter-calculix-supermuc.html
-          output: web, pdf
-
-      - title: SU2
+      - title: DUNE
         output: web, pdf
         subfolderitems:
 
         - title: Overview
-          url: /adapter-su2-overview.html
-          output: web, pdf
-
-        - title: Get the adapter
-          url: /adapter-su2-get.html
-          output: web, pdf
-
-        - title: Configuration
-          url: /adapter-su2-configure.html
+          url: /adapter-dune.html
           output: web, pdf
 
       - title: FEniCS
@@ -404,37 +397,44 @@ entries:
           url: /adapter-nutils.html
           output: web, pdf
 
-      - title: DUNE
+      - title: OpenFOAM
         output: web, pdf
         subfolderitems:
 
         - title: Overview
-          url: /adapter-dune.html
-          output: web, pdf
-
-      - title: DuMuX
-        output: web, pdf
-        subfolderitems:
-
-        - title: Overview
-          url: /adapter-dumux.html 
+          url: /adapter-openfoam-overview.html
           output: web, pdf
 
         - title: Get the adapter
-          url: /adapter-dumux-get.html 
+          url: /adapter-openfoam-get.html
           output: web, pdf
 
-        - title: Use the adapter
-          url: /adapter-dumux-use.html 
+        - title: Configuration
+          url: /adapter-openfoam-config.html
           output: web, pdf
 
-      - title: code_aster
-        url: /adapter-code_aster.html
+        - title: Extending
+          url: /adapter-openfoam-extend.html
+          output: web, pdf
+
+        - title: OpenFOAM support
+          url: /adapter-openfoam-support.html
+          output: web, pdf
+
+      - title: SU2
         output: web, pdf
         subfolderitems:
 
         - title: Overview
-          url: /adapter-code_aster.html
+          url: /adapter-su2-overview.html
+          output: web, pdf
+
+        - title: Get the adapter
+          url: /adapter-su2-get.html
+          output: web, pdf
+
+        - title: Configuration
+          url: /adapter-su2-configure.html
           output: web, pdf
 
   - title: Couple your code

--- a/pages/docs/adapters/adapter-overview.md
+++ b/pages/docs/adapters/adapter-overview.md
@@ -15,12 +15,12 @@ We host adapters for the following codes in the [preCICE GitHub organization](ht
 | [CalculiX](http://www.calculix.de/) | preCICE Developers | [code](https://github.com/precice/calculix-adapter), [docs](adapter-calculix-overview.html) | Structure part in CHT, FSI | |
 | [code_aster](https://code-aster.org/) | preCICE Developers | [code](https://github.com/precice/code_aster-adapter), [docs](adapter-code_aster.html) | Structure part in CHT | |
 | [deal.II](https://www.dealii.org/) | preCICE Developers | [code](https://github.com/precice/dealii-adapter), [docs](adapter-dealii-overview.html) | Structure part in FSI, any FEM | |
+| [DuMuX](https://dumux.org/) | preCICE Developers | [code](https://github.com/precice/dumux-adapter), [docs](adapter-dumux.html) | Darcy-scale in mutliscale, porous media | |
+| [DUNE](https://www.dune-project.org/) | preCICE Developers | [code](https://github.com/precice/dune-adapter), [docs](adapter-dune.html) | Structure part in FSI | |
 | [FEniCS](https://fenicsproject.org/) | preCICE Developers | [code](https://github.com/precice/fenics-adapter), [docs](adapter-fenics.html) | Structure part in CHT, FSI, any FEM | See also [FEniCS-X](https://github.com/precice/fenicsx-adapter) below (WIP) |
 | [Nutils](http://www.nutils.org/) | preCICE Developers | [docs](adapter-nutils.html) | Structure part in CHT, any FEM | |
 | [OpenFOAM](https://www.openfoam.com/) | preCICE Developers | [code](https://github.com/precice/openfoam-adapter), [docs](adapter-openfoam-overview.html) | Fluid part in CHT, FSI, FF | |
 | [SU2](https://su2code.github.io/) | preCICE Developers | [code](https://github.com/precice/su2-adapter), [docs](adapter-su2-overview.html) | Fluid part in FSI | [Maintainer needed](https://github.com/precice/su2-adapter/issues/16) |
-| [DuMuX](https://dumux.org/) | preCICE Developers | [code](https://github.com/precice/dumux-adapter), [docs](adapter-dumux.html) | Darcy-scale in mutliscale, porous media | |
-| [DUNE](https://www.dune-project.org/) | preCICE Developers | [code](https://github.com/precice/dune-adapter), [docs](adapter-dune.html) | Structure part in FSI | |
 
 ## Third-party adapters
 


### PR DESCRIPTION
Since we now have too many.

Everything now needs to be a folder, as folders come before single entries. But it is fine if folders have only one entry. Annoying to click twice for some adapters, but now it is consistent for all.

![image](https://github.com/precice/precice.github.io/assets/4943683/0001a60c-49a6-4d46-bc14-ad3aafdca002)
