### PR TITLE
Fix testprecice labels argument

### DIFF
--- a/pages/docs/dev-docs/dev-testing.md
+++ b/pages/docs/dev-docs/dev-testing.md
@@ -55,7 +55,7 @@ The latter is only useful for running individual tests in a debugger.
 
 Tests in CTest are named `precice.` followed by the full test name of boost test.
 To get a list of all tests for scripting purposes, use `./testprecice --list_units`.
-CTest additionally groups tests in labels. Use `./testprecice --print-labels` to display existing labels.
+CTest additionally groups tests in labels. Use `./testprecice --list_labels` to display existing labels.
 
 Some important options for `ctest` are:
 

--- a/pages/docs/dev-docs/dev-testing.md
+++ b/pages/docs/dev-docs/dev-testing.md
@@ -55,7 +55,7 @@ The latter is only useful for running individual tests in a debugger.
 
 Tests in CTest are named `precice.` followed by the full test name of boost test.
 To get a list of all tests for scripting purposes, use `./testprecice --list_units`.
-CTest additionally groups tests in labels. Use `./testprecice --list_labels` to display existing labels.
+CTest additionally groups tests in labels. Use `ctest --print-labels` to display existing labels.
 
 Some important options for `ctest` are:
 


### PR DESCRIPTION
@fsimonis correct?

I only get:

```
./testprecice --list_labels
This test suite runs on rank 0 of 1
Available labels:
  MPI_Ports
```