### PR TITLE
Document running participants in different systems

### DIFF
--- a/pages/docs/configuration/configuration-communication.md
+++ b/pages/docs/configuration/configuration-communication.md
@@ -66,3 +66,31 @@ If you build preCICE without MPI (and **only** in this case) you might also need
 ...
 </participant>
 ```
+
+## Running participants in different systems
+
+One advantage of communicating via TCP/IP sockets is that participants can be executed in different systems, even connected via the internet. This feature [has been demonstrated in the literature](https://doi.org/10.1007/978-3-031-40843-4_42) and has a few use cases, such as:
+
+- Coupling participants with licenses restricting them to a specific system
+- Coupling participants running on a cluster with GUI-based participants running locally, while exchanging only interface data
+
+You can achieve this by configuring an `m2n:sockets` communication interface with an explicitly-defined port, which you can then forward via your SSH connection. Since you only open one port, you need to select `enforce-gather-scatter`, so that only one rank of each participant communicates. For example:
+
+```xml
+<m2n:sockets port="12345" network="lo" from="RemoteParticipant" to="LocalParticipant" exchange-directory=".." enforce-gather-scatter="1"/>
+```
+
+We assume here the scenario of connecting a local laptop/workstation to a cluster, via a login node. First, connect via SSH to the login node of your cluster, forwarding connections to the local (`-L`) port 12345 to the remote port 12345 (of the login node):
+
+```shell
+ssh -L 12345:0.0.0.0:12345 user@login01.mycluster.edu
+```
+
+Then, in your job script, make the compute nodes forward any connections to remote (`-R`) port `12345` of the login node to the local port `12345` of the compute node (`-N`: without executing any commands)
+
+```shell
+ssh -R 12345:0.0.0.0:12345 login01 -N
+```
+
+The exchange directory also needs to be accessible by both participants, so that they can both access the `precice-run/` directory, which stores the addresses to find each other.
+

--- a/pages/docs/configuration/configuration-communication.md
+++ b/pages/docs/configuration/configuration-communication.md
@@ -93,4 +93,3 @@ ssh -R 12345:0.0.0.0:12345 login01 -N
 ```
 
 The exchange directory also needs to be accessible by both participants, so that they can both access the `precice-run/` directory, which stores the addresses to find each other.
-

--- a/pages/docs/configuration/configuration-communication.md
+++ b/pages/docs/configuration/configuration-communication.md
@@ -77,7 +77,7 @@ One advantage of communicating via TCP/IP sockets is that participants can be ex
 You can achieve this by configuring an `m2n:sockets` communication interface with an explicitly-defined port, which you can then forward via your SSH connection. Since you only open one port, you need to select `enforce-gather-scatter`, so that only one rank of each participant communicates. For example:
 
 ```xml
-<m2n:sockets port="12345" network="lo" from="RemoteParticipant" to="LocalParticipant" exchange-directory=".." enforce-gather-scatter="1"/>
+<m2n:sockets port="12345" network="lo" acceptor="RemoteParticipant" connector="LocalParticipant" exchange-directory=".." enforce-gather-scatter="1"/>
 ```
 
 We assume here the scenario of connecting a local laptop/workstation to a cluster, via a login node. First, connect via SSH to the login node of your cluster, forwarding connections to the local (`-L`) port 12345 to the remote port 12345 (of the login node):

--- a/pages/docs/configuration/configuration-communication.md
+++ b/pages/docs/configuration/configuration-communication.md
@@ -38,6 +38,16 @@ $ ip link
     link/ether 52:54:00:e0:03:62 brd ff:ff:ff:ff:ff:ff
 ```
 
+You can also specify a specific port that you want to use for the communication.
+In that case, it is also important to use a gather-scatter step, so that all communication
+goes via that one port:
+
+```xml
+<m2n:sockets port="12345" acceptor="MySolver1" connector="MySolver2" exchange-directory=".." enforce-gather-scatter="1"/>
+```
+
+This allows interesting use cases, such as [coupling participants running on different systems](running-distributed.html).
+
 The alternative to TCP/IP sockets is MPI ports (an MPI 2.0 feature):
 
 ```xml
@@ -66,30 +76,3 @@ If you build preCICE without MPI (and **only** in this case) you might also need
 ...
 </participant>
 ```
-
-## Running participants in different systems
-
-One advantage of communicating via TCP/IP sockets is that participants can be executed in different systems, even connected via the internet. This feature [has been demonstrated in the literature](https://doi.org/10.1007/978-3-031-40843-4_42) and has a few use cases, such as:
-
-- Coupling participants with licenses restricting them to a specific system
-- Coupling participants running on a cluster with GUI-based participants running locally, while exchanging only interface data
-
-You can achieve this by configuring an `m2n:sockets` communication interface with an explicitly-defined port, which you can then forward via your SSH connection. Since you only open one port, you need to select `enforce-gather-scatter`, so that only one rank of each participant communicates. For example:
-
-```xml
-<m2n:sockets port="12345" network="lo" acceptor="RemoteParticipant" connector="LocalParticipant" exchange-directory=".." enforce-gather-scatter="1"/>
-```
-
-We assume here the scenario of connecting a local laptop/workstation to a cluster, via a login node. First, connect via SSH to the login node of your cluster, forwarding connections to the local (`-L`) port 12345 to the remote port 12345 (of the login node):
-
-```shell
-ssh -L 12345:0.0.0.0:12345 user@login01.mycluster.edu
-```
-
-Then, in your job script, make the compute nodes forward any connections to remote (`-R`) port `12345` of the login node to the local port `12345` of the compute node (`-N`: without executing any commands)
-
-```shell
-ssh -R 12345:0.0.0.0:12345 login01 -N
-```
-
-The exchange directory also needs to be accessible by both participants, so that they can both access the `precice-run/` directory, which stores the addresses to find each other.

--- a/pages/docs/running/running-distributed.md
+++ b/pages/docs/running/running-distributed.md
@@ -51,6 +51,7 @@ One advantage of communicating via TCP/IP sockets is that participants can be ex
 
 - Coupling participants with licenses restricting them to a specific system
 - Coupling participants running on a cluster with GUI-based participants running locally, while exchanging only interface data
+- Coupling participants running on containers or virtual machines (see [related discussion](https://precice.discourse.group/t/how-to-configure-precice-communication-on-kubernetes-with-tcp-port-access-control/1451))
 
 You can achieve this by configuring an `m2n:sockets` communication interface with an explicitly-defined port, which you can then forward via your SSH connection. Since you only open one port, you need to select `enforce-gather-scatter`, so that only one rank of each participant communicates. For example:
 

--- a/pages/docs/running/running-distributed.md
+++ b/pages/docs/running/running-distributed.md
@@ -44,3 +44,30 @@ If you have logged into remote machine via SSH, then be careful to use a tool su
 This allows to safely detach from a session without the running process getting killed.
 
 If your cluster is managed using SLURM, then [further steps may be necessary](running-slurm).
+
+## Running participants in different systems
+
+One advantage of communicating via TCP/IP sockets is that participants can be executed in different systems, even connected via the internet. This feature [has been demonstrated in the literature](https://doi.org/10.1007/978-3-031-40843-4_42) and has a few use cases, such as:
+
+- Coupling participants with licenses restricting them to a specific system
+- Coupling participants running on a cluster with GUI-based participants running locally, while exchanging only interface data
+
+You can achieve this by configuring an `m2n:sockets` communication interface with an explicitly-defined port, which you can then forward via your SSH connection. Since you only open one port, you need to select `enforce-gather-scatter`, so that only one rank of each participant communicates. For example:
+
+```xml
+<m2n:sockets port="12345" network="lo" acceptor="RemoteParticipant" connector="LocalParticipant" exchange-directory=".." enforce-gather-scatter="1"/>
+```
+
+We assume here the scenario of connecting a local laptop/workstation to a cluster, via a login node. First, connect via SSH to the login node of your cluster, forwarding connections to the local (`-L`) port 12345 to the remote port 12345 (of the login node):
+
+```shell
+ssh -L 12345:0.0.0.0:12345 user@login01.mycluster.edu
+```
+
+Then, in your job script, make the compute nodes forward any connections to remote (`-R`) port `12345` of the login node to the local port `12345` of the compute node (`-N`: without executing any commands)
+
+```shell
+ssh -R 12345:0.0.0.0:12345 login01 -N
+```
+
+The exchange directory also needs to be accessible by both participants, so that they can both access the `precice-run/` directory, which stores the addresses to find each other.


### PR DESCRIPTION
@LouieVoit published a [very interesting paper](https://doi.org/10.1007/978-3-031-40843-4_42), using preCICE to couple a CFD solver running on a laptop (_"while waiting at the airport and connected to a poor wi-fi"_) to a massively-parallel MD simulation running on a cluster.

The paper is helpful to demonstrate the concept, but lacks some technical details. I got these from Louis via e-mail and I am summarizing them in this documentation addition at the bottom of the [communication configuration](https://precice.org/configuration-communication.html) page.

Note that this is not the first user that has asked for something like this. In the context of the helicopter simulations Master's thesis I supervised, we had a very similar issue, where each code was licensed for a different system.

- @LouieVoit Have I forgotten any details?
- @fsimonis Does this make sense, especially regarding `gather-scatter`?
- @davidscn Do you maybe want to test this? Could be very easy for you, since you daily work on a cluster.

