### PR TITLE
Fix bounding box definitions in code examples

### DIFF
--- a/pages/docs/couple-your-code/couple-your-code-direct-access.md
+++ b/pages/docs/couple-your-code/couple-your-code-direct-access.md
@@ -19,9 +19,10 @@ This concept is required if you want to access received meshes directly. It migh
     // Allocate and fill the  'boundingBox' according to the interested region
     // with the desired bounds, in our example we use the unit cube.
     // Assuming dim == 3, means that the bounding box has dim * 2 == 6 elements.
-    std::vector<double> boundingBox {
-        0, 0, 0, // minimum corner
-        1, 1, 1 // maximum corner
+    std::vector<double> boundingBox{
+        0, 1, // x-axis min and max
+        0, 1, // y-axis min and max
+        0, 1  // z-axis min and max
     };
 
     // Define region of interest, where we want to obtain the direct access.

--- a/pages/docs/couple-your-code/couple-your-code-just-in-time-mapping.md
+++ b/pages/docs/couple-your-code/couple-your-code-just-in-time-mapping.md
@@ -48,8 +48,9 @@ const std::string otherMesh = "ReceivedMeshName";
 // the unit cube. Assuming dim == 3, means that the bounding box has dim * 2 == 6
 // elements.
 std::vector<double> boundingBox{
-    0, 0, 0, // minimum corner
-    1, 1, 1  // maximum corner
+    0, 1, // x-axis min and max
+    0, 1, // y-axis min and max
+    0, 1  // z-axis min and max
 };
 
 // Define region of interest, where we want to obtain API access.


### PR DESCRIPTION
I noticed that the code example in `pages/docs/couple-your-code/couple-your-code-just-in-time-mapping.md` defines the bounding box as:
```c++
std::vector<double> boundingBox{
    0, 0, 0, // minimum corner
    1, 1, 1  // maximum corner
};
```
So in the order `x_min, y_min, z_min, x_max, y_max, z_max`.
But in the test cases (e.g., `AccessReceivedMeshAndMapping`) a different order is used: `x_min, x_max, y_min, y_max`.

In fact, when using the order form the code example, I get
```
(0) 11:45:07 [partition::ReceivedPartition]:106 in compute: ERROR: You are running this participant in serial mode and the bounding box on mesh "Fluid-Mesh", is empty. Did you call setMeshAccessRegion with valid data?
```
This is to be expected, since the bounding box defined this way has length zero in at least one dimension.