### PR TITLE
Add link to Plausible analytics

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -93,6 +93,10 @@ The website in its current form was planned and implemented by CH Lorenz Researc
 
 We use a non-commercial license of [Prince XML](http://www.princexml.com/) to generate the PDF version of the documentation. For more information see our [meta documentation page](docs-meta-publish-to-pdf.html).
 
+## Website analytics
+
+We use the open-source and privacy-friendly analytics service [Plausible](https://plausible.io/). Everyone can see the [analytics for this website](https://plausible.io/precice.org).
+
 ## Impressum
 
 This website is maintained by


### PR DESCRIPTION
@fsimonis mentioned a few times lately how cool our open analytics are, so I thought of adding a link to make this more discoverable.

I first tried adding a link in the footer, but that is already getting busy, and is now nicely aligned.