### PR TITLE
Update Roadmap

### DIFF
--- a/pages/docs/fundamentals/fundamentals-roadmap.md
+++ b/pages/docs/fundamentals/fundamentals-roadmap.md
@@ -14,21 +14,14 @@ If you are looking for features introduced already in the past, have a look at o
 
 ## In active development
 
-- [Waveform relaxation for multi-rate coupling and higher-order time stepping](https://github.com/precice/precice/projects/7)
-- [Partition-of-Unity RBF data mapping for very large problems](https://github.com/precice/precice/issues/1273)
-- [GPU support for data mapping methods](https://github.com/precice/precice/issues/1484)
-- [Coupling with Functional Mock-Up Units](https://github.com/precice/fmi-runner)
 - [Adaptive and flexible macro-micro coupling software](https://github.com/precice/micro-manager)
 - [Solver-based data mapping](couple-your-code-direct-access.html) to take advantage of higher-order shape functions
 - [Non-mesh-related global data exchange](couple-your-code-global-data.html)
 - [Dynamic coupling meshes](https://github.com/precice/precice/projects/2)
-- [Cell-based linear interpolation for volumetric coupling](https://github.com/precice/precice/issues/468)
 - [Improving](https://github.com/precice/precice/issues/1252) the experimental [Nearest-neighbor gradient data mapping](https://github.com/precice/precice/pull/1169)
 - [More robust and efficient quasi-Newton acceleration](https://github.com/precice/precice/pull/1152)
 - [Geometric multi-scale data mapping](https://github.com/orgs/precice/projects/14), e.g. for 3D-1D and 3D-2D coupled problems
 - [Extendable and modular system tests](https://github.com/orgs/precice/projects/12)
-- [More tutorial testcases for and better support of fluid-fluid coupling, including backflow](https://github.com/precice/tutorials/pull/326)
-- [Volume coupling for OpenFOAM](https://github.com/orgs/precice/projects/9)
 
 ## On our list
 

--- a/pages/docs/fundamentals/fundamentals-roadmap.md
+++ b/pages/docs/fundamentals/fundamentals-roadmap.md
@@ -22,6 +22,7 @@ If you are looking for features introduced already in the past, have a look at o
 - [More robust and efficient quasi-Newton acceleration](https://github.com/precice/precice/pull/1152)
 - [Geometric multi-scale data mapping](https://github.com/orgs/precice/projects/14), e.g. for 3D-1D and 3D-2D coupled problems
 - [Extendable and modular system tests](https://github.com/orgs/precice/projects/12)
+- [Standardization and tooling for the preCICE ecosystem](https://github.com/orgs/precice/projects/15)
 
 ## On our list
 


### PR DESCRIPTION
At the moment, the Roadmap looks a bit outdated, since many features shipped in v3.

As a first step, I have removed some of these features, keeping those that I understand we are still actively working on. @uekerman anything else to remove or now already add?

Does not need to be thorough, but let's not have something that looks immediately outdated.

- [x] Remove completed entries from Roadmap
- [ ] Add new points