### PR TITLE
Add link to Micro Manager logging documentation

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -270,6 +270,10 @@ entries:
           url: /tooling-micro-manager-running.html
           output: web, pdf
 
+        - title: Logging
+          url: /tooling-micro-manager-logging.html
+          output: web, pdf
+
         - title: Snapshot Computation
           url: /tooling-micro-manager-snapshot-configuration.html
           output: web, pdf


### PR DESCRIPTION
Documentation for the logging functionality in the Micro Manager was added via https://github.com/precice/micro-manager/pull/160 in the file [micro-manager/docs/logging.md](https://github.com/precice/micro-manager/blob/develop/docs/logging.md). This PR adds it to the sidebar of the website page.