### PR TITLE
Add a License Information page

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -32,6 +32,10 @@ entries:
       url: /fundamentals-terminology.html
       output: web, pdf
 
+    - title: License information
+      url: /fundamentals-license.html
+      output: web, pdf
+
     - title: Literature guide
       url: /fundamentals-literature-guide.html
       output: web, pdf

--- a/pages/docs/fundamentals/fundamentals-license.md
+++ b/pages/docs/fundamentals/fundamentals-license.md
@@ -1,0 +1,52 @@
+---
+title: License information
+permalink: fundamentals-license.html
+keywords: license, LGPLv3, CC-BY
+summary: preCICE is free/open-source software, without imposing any license restrictions on the software you couple.
+---
+
+The coupling library preCICE is part of the preCICE ecosystem. While every preCICE user uses the core library,
+users often use further components of the ecosystem, such as language bindings, adapters, and tutorial simulation setups.
+Let's look into some details.
+
+## preCICE is free/open-source software
+
+We are a [team of researchers in academia](about.html) and we are funded by various public funding resources (Germany/EU). This funding is rarely specific to software development, so what you see here is mostly an outcome of our research, plus a lot of additional effort from the maintainers and the community (people like you).
+
+Everything we develop is not only available with standard [open-source licenses](https://choosealicense.com/licenses/), but also developed in the open from the start on [GitHub](https://github.com/precice/). We develop methods in our research, which we implement in preCICE, and we want the community to be able to use our research outcomes.
+
+For us, open-source does not mean lower quality standards: quite the opposite.
+Our small team dedicates significant efforts on keeping everything tested, easy to use, and with high software quality standards.
+This time investment is often not justified in the short term by the specific funding programs.
+To raise some additional money to be able to partially fund positions to work specifically on software development (currently not the case), and to make the preCICE team a reliable partner, we offer [training](community-training.html) and [support](community-support-precice.html), with discounts for users in academia.
+
+Since preCICE is academic software, we expect research relying on our work to [cite preCICE](fundamentals-literature-guide.html). We do the same with all software projects we use in our publications. We also welcome [code contributions](community-contribute-to-precice.html).
+
+## Licenses
+
+### Core library and language bindings
+
+The coupling library itself is distributed under the [GNU LGPLv3](https://www.gnu.org/licenses/lgpl-3.0.en.html) license.
+This should not be confused with the more restrictive GNU GPLv3 license.
+The main difference is that you can link to preCICE from a proprietary code: the license restrictions of preCICE do not propagate to other codes.
+
+The same holds for all language bindings.
+
+### Adapters
+
+The preCICE adapters are code examples or stand-alone software packages demonstrating or falicitating coupling existing simulation codes.
+In principle, our adapters inherit the license of the code we are writing the adapters for.
+
+Note that you do not need to use specific simulation codes or adapters to use preCICE. You can always just [couple your code](couple-your-code-overview.html) using preCICE itself.
+
+### Tutorials
+
+The preCICE tutorials are example simulation setups, which sometimes include code. All tutorials are available under the same LGPLv3 license as the core library.
+
+### Documentation
+
+The preCICE documentation (as seen on this website), is available under the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/). This means you can copy parts of the documentation into your own work, but you need to attribute it to the preCICE developers (including `precice.org`).
+
+## Legal questions
+
+For all legal questions, see our [contact details](about.html#impressum).

--- a/pages/docs/fundamentals/fundamentals-overview.md
+++ b/pages/docs/fundamentals/fundamentals-overview.md
@@ -16,7 +16,7 @@ Coupling your own solver is very easy, due to the minimally-invasive approach of
 Once you add the (very few) calls to the preCICE library in your code, you can couple
 it with any other code at runtime. For well-known solvers such as OpenFOAM, deal.II, FEniCS, Nutils, CalculiX, or SU2, you can use one of our official adapters.
 
-preCICE is free/open-source software, using the [GNU LGPL3 license](https://www.gnu.org/licenses/lgpl-3.0.en.html). This license ensures the open future of the project, while allowing you to use the library also in closed-source solvers. The code is publicly available and actively developed on [GitHub](https://github.com/precice/precice).
+preCICE is free/open-source software, using the [GNU LGPL3 license](https://www.gnu.org/licenses/lgpl-3.0.en.html). This license ensures the open future of the project, while allowing you to use the library also in closed-source solvers. The code is publicly available and actively developed on [GitHub](https://github.com/precice). See more [license information](fundamentals-license.html).
 
 ![Big-picture overview of preCICE](material/overview/precice-overview.png)
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -271,7 +271,7 @@ layout: landing_page
 
     <div class="row">
       <div class="col-md-6">
-        <p>preCICE has been developed by three generations of doctoral candidates from the <a href="https://www.in.tum.de/i05">Chair of Scientific Computing</a> at the <strong>Technical University of Munich</strong> and from the <a href="https://www.ipvs.uni-stuttgart.de/">Institute for Parallel and Distributed Systems</a> at the <strong>University of Stuttgart</strong>. We develop everything openly on GitHub, the preCICE library is licensed under LGPLv3, and every other component is developed under compatible free software licenses.</p>
+        <p>preCICE has been developed by three generations of doctoral candidates from the <a href="https://www.in.tum.de/i05">Chair of Scientific Computing</a> at the <strong>Technical University of Munich</strong> and from the <a href="https://www.ipvs.uni-stuttgart.de/">Institute for Parallel and Distributed Systems</a> at the <strong>University of Stuttgart</strong>. We develop everything openly on GitHub, the preCICE library is licensed under LGPLv3, and every other component is developed under compatible free software licenses. <a href="fundamentals-license.html">More information.</a></p>
         <p>You can <strong>cite the preCICE library</strong> using the following paper. Please also consider citing the adapters you use, as well as the <a href="installation-distribution.html">preCICE Distribution</a> for <strong>reproducibility</strong>. You can find the respective references in our <a href="fundamentals-literature-guide.html">literature guide</a>.</p>
       </div>
       <div class="col-md-6 equal vertical-align">
@@ -296,7 +296,7 @@ layout: landing_page
       <div class="col-md-3 col-md-offset-1 col-sm-3 col-sm-offset-0 hidden-xs text-center">
         <a class="book-container no-icon" href="https://doi.org/10.12688/openreseurope.14445.2" target="_blank" rel="noreferrer noopener">
           <div class="book center-block">
-            <img class="no-margin" alt="preCICE reference paper" src="images/paper-v2-new-thumbnail.jpg" title="preCICE v2: A sustainable and user-friendly coupling library">
+            <img class="no-margin" alt="preCICE reference paper" src="images/paper-v2-thumbnail.jpg" title="preCICE v2: A sustainable and user-friendly coupling library">
           </div>
         </a>
       </div>


### PR DESCRIPTION
Mainly serving as one page to link to for such questions, e.g., from the footer (dependency of #406).

While this information already exists in bits on the landing page and on the docs overview, this page allows us to explain a bit more the restrictions, expectations, and the business model.

@uekerman what do you think?

![Screenshot 2024-05-13 at 14-37-02 License information preCICE - The Coupling Library](https://github.com/precice/precice.github.io/assets/4943683/acf6c0f1-d757-4fb9-b14b-29c8dbc88a21)
