### PR TITLE
Unpin runner in CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout website
         uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout website
         uses: actions/checkout@v2


### PR DESCRIPTION
GitHub [phased out the ubuntu-20.04 runners](https://github.com/actions/runner-images/issues/11101). Some workflows were pinned to `ubuntu-20.04`, while others were using `ubuntu-latest`. I don't think there is any critical reason to keep them pinned, if they work. It is announced when the default changes, so we can figure it out easily if we get any issues in the future.

This PR changes all pinned runners to `ubuntu-latest`.