### PR TITLE
Add posix-spawn to gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/rtomayko/posix-spawn.git
+  revision: 0fce38ed5458b638eda5f3bb711903424a4366db
+  branch: refs/pull/93/head
+  specs:
+    posix-spawn (0.3.15)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -100,7 +107,6 @@ GEM
       uri
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    posix-spawn (0.3.15)
     progressbar (1.11.0)
     public_suffix (4.0.7)
     racc (1.6.0)
@@ -142,6 +148,7 @@ DEPENDENCIES
   jemoji
   nokogiri
   open-uri
+  posix-spawn!
   webrick
 
 BUNDLED WITH


### PR DESCRIPTION
As suggested by the build failure message in https://github.com/precice/precice.github.io/actions/runs/11479909314/job/31947178415 (commit https://github.com/precice/precice.github.io/commit/d6433acc2fbb005c03d9f119315eac63c4f57d44):

```
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.
```