### PR TITLE
Add ECCOMAS Coupled 2025 in events

### DIFF
--- a/_data/sidebars/community_sidebar.yaml
+++ b/_data/sidebars/community_sidebar.yaml
@@ -11,6 +11,10 @@ entries:
     url: /community.html
     output: web
 
+  - title: Coupled Problems 2025
+    url: /eccomas-coupled-2025.html
+    output: web
+
   - title: preCICE Workshop 2024
     url: /precice-workshop-2024.html
     output: web

--- a/pages/community/eccomas-coupled-2025.md
+++ b/pages/community/eccomas-coupled-2025.md
@@ -10,7 +10,7 @@ The [ECCOMAS Coupled Problems 2025](https://coupled2025.cimne.com/) will take pl
 
 We are again organizing a preCICE minisymposium: [Multi-Physics and Multi-Scale Simulations with the Coupling Library preCICE](https://coupled2025.cimne.com/event/area/3dec3ef1-70ff-11ef-bbc6-000c29ddfc0c) (IS042).
 
-Feel free to ask questions in the [corresponding thread of the forum](TODO) (link pending).
+Feel free to ask questions in the [corresponding thread of the forum](https://precice.discourse.group/t/call-for-contributions-eccomas-coupled-problems-2025/2197).
 
 ## Schedule of the Minisymposium
 

--- a/pages/community/eccomas-coupled-2025.md
+++ b/pages/community/eccomas-coupled-2025.md
@@ -1,0 +1,21 @@
+---
+title: ECCOMAS Coupled Problems 2025
+keywords: 2025, ECCOMAS, COUPLED, event, events, minisymposium
+summary:
+permalink: eccomas-coupled-2025.html
+toc: false
+---
+
+The [ECCOMAS Coupled Problems 2025](https://coupled2025.cimne.com/) will take place on Sardinia, Italy from May 26 to 29.
+
+We are again organizing a preCICE minisymposium: [Multi-Physics and Multi-Scale Simulations with the Coupling Library preCICE](https://coupled2025.cimne.com/event/area/3dec3ef1-70ff-11ef-bbc6-000c29ddfc0c) (IS042).
+
+Feel free to ask questions in the [corresponding thread of the forum](TODO) (link pending).
+
+## Schedule of the Minisymposium
+
+We will announce the schedule here once we have it.
+
+## Related talks in other sessions
+
+We will announce preCICE-related talks in other sessions once the conference scheduled is published. Let us know if you are talking about preCICE in another session.


### PR DESCRIPTION
We still need a link to Discourse. Once merge, the link to the page will be:

https://precice.org/eccomas-coupled-2025.html

Edit: The CI failure is unrelated. https://github.com/precice/precice.github.io/pull/466 should resolve it.