### PR TITLE
Gismo adapter docs: Rendering and readability improvements

### DIFF
--- a/pages/docs/adapters/adapter-gismo.md
+++ b/pages/docs/adapters/adapter-gismo.md
@@ -33,7 +33,7 @@ For example, to build the solver `perpendicular-flap-vertex-gismo`, configure an
 
 ```bash
 cmake .. -DGISMO_OPTIONAL="gsElasticity;gsStructuralAnalysis;gsPreCICE"
-make install perpendicular-flap-vertex-gismo
+make perpendicular-flap-vertex-gismo
 ```
 
 For more details, refer to the documentation and examples within each submodule. Available solvers:

--- a/pages/docs/adapters/adapter-gismo.md
+++ b/pages/docs/adapters/adapter-gismo.md
@@ -23,32 +23,29 @@ Clone G+Smo and build a specific solver:
 git clone https://github.com/gismo/gismo.git
 cd gismo
 mkdir build & cd build
-cmake .. -DGISMO_OPTIONAL="<Other submodules>;gsPreCICE"
+cmake .. -DGISMO_OPTIONAL="<additional submodules>;gsPreCICE"
 make <solver_name>
 ```
 
-Depending on the solver, different submodules need to be added.
+Depending on the solver, different submodules need to be added. These `<additional submodules>` can be [`gsElasticity`](https://github.com/gismo/gsElasticity), [`gsKLShell`](https://github.com/gismo/gsKLShell) and [`gsStructuralAnalysis`](https://github.com/gismo/gsStructuralAnalysis).
 
-`<Other submodules>` can be [`gsElasticity`](https://github.com/gismo/gsElasticity), [`gsKLShell`](https://github.com/gismo/gsKLShell) and [`gsStructuralAnalysis`](https://github.com/gismo/gsStructuralAnalysis). For more details, refer to the documentation and examples within each submodule.
+For example, to build the solver `perpendicular-flap-vertex-gismo`, configure and build with:
 
-| **Solver**                          | **Required Submodules**                                           | **Configuration**                                |
-|------------------------------------|-------------------------------------------------------------------|---------------------------------------------------|
-| `perpendicular-flap-vertex-gismo` | [`gsElasticity`](https://github.com/gismo/gsElasticity),[`gsStructuralAnalysis`](https://github.com/gismo/gsStructuralAnalysis)   | `cmake .. -DGISMO_OPTIONAL="gsPreCICE;gsElasticity;gsStructuralAnalysis"`|
+```bash
+cmake .. -DGISMO_OPTIONAL="gsElasticity;gsStructuralAnalysis;gsPreCICE"
+make install perpendicular-flap-vertex-gismo
+```
+
+For more details, refer to the documentation and examples within each submodule. Available solvers:
+
+| **Solver**                          | **Additional submodules**                                           |
+|------------------------------------|-------------------------------------------------------------------|
+| `perpendicular-flap-vertex-gismo` | [`gsElasticity`](https://github.com/gismo/gsElasticity),[`gsStructuralAnalysis`](https://github.com/gismo/gsStructuralAnalysis)   |
 
 Finally, make the solver discoverable, e.g. by installation (by default, to `/usr/local/`, which might not be in your `LD_LIBRARY_PATH`):
 
 ```bash
 make install <solver_name>
-```
-
-### Example instructions for `perpendicular-flap-vertex-gismo`
-
-```bash
-git clone https://github.com/gismo/gismo.git
-cd gismo
-mkdir build & cd build
-cmake .. -DGISMO_OPTIONAL="gsElasticity;gsStructuralAnalysis;gsPreCICE"
-make install perpendicular-flap-vertex-gismo
 ```
 
 ## History


### PR DESCRIPTION
Reviewing again the [gismo adapter docs](https://precice.org/adapter-gismo.html), I noticed two issues:

1. The example section feels a bit disconnected
2. The table is formatted strangely due to the three long columns:

![Screenshot from 2025-04-07 15-36-53](https://github.com/user-attachments/assets/cc651060-280a-45de-94bb-7a20644f7f9e)

This PR removes the third column, which is already covered by the example. It also shortens and moves the example up, merging it into the installation section.

@Crazy-Rich-Meghan @uekerman FYI.