### PR TITLE
Add Python code for `couple your code` section

### DIFF
--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -340,4 +340,14 @@ div#tg-sb-sidebar {
   div#tg-sb-sidebar  {
     position: static;
   }
+/* style navtabs */
+.post-content ol li, .post-content ul li {
+  margin: 0px;
+}
+div.tab-content {
+  padding: 0px;
+  background-color: white;
+  }
+div.tab-content div.tab-pane pre {
+  margin-top: 0px;
 }

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -623,6 +623,8 @@ div#toc ul li ul li {
 
 .tab-content {
     padding: 15px;
+    padding-top: 4px;
+    padding-bottom: 4px;
     background-color: #FAFAFA;
 }
 

--- a/css/printstyles.css
+++ b/css/printstyles.css
@@ -40,7 +40,7 @@ a[href^="http:"]::after, a[href^="https:"]::after, a[href^="ftp:"]::after {
 a[href] {
     color: #0A76BB !important;
 }
-a[href*="mailto"]::after, a[data-toggle="tooltip"]::after, a[href].noCrossRef::after {
+a[href*="mailto"]::after, a[data-toggle="tooltip"]::after, a[href].noCrossRef::after, a[data-toggle="tab"]::after {
     content: "";
 }
 
@@ -219,4 +219,55 @@ pre > code {
 h1[id], h2[id], h3[id], h4[id], h5[id], h6[id], dt[id] {
     padding-top: 1.5em;
     margin-top: -1em;
+}
+
+/* prepare nav tabs for printing */
+.nav > li.active > a, /* tab headers */
+.nav > li > a {
+    color: black;
+    background-color: white;
+    border: 1px solid #ccc;
+    border-radius: 4px 4px 0 0;
+}
+.tab-content > .tab-pane {
+    display: block !important; /* display non-active panes */
+    position: relative;
+}
+div.tab-content div.tab-pane pre {
+  margin-top: 1em;
+}
+/* create counters to link tab headers to tab contents */
+.post-content ul.nav.nav-tabs { 
+    counter-reset: tab_number; /* creates a new instance of counter with name tab_number */
+}
+.post-content .nav.nav-tabs li::after {
+    counter-increment: tab_number; /* increment counter */
+    content: counter(tab_number); /* display value in small bubble */
+    position: absolute;
+    top:  -1em;
+    left:  -1em;
+    padding: 2px 5px;
+    background-color: white;
+    color: black;
+    font-size: 0.65em;
+    border-radius: 50%;
+    border: 1px solid #ccc;
+    box-shadow: 1px 1px 1px grey;
+}
+div.tab-content { 
+  counter-reset: pane_number; 
+}
+div.tab-pane::after {
+    counter-increment: pane_number;
+    content: counter(pane_number);
+    position: absolute;
+    top: -1em;
+    left: -1em;
+    padding: 2px 5px;
+    background-color: white;
+    color: black;
+    font-size: 0.65em;
+    border-radius: 50%;
+    border: 1px solid #ccc;
+    box-shadow: 1px 1px 1px gray;
 }

--- a/pages/docs/couple-your-code/couple-your-code-defining-mesh-connectivity.md
+++ b/pages/docs/couple-your-code/couple-your-code-defining-mesh-connectivity.md
@@ -14,6 +14,12 @@ For surface coupling in 2D, mesh connectivity boils down to defining edges betwe
 For volume coupling in 2D, mesh connectivity boils down to defining triangles and / or quads between vertices. In 3D, you need to define tetrahedra introduced in version `2.5.0`.
 
 All kind of connectivity can be built up directly from vertices. Triangles and quads also allow us to define them using edge IDs.
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-1" data-toggle="tab">C++</a></li>
+    <li><a href="#python-1" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-1" markdown="1">
 
 ```cpp
 void setMeshEdge(precice::string_view meshName, VertexID firstVertexID, VertexID secondVertexID);
@@ -22,7 +28,25 @@ void setMeshQuad(precice::string_view meshName, VertexID firstVertexID, VertexID
 void setMeshTetrahedron(precice::string_view meshName, VertexID firstVertexID, VertexID secondVertexID, VertexID thirdVertexID, VertexID fourthVertexID);
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-1" markdown="1">
+
+```python
+set_mesh_edge(mesh_name, first_vertex_id, second_vertex_id)
+set_mesh_triangle(mesh_name, first_vertex_id, second_vertex_id, third_vertex_id)
+set_mesh_quad(mesh_name, first_vertex_id, second_vertex_id, third_vertex_id, fourth_vertex_id)
+set_mesh_tetrahedron(mesh_name, first_vertex_id, second_vertex_id, third_vertex_id, fourth_vertex_id)    
+```
+
+</div>
+</div>
 There are also bulk versions of these methods, which can be easier to handle in some cases:
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-2" data-toggle="tab">C++</a></li>
+    <li><a href="#python-2" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-2" markdown="1">
 
 ```cpp
 void setMeshEdges(precice::string_view meshName, precice::span<const VertexID> vertices);
@@ -31,12 +55,39 @@ void setMeshQuads(precice::string_view meshName, precice::span<const VertexID> v
 void setMeshTetrahedra(precice::string_view meshName, precice::span<const VertexID> vertices);
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-2" markdown="1">
+
+```python
+set_mesh_edges(mesh_name, vertices)
+set_mesh_triangles(mesh_name, vertices)
+set_mesh_quads(mesh_name, vertices)
+set_mesh_tetrahedra(mesh_name, vertices)
+```
+
+</div>
+</div>
 If you do not configure any features in the preCICE configuration that require mesh connectivity, all these API functions are [no-ops](https://en.wikipedia.org/wiki/NOP_(code)). Thus, don't worry about performance. If you need a significant workload to already create this connectivity information in your adapter in the first place, you can also explicitly ask preCICE whether it is required:
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-3" data-toggle="tab">C++</a></li>
+    <li><a href="#python-3" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-3" markdown="1">
 
 ```cpp
 bool requiresMeshConnectivityFor(precice::string_view meshName);
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-3" markdown="1">
+
+```python
+requires_mesh_connectivity_for(mesh_name)   
+```
+
+</div>
+</div>
 {% warning %}
 The API function `isMeshConnectivityRequired` is only supported since v2.3.
 {% endwarning %}
@@ -52,6 +103,12 @@ Quads are only supported since v2.1. For older version, the methods only exist a
 {% endwarning %}
 
 The following code shows how mesh connectivity can be defined in our example. For sake of simplification, let's only define one triangle and let's assume that it consists of the first three vertices.
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-4" data-toggle="tab">C++</a></li>
+    <li><a href="#python-4" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-4" markdown="1">
 
 ```cpp
 /* ... */
@@ -83,6 +140,30 @@ if (precice.requiresMeshConnectivityFor(meshName)) {
 /* ... */
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-4" markdown="1">
+
+```python
+# We define the unit square in 2D with vertices A, B, C, D
+coords = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
+vertex_ids = precice.set_mesh_vertices(mesh_name, coords)
+
+if precice.requires_mesh_connectivity_for(mesh_name):
+
+  # Define triangles ABC and BCD separately
+  precice.set_mesh_triangle(mesh_name, vertex_ids[0], vertex_ids[1],  vertex_ids[2])
+  precice.set_mesh_triangle(mesh_name, vertex_ids[1], vertex_ids[2],  vertex_ids[3])
+
+  # Define triangles in one go
+  triangles = np.array([
+    [vertex_ids[0], vertex_ids[1],  vertex_ids[2]],
+    [vertex_ids[1], vertex_ids[2],  vertex_ids[3]]
+  ])
+  precice.set_mesh_triangles(mesh_name, triangles)
+```
+
+</div>
+</div>
 ## Mesh pre-processing
 
 preCICE pre-processes all provided meshes during initialization, removing duplicates and adding missing hierarchical elements.
@@ -109,6 +190,12 @@ In this case you can save a mapping from Solver ID to preCICE Vertex ID, after d
 When iterating over the faces, get the vertex identifiers of defining points.
 For triangular faces, these would be the 3 corner points.
 Then map these Solver IDs to preCICE IDs, and use those to define your connectivity.
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-5" data-toggle="tab">C++</a></li>
+    <li><a href="#python-5" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-5" markdown="1">
 
 ```cpp
 Participant participant(...);
@@ -131,6 +218,30 @@ for (auto& tri: solver.triangularFaces) {
 }
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-5" markdown="1">
+
+```python
+participant = precice.Participant(...)
+
+id_maps = dict()
+for vertex in solver.vertices:
+  vertex_id = participant.set_mesh_vertex("MyMesh", vertex.coords)
+  # Set the vertex_id as label
+  id_maps[vertex._id] = vertex_id
+
+for tri in solver.triangular_faces:
+  # Lookup the precice vertex id using solver vertex id
+  a = id_maps.get(tri.a._id)
+  b = id_maps.get(tri.b._id)
+  c = id_maps.get(tri.c._id)
+
+  participant.set_mesh_triangle(mesh_name, a, b, c)
+```
+
+</div>
+</div>
+
 ### Solver supports custom attributes
 
 You solver doesn't provide a unique identifier for each vertex.
@@ -145,6 +256,12 @@ Examples of such attributes:
 In this case you can save preCICE Vertex IDs as labels directly in the solver vertices.
 Define the vertices using the preCICE API, then iterate over them and apply the preCICE vertex IDs as labels.
 When iterating over faces, get the preCICE vertex IDs from the point labels, and use those to define your connectivity.
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-6" data-toggle="tab">C++</a></li>
+    <li><a href="#python-6" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-6" markdown="1">
 
 ```cpp
 Participant participant(...);
@@ -164,6 +281,27 @@ for (auto& tri: solver.triangularFaces) {
 }
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-6" markdown="1">
+
+```python
+participant = precice.Participant(...)
+
+for vertex in solver.vertices:
+  vertex_id = participant.set_mesh_vertex("MyMesh", vertex.coords)
+  vertex.label = vertex_id
+
+for tri in solver.triangular_faces:
+  a = tri.a.label
+  b = tri.b.label
+  c = tri.c.label
+
+  participant.set_mesh_triangle("MyMesh", a, b, c)
+```
+
+</div>
+</div>
+
 ### Solver supports coordinates only
 
 Your solver provides coordinates only or labels are already used for another purpose.
@@ -173,6 +311,12 @@ Depending on your solver, coordinates available at various stages may be subject
 Hence, a C++ `std::map` without custom comparator, or python `dict` may not be sufficient.
 
 An alternative would be to use a spatial index as a data structure to store this information.
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-7" data-toggle="tab">C++</a></li>
+    <li><a href="#python-7" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-7" markdown="1">
 
 ```cpp
 Participant participant(...);
@@ -224,7 +368,8 @@ class IDLookup {
 };
 ```
 
-In python, you could use the rtree package:
+</div>
+<div role="tabpanel" class="tab-pane" id="python-7" markdown="1">
 
 ```py
 import rtree
@@ -242,3 +387,6 @@ for tri in solver.triangularFaces:
   c = index.nearest(tri.c.coords)
   participant.set_mesh_triangle("MyMesh", a, b, c)
 ```
+
+</div>
+</div>

--- a/pages/docs/couple-your-code/couple-your-code-initializing-coupling-data.md
+++ b/pages/docs/couple-your-code/couple-your-code-initializing-coupling-data.md
@@ -6,12 +6,33 @@ summary: "As default values, preCICE assumes that all coupling variables are zer
 ---
 
 By default preCICE assumes that all coupling variables are zero initially. If you want to provide non-zero initial values, you can write data before calling `initialize()`. This data will then be used as initial data. To check whether initial data is required, you can use the following function:
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-1" data-toggle="tab">C++</a></li>
+    <li><a href="#python-1" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-1" markdown="1">
 
 ```cpp
 bool requiresInitialData()
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-1" markdown="1">
+
+```python
+requires_initial_data()
+```
+
+</div>
+</div>
 To support data initialization, we extend our example as follows:
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-2" data-toggle="tab">C++</a></li>
+    <li><a href="#python-2" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-2" markdown="1">
 
 ```cpp
 
@@ -28,6 +49,23 @@ while (precice.isCouplingOngoing()){
 }
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-2" markdown="1">
+
+```python
+[...]
+
+if precice.requires_initial_data():
+  precice.write_data("FluidMesh", "Forces", vertex_ids, forces)
+
+precice.initialize()
+
+while precice.is_coupling_ongoing():
+  [...]
+```
+
+</div>
+</div>
 Now, you can specify at runtime if you want to initialize coupling data. For example to initialize displacements:
 
 ```xml

--- a/pages/docs/couple-your-code/couple-your-code-mesh-and-data-access.md
+++ b/pages/docs/couple-your-code/couple-your-code-mesh-and-data-access.md
@@ -9,6 +9,13 @@ For coupling, we need coupling meshes. Let's see how we can tell preCICE about o
 
 Coupling meshes and associated data fields are defined in the preCICE configuration file, which you probably already know from the tutorials. The concrete values, however, you can access with the API:
 
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-1" data-toggle="tab">C++</a></li>
+    <li><a href="#python-1" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-1" markdown="1">
+
 ```cpp
 VertexID setMeshVertex(
     ::precice::string_view        meshName,
@@ -20,10 +27,26 @@ void setMeshVertices(
     precice::span<VertexID>     ids);
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-1" markdown="1">
+
+```python
+vertex_id = set_mesh_vertex(mesh_name, position)
+vertex_ids = set_mesh_vertices(mesh_name, positions)
+```
+
+</div>
+</div>
 * `setMeshVertex` defines the coordinates of a single mesh vertex and returns a vertex ID, which you can use to refer to this vertex.
 * `setMeshVertices` defines multiple vertices at once. So, you can use this function instead of calling `setMeshVertex` multiple times. This is also good practice for performance reasons.
 
 To write data to the coupling data structure the following API function is needed:
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-2" data-toggle="tab">C++</a></li>
+    <li><a href="#python-2" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-2" markdown="1">
 
 ```cpp
 void Participant::writeData(
@@ -33,7 +56,22 @@ void Participant::writeData(
     precice::span<const double>   values)
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-2" markdown="1">
+
+```python
+write_data(mesh_name, data_name, vertex_ids, values)
+```
+
+</div>
+</div>
 Similarly, there is a `readData` API function for reading coupling data:
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-3" data-toggle="tab">C++</a></li>
+    <li><a href="#python-3" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-3" markdown="1">
 
 ```cpp
 void readData(
@@ -44,9 +82,24 @@ void readData(
     precice::span<double>         values) const;
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-3" markdown="1">
+
+```python
+values = read_data(mesh_name, data_name, vertex_ids, relative_read_time)
+```
+
+</div>
+</div>
 The relative read time can be anything from the current point in time (`0`) to the end of the time window (`getMaxTimeStepSize()`). We will talk about the additional argument `relativeReadTime` in detail in [the section on time interpolation](couple-your-code-waveform.html).
 
 Let's define coupling meshes and access coupling data in our example code:
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-4" data-toggle="tab">C++</a></li>
+    <li><a href="#python-4" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-4" markdown="1">
 
 ```cpp
 turnOnSolver(); //e.g. setup and partition mesh
@@ -87,6 +140,45 @@ precice.finalize(); // frees data structures and closes communication channels
 turnOffSolver();
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-4" markdown="1">
+
+```python
+turn_on_solver() # e.g. setup and partition mesh
+precice = precice.Participant("FluidSolver", "precice-config.xml", rank, size) # Initialize participant
+
+mesh_dim = precice.get_mesh_dimensions("FluidMesh")
+
+# define coords of vertices at wet surface
+coords = np.zeros((vertex_size, mesh_dim))
+
+vertex_ids = precice.set_mesh_vertices("FluidMesh", coords)
+
+forces_dim = precice.get_data_dimensions("FluidMesh", "Forces")
+forces = np.zeros((vertex_size, forces_dim))
+
+displacements_dim = precice.get_data_dimensions("FluidMesh", "Displacements")
+displacements = np.zeros((vertex_size, displacements_dim))
+
+precice.initialize()
+while participant.is_coupling_ongoing(): # time loop
+  precice_dt = precice.get_max_time_step_size()
+  solver_dt = begin_time_step() # e.g. compute adaptive dt
+  dt = min(precice_dt, solver_dt)
+  displacements = precice.read_data("FluidMesh", "Displacements", vertex_ids, dt)
+  set_displacements(displacements)
+  solve_time_step(dt)
+  forces = compute_forces()
+  precice.write_data("FluidMesh", "Forces", vertex_ids, forces)
+  precice.advance(dt)
+  end_time_step() # e.g. update variables, increment time
+
+precice.finalize() # frees data structures and closes communication channels
+turn_off_solver()
+```
+
+</div>
+</div>
 Did you see that your fluid solver now also needs to provide the functions `computeForces` and `setDisplacements`? As you are an expert in your fluid code, these functions should be easy to implement. Most probably, you already have such functionality anyway. If you are not an expert in your code try to find an expert :smirk:.
 
 Once your adapter reaches this point, it is a good idea to test your adapter against one of the [solverdummies](couple-your-code-api#minimal-reference-implementation), which then plays the role of the `SolidSolver`.
@@ -127,7 +219,7 @@ You can use the following `precice-config.xml`:
       <read-data  name="Forces" mesh="StructureMesh"/>
     </participant>
 
-    <m2n:sockets from="FluidSolver" to="SolidSolver"/>
+    <m2n:sockets acceptor="FluidSolver" connector="SolidSolver"/>
 
     <coupling-scheme:serial-explicit>
       <participants first="FluidSolver" second="SolidSolver"/>

--- a/pages/docs/couple-your-code/couple-your-code-preparing-your-solver.md
+++ b/pages/docs/couple-your-code/couple-your-code-preparing-your-solver.md
@@ -7,6 +7,13 @@ summary: "If you want to couple your own code you need to properly understand it
 
 Let's say you want to prepare a fluid solver for fluid-structure interaction and that your code looks like this:
 
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp" data-toggle="tab">C++</a></li>
+    <li><a href="#python" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="cpp" markdown="1">
+
 ```cpp
 turnOnSolver(); //e.g. setup and partition mesh
 
@@ -18,8 +25,25 @@ while (not simulationDone()){ // time loop
   endTimeStep(); // e.g. update variables, increment time
 }
 turnOffSolver();
+
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python" markdown="1">
+
+```python
+turn_on_solver() #e.g. setup and partition mesh
+
+while not simulation_done(): # time loop
+  dt = begin_time_step() #e.g compute adaptive dt
+  solve_time_step(dt)
+  end_time_step() #e.g. update variables, increment time
+
+turn_off_solver()
+```
+
+</div>
+</div>
 Probably most solvers have such a structures: something in the beginning (reading input, domain decomposition), a big time loop, and something in the end. Each time step also falls into three parts: some pre-computations (e.g. computing an adaptive time step size), the actual computation (solving a linear or non-linear equation system), and something in the end (updating variables, incrementing time). Try to identify these parts in the code you want to couple.
 
 In the following steps, we will slowly add more and more calls to the preCICE API in this code snippet. Some part of the preCICE API is briefly described in each step. More precisely (no pun intended :grin:), we use the native `C++` API of preCICE. The API is, however, also available in other scientific programming languages: plain `C`, `Fortran`, `Python`, `Matlab`, `Julia`, and `Rust` (see [Application Programming Interface](couple-your-code-api)).

--- a/pages/docs/couple-your-code/couple-your-code-steering-methods.md
+++ b/pages/docs/couple-your-code/couple-your-code-steering-methods.md
@@ -9,6 +9,13 @@ summary: "In this step, you get to know the most important API functions of preC
 As a first preparation step, you need to include the preCICE library headers. In C++, you need to include the file [precice.hpp](https://github.com/precice/precice/blob/develop/src/precice/precice.hpp).
 The handle to the preCICE API is the class `precice::Participant`. Its constructor requires the participant's name, the preCICE configuration file's name and the `rank` and `size` of the current thread. Once the basic preCICE interface is set up, we can _steer_ the behaviour of preCICE. For that we need the following functions:
 
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-1" data-toggle="tab">C++</a></li>
+    <li><a href="#python-1" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="cpp-1" markdown="1">
+
 ```cpp
 Participant( String participantName, String configurationFileName, int rank, int size );
 void initialize();
@@ -16,6 +23,18 @@ void advance ( double computedTimeStepSize );
 void finalize();
 ```
 
+  </div>
+  <div role="tabpanel" class="tab-pane" id="python-1" markdown="1">
+
+```python
+participant = Participant(participant_name, configuration_file_name, rank, size)
+participant.initialize()
+participant.advance(computed_timestep_size)
+participant.finalize()
+```
+
+  </div>
+</div>
 What do they do?
 
 * `initialize` establishes communication channels and sets up data structures of preCICE.
@@ -23,19 +42,34 @@ What do they do?
 * `finalize` frees the preCICE data structures and closes communication channels.
 
 The following function allows us to query the maximum allowed time step size from preCICE:
-
-
 <ul id="apiTabs" class="nav nav-tabs">
-    <li class="active"><a href="#cpp" data-toggle="tab">C++</a></li>
-    <li><a href="#python" data-toggle="tab">Python</a></li>
+    <li class="active"><a href="#cpp-2" data-toggle="tab">C++</a></li>
+    <li><a href="#python-2" data-toggle="tab">Python</a></li>
 </ul>
 <div class="tab-content">
-  <div role="tabpanel" class="tab-pane active" id="cpp" markdown="1">
+  <div role="tabpanel" class="tab-pane active" id="cpp-2" markdown="1">
+
 ```cpp
 double getMaxTimeStepSize();
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-2" markdown="1">
+
+```python
+get_max_time_step_size()
+```
+
+</div>
+</div>
+
 But let's ignore the details of time step sizes for the moment. This will be the topic of [Step 5](couple-your-code-time-step-sizes.html). We can now extend the code of our fluid solver:
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-3" data-toggle="tab">C++</a></li>
+    <li><a href="#python-3" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="cpp-3" markdown="1">
 
 ```cpp
 #include <precice/precice.hpp>
@@ -60,29 +94,31 @@ while (not simulationDone()){ // time loop
 precice.finalize(); // frees data structures and closes communication channels
 turnOffSolver();
 ```
-  </div>
-  <div role="tabpanel" class="tab-pane" id="python" markdown="1">
+
+</div>
+<div role="tabpanel" class="tab-pane" id="python-3" markdown="1">
+
 ```python
 import precice
 
 turn_on_solver()  # e.g. setup and partition mesh
 
-precice = precice.Interface(
+precice = precice.Participant(
     "FluidSolver", "precice-config.xml", rank, size
-)
-precice_dt = precice.initialize()
+) # construct participant
 
-u = initialize_solution()
-
-while t < t_end:  # time loop
-    dt = compute_adaptive_dt()
-    dt = min(precice_dt, dt)  # more about this in Step 5
-    u = solve_time_step(dt, u)  # returns new solution
-    precice_dt = precice.advance(dt)
-    t = t + dt
+precice.initialize()
+while not simulation_done():  # time loop
+    precice_dt = precice.get_max_time_step()
+    solver_dt = begin_time_step() # e.g. compute adaptive dt
+    dt = min(precice_dt, solver_dt)
+    solve_time_step(dt)
+    precice.advance(dt)
+    end_time_step() # e.g. update variables, increment time
 
 precice.finalize()  # frees data structures and closes communication channels
+turn_off_solver()
 ```
-  </div>
-</div>
 
+</div>
+</div>

--- a/pages/docs/couple-your-code/couple-your-code-steering-methods.md
+++ b/pages/docs/couple-your-code/couple-your-code-steering-methods.md
@@ -24,6 +24,13 @@ What do they do?
 
 The following function allows us to query the maximum allowed time step size from preCICE:
 
+
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp" data-toggle="tab">C++</a></li>
+    <li><a href="#python" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="cpp" markdown="1">
 ```cpp
 double getMaxTimeStepSize();
 ```
@@ -53,3 +60,29 @@ while (not simulationDone()){ // time loop
 precice.finalize(); // frees data structures and closes communication channels
 turnOffSolver();
 ```
+  </div>
+  <div role="tabpanel" class="tab-pane" id="python" markdown="1">
+```python
+import precice
+
+turn_on_solver()  # e.g. setup and partition mesh
+
+precice = precice.Interface(
+    "FluidSolver", "precice-config.xml", rank, size
+)
+precice_dt = precice.initialize()
+
+u = initialize_solution()
+
+while t < t_end:  # time loop
+    dt = compute_adaptive_dt()
+    dt = min(precice_dt, dt)  # more about this in Step 5
+    u = solve_time_step(dt, u)  # returns new solution
+    precice_dt = precice.advance(dt)
+    t = t + dt
+
+precice.finalize()  # frees data structures and closes communication channels
+```
+  </div>
+</div>
+

--- a/pages/docs/couple-your-code/couple-your-code-time-step-sizes.md
+++ b/pages/docs/couple-your-code/couple-your-code-time-step-sizes.md
@@ -8,6 +8,12 @@ redirect_from:
 ---
 
 In previous steps, you have already seen that there are quite some things going on with time step sizes. Let us now have a look at what is actually happening.
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-1" data-toggle="tab">C++</a></li>
+    <li><a href="#python-1" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-1" markdown="1">
 
 ```cpp
 ...
@@ -26,6 +32,27 @@ while (not simulationDone()){ // time loop
 }
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-1" markdown="1">
+
+```python
+...
+solver_dt = 0 # solver time step size
+precice_dt = 0 # maximum precice time step size
+dt = 0  # actual time step size
+
+precice.initialize()
+while not simulation_done(): # time loop
+  precice_dt = precice.get_max_time_step_size()
+  solver_dt = begin_time_step() # e.g. compute adaptive dt
+  dt = min(precice_dt, solver_dt)
+  solve_time_step(dt) 
+  precice.advance(dt)
+  end_time_step() # e.g. update variables, increment time
+```
+
+</div>
+</div>
 Good thing to know: in this step, you do really not have to alter your code. Everything needed is already there and can be configured. :relieved:
 
 There are basically two options to choose from in the configuration.
@@ -50,24 +77,70 @@ The figure below illustrates this procedure (k is the subcycling index, the dash
 
 * After each time step, both participants tell preCICE which time step size `dt` they just used by calling `precice.advance(dt)`. This way, preCICE can keep track of the total time. `preciceDt` is the remainder time to the next window:
 
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-2" data-toggle="tab">C++</a></li>
+    <li><a href="#python-2" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-2" markdown="1">
+
 ```c++
 preciceDt = precice.getMaxTimeStepSize();
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-2" markdown="1">
+
+```python
+precice_dt = precice.get_max_time_step_size()
+```
+
+</div>
+</div>
 * Both participants compute their next (adaptive) time step size. It can be larger or smaller than the remainder `preciceDt`.
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-3" data-toggle="tab">C++</a></li>
+    <li><a href="#python-3" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-3" markdown="1">
 
 ```c++
 solverDt = beginTimeStep();
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-3" markdown="1">
+
+```python
+solver_dt = begin_time_step()
+```
+
+</div>
+</div>
 If it is larger, the remainder `preciceDt` is used instead (orange participant, dark orange is used).
 If it is smaller, the participant's time step size `solverDt` can be used (blue participant, dark blue is used).
 These two cases are reflected in:
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-4" data-toggle="tab">C++</a></li>
+    <li><a href="#python-4" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-4" markdown="1">
 
 ```c++
 dt = min(preciceDt, solverDt)
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-4" markdown="1">
+
+```python
+dt = min(precice_dt, solver_dt)
+```
+
+</div>
+</div>
 * Once both participants reach the end of the time window, coupling data is exchanged.
 
 {% note %}
@@ -88,6 +161,12 @@ Such small time steps can lead to problems in the solver.
 
 One strategy to avoid this situation is to extend the last time step of a time window preventing problematic time step sizes.
 The follow example extends the time step negotiation between the solver and preCICE to ensure the next time step size `preciceDt - solverDt` stays over some threshold `minDt`.
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-5" data-toggle="tab">C++</a></li>
+    <li><a href="#python-5" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-5" markdown="1">
 
 ```cpp
 ...
@@ -113,6 +192,34 @@ precice.advance(dt);
 ...
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-5" markdown="1">
+
+```python
+...
+solver_dt = begin_time_step() # e.g. compute adaptive dt
+# Can lead to using a dt that only approximately reaches end of time window
+# dt = min(precice_dt, solver_dt);
+
+# Specify a minimal time step size
+min_dt = 10e-14
+if precice_dt - solver_dt < min_dt:
+  dt = precice_dt
+else:
+  dt = solver_dt
+displacements = precice.read_data("FluidMesh", "Displacements", vertex_ids, dt)
+set_displacements(displacements)
+solve_time_step(dt)
+forces = compute_forces()
+precice.write_data("FluidMesh", "Displacements", vertex_ids, forces)
+# if dt = preciceDt, we will exactly reach the end of the window when calling advance
+precice.advance(dt)
+...
+```
+
+</div>
+</div>
+
 {% note %}
 The strategy presented above is only one possibility. Generally, the participant knows best how to determine the allowed time step size and there often are additional requirements you might want to consider, depending on the use case and discretization techniques the participant is using.
 {% endnote %}
@@ -126,29 +233,92 @@ The `first` participant sets the time step size. This requires that the `second`
 * The blue participant B is `first` and computes a step with its time step size (Step 1).
 * In `advance`, this time step size is given to preCICE (Step 2).
 
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-6" data-toggle="tab">C++</a></li>
+    <li><a href="#python-6" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-6" markdown="1">
+
 ```c++
 precice.advance(dt);
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-6" markdown="1">
+
+```python
+precice.advance(dt)
+```
+
+</div>
+</div>
 * preCICE has tracked the time level of the orange participant A and returns the remainder to reach B's time step size.
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-7" data-toggle="tab">C++</a></li>
+    <li><a href="#python-7" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-7" markdown="1">
 
 ```c++
 preciceDt = precice.getMaxTimeStepSize();
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-7" markdown="1">
+
+```python
+precice_dt = precice.get_max_time_step_size()
+```
+
+</div>
+</div>
 * A computes its next (adaptive) time step size. It can now be larger or smaller than the remainder.
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-8" data-toggle="tab">C++</a></li>
+    <li><a href="#python-8" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-8" markdown="1">
 
 ```c++
 solverDt = beginTimeStep();
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-8" markdown="1">
+
+```python
+solver_dt = begin_time_step()
+```
+
+</div>
+</div>
+
 If it is larger, the remainder `preciceDt` is used instead (the case below in Step 3, dark orange is used).
 If it is smaller, the participant's time step size `solverDt` can be used (not visualized).
 These two cases are again reflected in the formula:
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-9" data-toggle="tab">C++</a></li>
+    <li><a href="#python-9" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-9" markdown="1">
 
 ```c++
-dt = min(preciceDt, solverDt)
+dt = min(preciceDt, solverDt);
 ```
+
+</div>
+<div role="tabpanel" class="tab-pane" id="python-9" markdown="1">
+
+```python
+dt = min(precice_dt, solver_dt)
+```
+
+</div>
+</div>
 
 * The procedure starts over with the blue participant B.
 
@@ -163,16 +333,50 @@ You never need to alter your code if you want to switch the first and second par
 ## Steering the end of the simulation
 
 One last thing about time. There is also a helper function in preCICE that allows you to steer the end of a coupled simulation:
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-10" data-toggle="tab">C++</a></li>
+    <li><a href="#python-10" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-10" markdown="1">
 
 ```c++
 bool isCouplingOngoing();
 ```
 
+</div>
+<div role="tabpanel" class="tab-pane" id="python-10" markdown="1">
+
+```python
+is_ongoing = is_coupling_ongoing()
+```
+
+</div>
+</div>
+
 This functions looks at `max-time-windows` and `max-time` as defined in the preCICE configuration and knows when it is time to go. Then, you should call `finalize`. It replaces your `simulationDone()`.
+<ul id="apiTabs" class="nav nav-tabs">
+    <li class="active"><a href="#cpp-11" data-toggle="tab">C++</a></li>
+    <li><a href="#python-11" data-toggle="tab">Python</a></li>
+</ul>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="cpp-11" markdown="1">
 
 ```c++
-while (not precice.isCouplingOngoing()){ // time loop
+while (precice.isCouplingOngoing()){ // time loop
   ...
 }
 precice.finalize();
 ```
+
+</div>
+<div role="tabpanel" class="tab-pane" id="python-11" markdown="1">
+
+```python
+while precice.is_coupling_ongoing(): # time loop
+  ...
+precice.finalize()  
+```
+
+</div>
+</div>


### PR DESCRIPTION
This PR implements the discussions of #211.

Add Python code examples for the `couple your code` section using nav tabs. 