### PR TITLE
Add imported to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _pdf
 .idea
 vendor/
 .bundle/
+imported/


### PR DESCRIPTION
Hey, is there a reason why imported is not in .gitignore? It keeps messing with my PRs.