### PR TITLE
Add Micro Manager snapshot docs to sidebar

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -269,6 +269,10 @@ entries:
         - title: Running
           url: /tooling-micro-manager-running.html
           output: web, pdf
+
+        - title: Snapshot Computation
+          url: /tooling-micro-manager-snapshot-configuration.html
+          output: web, pdf
     
     - title: Performance analysis
       url: /tooling-performance-analysis.html


### PR DESCRIPTION
Add the page for the snapshot computation in the Micro Manager to the sidebar.