### PR TITLE
Remove version from docs sidebar

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -2,8 +2,8 @@
 
 entries:
 - title: sidebar
-  product: Docs
-  version: v3.1.2
+  product: Documentation
+  version:
   folders:
 
   - title:


### PR DESCRIPTION
Do we really need the version number in the sidebar?

![Screenshot from 2024-12-18 13-28-52](https://github.com/user-attachments/assets/b9ee68b6-95a4-43d1-8001-33c7df80a43c)

- It is not very accurate: We sometimes include forward-referencing content, and it is not fixed at the time of the respective release.
- It is misleading: users think that they can click somewhere to change that (user observation at the SSE).
- It is yet another hard-coded place to update.

This PR removes the version and expands "Docs" to "Documentation".

I have not tested how this change renders.