### PR TITLE
Restore comments in news_banner.html (and disable banner)

### DIFF
--- a/_includes/news_banner.html
+++ b/_includes/news_banner.html
@@ -1,7 +1,14 @@
-{% if include.onlanding %}
-{% else %}
-{% endif %}
+{% comment %}{% raw %}
 
+For landing-only news use:
+{% if include.onlanding %}
+
+For news visible on all pages use:
+{% if true %}.
+
+{% endraw %}{% endcomment %}
+
+{% if false %}
 <div class="background-light banner-container">
   <div class="container">
     <div class="row no-margin">
@@ -13,3 +20,5 @@
     </div>
   </div>
 </div>
+{% else %}
+{% endif %}


### PR DESCRIPTION
These comments were moved to the [README.md](https://github.com/precice/precice.github.io/blob/master/README.md) in https://github.com/precice/precice.github.io/commit/d68cf8afc84bbb71f050a564d73a076fe056f395, but I think they are useful in the file as well, for quick access.

Even if we end up disagreeing about this, we need at least a link to the README from the file itself (and potentially move the whole thing into https://precice.org/docs-meta-overview.html or a subpage).

Also disables the banner of the workshop registration, per @IshaanDesai's request.