### PR TITLE
Add link-only property to folderitems

### DIFF
--- a/_data/sidebars/tutorial_sidebar.yml
+++ b/_data/sidebars/tutorial_sidebar.yml
@@ -25,14 +25,17 @@ entries:
     - title: Flow over heated plate
       url: /tutorials-flow-over-heated-plate.html
       output: web
+      link-only: true
 
     - title: Partitioned heat conduction
       url: /tutorials-partitioned-heat-conduction.html
       output: web
+      link-only: true
 
     - title: Perpendicular flap
       url: /tutorials-perpendicular-flap.html
       output: web
+      link-only: true
 
   - title: All tutorials
     output: web

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -26,7 +26,7 @@
       {% if folderitem.external_url %}
       <li><a title="{{folderitem.title}}" href="{{folderitem.external_url}}" target="_blank" rel="noopener">{{folderitem.title}}</a></li>
       {% elsif page.url == folderitem.url %}
-      <li class="active"><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+      <li {% if folderitem.link-only == nil or folderitem.link-only == false %} class="active" {% endif %} ><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
       {% elsif folderitem.type == "empty" %}
       <li><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
 


### PR DESCRIPTION
This PR adds the link-only folderitem property.

If a folderitem is only considered active if it doesn't have this property or if it is false.

This means that the "Basic Tutorials" now "forward" to the tutorial in the "All tutorials" section.

Solves #376
