### PR TITLE
Fix layout semantics

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,6 @@
-<footer>
-	<div class="row text-center">
+<div class="container">
+  <div class="row text-center">
+    <hr class="faded">
 
 		{% if page.last_updated %}<span>Page last updated:</span> {{page.last_updated}}<br/>{% endif %} Site last generated: {{ site.time | date: "%b %-d, %Y"  }} <br />
 
@@ -11,4 +12,4 @@
 
 	</div>
 
-</footer>
+</div>

--- a/_includes/news_banner.html
+++ b/_includes/news_banner.html
@@ -4,7 +4,7 @@
 
 {% if true %}
 
-<div class="background-light banner-container">
+<aside role="banner" class="background-light banner-container">
   <div class="container">
     <div class="row no-margin">
       <div class="col-lg-12 banner">
@@ -14,6 +14,6 @@
       </div>
     </div>
   </div>
-</div>
+</aside>
 
 {% endif %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,5 +1,6 @@
 {% assign sidebar = site.data.sidebars[page.sidebar].entries %}
 
+<nav aria-label="{{sidebar[0].product}}">
 <ul id="mysidebar" class="nav">
   <li class="sidebarTitle">{{sidebar[0].product}} {{sidebar[0].version}}</li>
   {% for entry in sidebar %}
@@ -67,6 +68,7 @@
   </p>
   -->
 </ul>
+</nav>
 
 <!-- this highlights the active parent class in the navgoco sidebar. this is critical so that the parent expands when you're viewing a page. This must appear below the sidebar code above. Otherwise, if placed inside customscripts.js, the script runs before the sidebar code runs and the class never gets inserted.-->
 <script>$("li.active").parents('li').toggleClass("active");</script>

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -1,5 +1,5 @@
-<!-- Navigation -->
-<nav class="navbar navbar-inverse navbar-fixed-top">
+<a!-- Navigation -->
+<nav class="navbar navbar-inverse navbar-fixed-top" aria-label="Main">
     <div class="container topnavlinks">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -82,37 +82,28 @@
 <body>
     <header>
         {% include topnav.html %}
-    </header>
-    <main>
           <!-- News banner -->
           {% include news_banner.html onlanding=false %}
-        <!-- Page Content -->
-        <div class="container">
-            <div id="main">
-                <!-- Content Row -->
-                <div class="row">
-                    {% assign content_col_size = "col-md-12" %}
-                    {% unless page.hide_sidebar %}
-                    <!-- Sidebar Column -->
-                    <div class="col-md-3" id="tg-sb-sidebar">
-                        {% include sidebar.html %}
-                    </div>
-                    {% assign content_col_size = "col-md-9" %}
-                    {% endunless %}
-
-                    <!-- Content Column -->
-                    <div class="{{content_col_size}}" id="tg-sb-content">
-                        {{content}}
-                        {{site.data.alerts.hr_faded}}
-                        {% include footer.html %}
-                    </div>
-                    <!-- /.row -->
-                </div>
-            <!-- /.container -->
-            </div>
-        <!-- /#main -->
+    </header>
+    <div class="container">
+        {% unless page.hide_sidebar %}
+        <div class="row">
+          <div class="col-md-3" id="tg-sb-sidebar">
+            {% include sidebar.html %}
+          </div>
+          <main class="col-md-9" id="tg-sb-content">
+            {{content}}
+          </main>
         </div>
-    </main>
+        {% else %}
+        <main id="tg-sb-content">
+          {{content}}
+        </main>
+        {% endunless %}
+    </div>
+    <footer>
+      {% include footer.html %}
+    </footer>
 </body>
 
 {% if site.google_analytics %}

--- a/_layouts/landing_page.html
+++ b/_layouts/landing_page.html
@@ -6,19 +6,17 @@
 <body>
 	<header>
 		{% include topnav.html %}
-	</header>
-
-	<main>
 		<!-- News banner -->
     {% include news_banner.html onlanding=true %}
-
+	</header>
+	<main>
     <!-- Page Content -->
 		{{content}}
 	</main>
 
-	<div class="container">
+  <footer>
 		{% include footer.html %}
-	</div>
+  </footer>
 
 	<script src="{{ "js/github-queries.js" }}"></script>
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -40,16 +40,19 @@ layout: default
     <div class="row">
         <div class="col-md-9 col-sm-8">
           {% unless page.toc == false %}
+          <nav aria-label="table of contents">
           {% if page.tocheaders %}
           {% include toc.html headers=page.tocheaders %}
           {% else %}
           {% include toc.html %}
           {% endif %}
+          </nav>
           {% endunless %}
         </div>
 
         <div class="col-md-3 col-sm-4">
-            {% unless page.editme == false %}
+          {% unless page.editme == false %}
+          <aside>
             {% if page.github_editme_path %}
                 {% comment %}
                     a complete edit_me path looks like this:
@@ -69,14 +72,15 @@ layout: default
             <div class="text-right">
               <small>Updated {{ page.last_modified_at | date:  '%d %b %y' -}}</small>
             </div>
-            {% endunless %}
+          </aside>
+          {% endunless %}
         </div>
     </div>
 
    {{content}}
 
+    {% if page.tags != null %}
     <div class="tags">
-        {% if page.tags != null %}
         <b>Tags: </b>
         {% assign projectTags = site.data.tags.allowed-tags %}
         {% for tag in page.tags %}
@@ -84,8 +88,8 @@ layout: default
         <a href="{{ "tag_" | append: tag | append: ".html" }}" class="btn btn-default navbar-btn cursorNorm" role="button">{{page.tagName}}{{tag}}</a>
         {% endif %}
         {% endfor %}
-        {% endif %}
     </div>
+    {% endif %}
 
 {% comment %}
 {% include commento.html %}


### PR DESCRIPTION
This PR fixes the landmark semantics of the HTML layout using the [Accessibility insights for web](https://accessibilityinsights.io/docs/web/overview/) inspectors.

- sidebar and table of content navigations are now correctly wrapped in `nav` tags and use `aria-label` to describe which label they are
- the `main` content does not contain elements which are repeated over the website
- the website footer is outside of the `main` tag
- the sidebar is outside of the `main` tag
- the news banner is a `<aside role="banner">` and outside the `main` tag
- the edit section is wrapped in an `aside`



| | Doc | Home |
--- | --- | ---
Old|![old doc](https://github.com/user-attachments/assets/f32e6a87-9800-419d-bd65-00497fc8cec4) | ![old home](https://github.com/user-attachments/assets/24e832be-ceba-4880-9050-065fbe20be7a)
New|![new doc](https://github.com/user-attachments/assets/649fb150-5cd0-4fa0-a721-a1893d0c95bb) | ![new home](https://github.com/user-attachments/assets/aa272061-c49b-42cc-93d0-ce2dcd1a03cf) 

