### PR TITLE
Mention precice/config-check on website

### DIFF
--- a/pages/docs/tooling/tooling-builtin.md
+++ b/pages/docs/tooling/tooling-builtin.md
@@ -73,7 +73,7 @@ The `check` runs the preCICE configuration parsing and checking logic on the giv
 This will find the majority of the configuration mistakes without having to start a simulation.
 These checks include wrong tags and attribute values, and more elaborate naming checks.
 More advanced logic, such as checks if all necessary data are exchanged in a coupling scheme, are not covered.
-For more logical checks, see [here](https://github.com/precice/config-check).
+For more logical checks, see the [preCICE config checker](https://github.com/precice/config-check).
 
 The basic usage is to check a configuration file:
 

--- a/pages/docs/tooling/tooling-builtin.md
+++ b/pages/docs/tooling/tooling-builtin.md
@@ -73,6 +73,7 @@ The `check` runs the preCICE configuration parsing and checking logic on the giv
 This will find the majority of the configuration mistakes without having to start a simulation.
 These checks include wrong tags and attribute values, and more elaborate naming checks.
 More advanced logic, such as checks if all necessary data are exchanged in a coupling scheme, are not covered.
+For more logical checks, see [here](https://github.com/precice/config-check).
 
 The basic usage is to check a configuration file:
 


### PR DESCRIPTION
Not fully convinced whether this is the best place to put the reference to the student project, but also could not think of a better place. 
In the near to mid future, we anyways want to re-structure the tooling some more and combine both precice checkers to be executed with the same command (If both are installed, otherwise only the installed one is executed and a message printed that another check exists too).