### PR TITLE
Add perpendicular-flap-stress tutorial to sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -285,6 +285,7 @@ subprojects:
   - imported/tutorials/oscillator
   - imported/tutorials/oscillator-overlap
   - imported/tutorials/perpendicular-flap
+  - imported/tutorials/perpendicular-flap-stress
   - imported/tutorials/turek-hron-fsi3
   - imported/tutorials/partitioned-pipe
   - imported/tutorials/partitioned-pipe-two-phase

--- a/_data/sidebars/tutorial_sidebar.yml
+++ b/_data/sidebars/tutorial_sidebar.yml
@@ -169,7 +169,7 @@ entries:
           output: web
         
         - title: Stresses variant
-          url: /tutorials-perpendicular-flap-stresses.html
+          url: /tutorials-perpendicular-flap-stress.html
           output: web
     
     - title: Resonant circuit

--- a/_data/sidebars/tutorial_sidebar.yml
+++ b/_data/sidebars/tutorial_sidebar.yml
@@ -169,7 +169,7 @@ entries:
           output: web
         
         - title: Stresses variant
-          url: /tutorials-perpendicular-flap-stress.html
+          url: /tutorials-perpendicular-flap-stresses.html
           output: web
     
     - title: Resonant circuit

--- a/_data/sidebars/tutorial_sidebar.yml
+++ b/_data/sidebars/tutorial_sidebar.yml
@@ -160,9 +160,18 @@ entries:
           url: /tutorials-partitioned-heat-conduction-overlap.html
           output: web
 
-    - title: Perpendicular flap
-      url: /tutorials-perpendicular-flap.html
-      output: web
+      subfolders:
+      - title: Perpendicular flap
+        output: web
+        subfolderitems:
+
+        - title: Basic variant
+          url: /tutorials-perpendicular-flap.html
+          output: web
+        
+        - title: Stresses variant
+          url: /tutorials-perpendicular-flap-stress.html
+          output: web
     
     - title: Resonant circuit
       url: /tutorials-resonant-circuit.html

--- a/_data/sidebars/tutorial_sidebar.yml
+++ b/_data/sidebars/tutorial_sidebar.yml
@@ -168,7 +168,7 @@ entries:
           url: /tutorials-perpendicular-flap.html
           output: web
         
-        - title: Stresses variant
+        - title: Stress variant
           url: /tutorials-perpendicular-flap-stress.html
           output: web
     

--- a/_data/sidebars/tutorial_sidebar.yml
+++ b/_data/sidebars/tutorial_sidebar.yml
@@ -160,7 +160,6 @@ entries:
           url: /tutorials-partitioned-heat-conduction-overlap.html
           output: web
 
-      subfolders:
       - title: Perpendicular flap
         output: web
         subfolderitems:

--- a/pages/tutorials/tutorials.md
+++ b/pages/tutorials/tutorials.md
@@ -66,7 +66,7 @@ In the following cases, you can explore different aspects of preCICE:
   - [Overlapping Schwarz variant](tutorials-partitioned-heat-conduction-overlap.html): An overlapping Schwarz method of the partitioned heat conduction case, coupling two Dirichlet participants.
 - Perpendicular flap collection
   - [Basic variant](tutorials-perpendicular-flap.html) (as in "featured")
-  - [Stresses variant](tutorials-perpendicular-flap-stress.html)
+  - [Stress variant](tutorials-perpendicular-flap-stress.html)
 - [Resonant circuit](tutorials-resonant-circuit.html): The basic LC circuit, with two MATLAB solvers.
 - [Two-scale heat conduction](tutorials-two-scale-heat-conduction.html): A heat conduction scenario with an underlying micro-structure which is resolved to get the constitutive properties on the macro scale.
 - [Turek-Hron FSI3](tutorials-turek-hron-fsi3.html): The well-known fluid-structure interaction benchmark, with OpenFOAM and deal.II.

--- a/pages/tutorials/tutorials.md
+++ b/pages/tutorials/tutorials.md
@@ -64,7 +64,9 @@ In the following cases, you can explore different aspects of preCICE:
   - [Complex variant](tutorials-partitioned-heat-conduction-complex.html): A partitioned heat conduction case with FEniCS, showcasing advanced features and geometries.
   - [Direct mesh access variant](tutorials-partitioned-heat-conduction-direct.html): A partitioned heat conduction case with Nutils, showcasing the direct mesh access feature.
   - [Overlapping Schwarz variant](tutorials-partitioned-heat-conduction-overlap.html): An overlapping Schwarz method of the partitioned heat conduction case, coupling two Dirichlet participants.
-- [Perpendicular flap](tutorials-perpendicular-flap.html) (as in "featured")
+- Perpendicular flap collection
+  - [Basic variant](tutorials-perpendicular-flap.html) (as in "featured")
+  - [Stresses variant](tutorials-perpendicular-flap-stress.html)
 - [Resonant circuit](tutorials-resonant-circuit.html): The basic LC circuit, with two MATLAB solvers.
 - [Two-scale heat conduction](tutorials-two-scale-heat-conduction.html): A heat conduction scenario with an underlying micro-structure which is resolved to get the constitutive properties on the macro scale.
 - [Turek-Hron FSI3](tutorials-turek-hron-fsi3.html): The well-known fluid-structure interaction benchmark, with OpenFOAM and deal.II.


### PR DESCRIPTION
Follow-up of https://github.com/precice/tutorials/pull/603
Following the checklist on https://precice.org/community-contribute-to-precice.html#adding-a-new-tutorial-to-the-website

I have not yet tried locally if the rendering works correctly.