### PR TITLE
Fix broken link

### DIFF
--- a/pages/docs/dev-docs/dev-logging.md
+++ b/pages/docs/dev-docs/dev-logging.md
@@ -64,7 +64,7 @@ The relative convergence limit="1e-8" is close to the hard-coded numerical resol
 ## Formatting
 
 We use the `fmtlib` for formatting the messages, which reimplements the python format syntax.
-See the [offical syntax reference](https://fmt.dev/latest/syntax.html).
+See the [offical syntax reference](https://fmt.dev/).
 
 ```cpp
 // Simple message


### PR DESCRIPTION
https://fmt.dev/latest/syntax.html doesn't work anymore, hence I suggest using https://fmt.dev/