### PR TITLE
Workshop 2025: Add list of talks and posters

### DIFF
--- a/pages/community/precice-workshop-2025.md
+++ b/pages/community/precice-workshop-2025.md
@@ -9,7 +9,7 @@ redirect_from: /preCICE2025/
 
 <img class="img-responsive center-block" src="images/events/precice2025/precice2025.svg" alt="preCICE Workshop banner" style="max-width: 500px; width: 100%; margin:auto;">
 
-The 6th preCICE Workshop will be held at the [Helmut-Schmidt University of Hamburg](https://www.hsu-hh.de/) on September 8-12, 2025. The workshop is a coming together of the preCICE community to share ideas, experiences and knowledge about using preCICE, and to learn from others in the process. Like always, we plan to have user and developer talks, hands-on training sessions, discussions with the developers about your applications and use cases, and plenty of opportunities for networking. Read more about [how a preCICE workshop looks like](precice-workshop.html).
+The 6th preCICE Workshop will be held at the [Helmut Schmidt University / University of the German Federal Armed Forces Hamburg](https://www.hsu-hh.de/) on September 8-12, 2025, co-organized by the local user group. The workshop is a coming together of the preCICE community to share ideas, experiences and knowledge about using preCICE, and to learn from others in the process. Like always, we plan to have user and developer talks, hands-on training sessions, discussions with the developers about your applications and use cases, and plenty of opportunities for networking. Read more about [how a preCICE workshop looks like](precice-workshop.html).
 
 The workshop will include a hands-on [training course](community-training.html). The course is suited for both beginners and current preCICE users, since advanced topics will also be covered. We will extend the course by a new module on HPC.
 
@@ -94,20 +94,247 @@ Preliminary schedule:
 - Wednesday (main workshop):
   - 09:00-12:00 Training course, part 6 (new)
   - 12:00-13:00 Lunch
-  - 13:00-18:00: Introduction and (user/developer) talks
+  - 13:00-14:30 Welcome and user introductions
+  - 14:30-15:00 Coffee break
+  - 15:00-16:30 News, part 1
+  - 16:30-18:00 Talks
   - 19:00: Invited dinner at [Alster Lagune](https://alsterlagune.de/)
 - Thursday (main workshop):
   - 09:00-10:00 Keynote talk: [Daniel J Bodony](https://aerospace.illinois.edu/directory/profile/bodony)
-  - 10:00-10:30 Talks
+  - 10:00-10:30 News, part 2
   - 10:30-12:00 Poster session
   - 12:00-13:00 Lunch
-  - 13:00-18:00 Talks, World Café
+  - 13:00-15:00 Talks
+  - 15:00-15:30 Coffee break
+  - 15:30-16:30 Talks
+  - 16:30-16:45 Group photo
+  - 16:45-18:00 World Café
 - Friday (main workshop):
   - 09:00-12:00 User support session
   - 12:00-13:00 Lunch
   - 13:00-15:00 User support session
 
 A few weeks after the workshop, we will also have an online follow-up user support session (TBA).
+
+### News
+
+<details class="workshop-event" id="news-library"><br/>
+  <summary>
+  News on the preCICE coupling library<br/>
+  <p>Frédéric Simonis (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Simonis/">webpage</a>, <a href="https://github.com/fsimonis">GitHub</a>)</p>
+  </summary>
+  <p>New features, fixes, and plans in the core library. A deeper look into the <a href="https://github.com/precice/precice/releases/tag/v3.2.0">v3.2.0</a> release notes and further developments since (<a href="https://github.com/precice/precice/tree/develop/docs/changelog">changelog entries</a>, <a href="https://github.com/precice/precice/milestone/27?closed=1">v3.3.0 milestone</a>, <a href="./fundamentals-roadmap.html">roadmap</a>).</p>
+</details>
+<details class="workshop-event" id="news-ecosystem"><br/>
+  <summary>
+  News on the preCICE coupling ecosystem<br/>
+  <p>Gerasimos Chourdakis (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Chourdakis/">webpage</a>, <a href="https://github.com/MakisH">GitHub</a>)</p>
+  </summary>
+  <p>Updates on the available bindings, adapters, tutorials, and further tools built on top of the core library and included in the <a href="./installation-distribution.html">preCICE distribution</a>.</p>
+</details>
+<details class="workshop-event" id="news-preeco"><br/>
+  <summary>
+  News on the standardization process<br/>
+  <p>Benjamin Uekermann (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Uekermann-00001/">webpage</a>, <a href="https://github.com/uekerman">GitHub</a>)</p>
+  </summary>
+  <p>Updates on the standardization process and the DFG project preECO, including <a href="https://precice.org/community-guidelines-adapters.html">guidelines for adapters</a> and <a href="https://precice.org/community-guidelines-application-cases.html">guidelines for application cases</a>.</p>
+</details>
+<details class="workshop-event" id="news-tooling"><br/>
+  <summary>
+  News on the automation tools<br/>
+  <p>Felix Neubauer (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Neubauer-00007/">webpage</a>, <a href="https://github.com/Logende">GitHub</a>)</p>
+  </summary>
+  <p>Overview of new automation tools such as the <a href="https://github.com/precice/cli">preCICE command-line interface</a>, <a href="https://github.com/precice/case-generate">configuration generator</a>, <a href="https://github.com/precice/config-check">configuration checker</a>, and more.</p>
+</details>
+
+### Talks
+
+<details class="workshop-event" id="talk-birken"><br/>
+  <summary>
+  A time adaptive Quasi-Newton Waveform method for partitioned dynamic coupling<br/>
+  <p>Philipp Birken* (<a href="https://www.maths.lu.se/english/research/staff/philipp-birken/">webpage</a>), Niklas Kotarsky<br/>
+  Lund University, Sweden</p>
+  </summary>
+  <p>We consider coupled time dependent partial differential equations on separate domains, This can be used to model conjugate heat transfer, but also the transfer of wind stress between ocean and atmosphere, or flutter of airplanes. Our interest is in so called waveform relaxation. There, the subproblems are solved iteratively on a time window, given an approximation of the solution to the other problem. These methods open up variable time steps and time adaptivity while using separate codes for the subproblem. They can be combined with a relaxation step or Quasi-Newton acceleration.
+  <br/><br/>
+  We present a novel time adaptive Quasi-Newton waveform method. This employs a fixed auxiliary time grid to define the Quasi-Newton method, leading to an interpolation error. This error can be controlled through the choice of the auxiliary grid. The method is amenable for implementation in a coupler such as preCICE and is in fact part of the current release. We discuss theoretical  properties for the linear case and demonstrate its performance on a thermal transfer test case and a fluid-structure interaction test case in a setup with open Source PDE solvers, coupled to preCICE.</p>
+</details>
+
+<details class="workshop-event" id="talk-caccia"><br/>
+  <summary>Coupled Multibody and 3D Structural Dynamics Simulations with MBDyn, CalculiX, and preCICE
+  <p>Claudio Caccia* (<a href="https://www.aero.polimi.it/en/staff/claudiogiovanni.caccia">webpage</a>, <a href="https://github.com/Ccaccia73">GitHub</a>), Pierangelo Masarati<br/>
+  Politecnico di Milano, Italy</p>
+  </summary>
+  <p>Multibody dynamics (MBD) provides an efficient framework for simulating flexible structures, especially when using beam or shell elements. However, in regions where complex stress distributions occur, simplified models fail to be informative, and a full 3D structural model is required. This presentation outlines a methodological approach for integrating the multibody solver MBDyn with the finite element solver CalculiX through the use of preCICE. The integration of these approaches allows the execution of simulations that are both efficient in terms of computational resources and detailed in their representation of structural dynamics.
+  <br/><br/>
+  This coupling strategy can also reproduce well-established structural modeling techniques, such as RBE2 or RBE3 elements, but applied across different solvers. The presentation will include case studies that demonstrate the methodology in action, emphasizing its capacity for fast and efficient structural dynamics simulations.
+  <br/><br/>
+  Beyond structural simulations, preCICE also enables coupling with computational fluid dynamics solvers, extending this methodology to fluid-structure interaction problems, such as helicopter blade aeroelasticity. Furthermore, the adaptability of this methodology ensures its efficacy in a broad spectrum of coupled problems, thereby facilitating the simulation of intricate engineering systems while maintaining optimal computational efficiency.</p>
+</details>
+
+<details class="workshop-event" id="talk-chen"><br/>
+  <summary>Bound-Aware Quasi-Newton Strategies for Partitioned Coupling in preCICE
+  <p>Jun Chen* (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Chen-00029/">webpage</a>, <a href="https://github.com/Fujikawas">GitHub</a>), Miriam Schulte<br/>
+  University of Stuttgart, Germany</p>
+  </summary>
+  <p>In partitioned multi-physics simulations and in preCICE, quasi-Newton (QN) methods are widely used to accelerate convergence at the coupling interface. However, standard QN schemes often disregard bound constraints arising from the underlying physic-such as saturation or pressure limits in porous media-resulting in physical values exceeding the prescribed bounds and reduced robustness. In this talk, we present and compare several bound-aware QN approaches designed to handle such constraints effectively within the preCICE framework.
+  We focus on modular methods that balance step length control, projection techniques, and space-splitting strategies that separate trusted and extrapolated components of the update. These methods aim to balance convergence speed with physical feasibility, especially in strongly nonlinear or ill-scaled settings. The fundamental principles and the trade-offs between the various methods will be discussed, with conclusions drawn from experiments in designed scenarios involving bounded variables.
+  All methods are being implemented and tested in preCICE. The goal is to make these strategies accessible and beneficial to users facing similar challenges when coupling scenarios involving physically meaningful bounds.</p>
+</details>
+
+<details class="workshop-event" id="talk-kleiner"><br/>
+  <summary>Coupled simulations of ice sheet dynamics and subglacial hydrology of the Greenland Ice Sheet: insights into performance
+  <p>Daniel Abele, Thomas Kleiner* (<a href="https://www.awi.de/ueber-uns/organisation/mitarbeiter/detailseite/thomas-kleiner.html">webpage</a>), Angelika Humbert<br/>
+  Alfred-Wegener-Institut, Helmholtz-Zentrum für Polar- und Meeresforschung, Bremerhaven, Germany</p>
+  </summary>
+  <p>Ice sheet dynamics strongly depend on sliding at the glacier base and, therefore, on the subglacial hydrology. Correspondingly, the glaciers influence the hydrological system through, e.g., ice overburden pressure and melt water generated by geothermal and frictional heat. Because of this interaction, coupled simulations of the system are required. We use preCICE to couple the finite element Ice-sheet and Sea-level System Model (ISSM) and CUAS-MPI, a parallel implementation of the Confined-Unconfined Aquifer System model for subglacial hydrology based on finite differences.
+  <br/><br/>
+  We present our recent progress on the preCICE adapters for both models (solvers) and the coupling setup, including work on preECO standard conformity and the adoption of the adapter configuration schema. Performance measurements are conducted using a real-world scenario that simulates the entire Greenland Ice Sheet, where we compare serial and parallel coupling. We also discuss the technical realisation of the coupling workflow on a high-performance computing cluster. The performance results show that coupling with preCICE has low computational overhead and does not negatively impact scaling.</p>
+</details>
+
+<details class="workshop-event" id="talk-ponce-tovar"><br/>
+  <summary>Volume-coupled nuclear reactor analysis with preCICE
+  <p>Mario A. Ponce Tovar* (<a href="https://www.psi.ch/de/lrt/people/mario-adolfo-ponce-tovar">webpage</a>), Cynthia C. Güttlein, Ivor D. Clifford, Alexey Cherezov, Hakim Ferroukhi<br/>
+  Paul Scherrer Institut, ETH Zurich, Switzerland</p>
+  </summary>
+  <p>Since the release of the preCICE library, it has garnered growing interest within the nuclear energy community. Multiphysics coupling, and particularly black-box coupling, is highly relevant within the field due to the multitude of considered phenomena and the large quantity of established single-physics codes that are present. Coupling needs have traditionally been met by bespoke coupling implementations (lacking generality and performance), or by employing generalized PDE frameworks such as OpenFOAM or MOOSE which limit the user to a single discretization method. Given that preCICE offers an antidote to these limitations, it has already been applied to both fission and fusion reactor analysis with success. However, the examples in the available literature have been limited to surface-coupled and multi-fidelity “high-low” applications, leaving out the most critical coupled problem in fission reactor analysis. Now, leveraging the volume-coupling capabilities of preCICE v3, we have modelled a coupled fission microreactor with time-dependent neutronics and thermal feedback. Furthermore, we plan to develop a complete open-source toolchain for such reactors—with preCICE as the backbone. This talk will give an overview of the coupled codes/frameworks, the results of a preliminary benchmark which compares preCICE with internal coupling, and how we envision the advanced features of the library being employed going forward.</p>
+</details>
+
+<details class="workshop-event" id="talk-thornton"><br/>
+  <summary>Coupling Particle Simulations: Challenges, Strategies, and the ON-DEM Vision
+  <p>Anthony Thornton*, Thomas Weinhart, Daniel Bareto<br/>
+  University of Manchester, UK</p>
+  </summary>
+  <p>The Discrete Particle Method (DPM), aka Discrete Element Method (DEM), simulates the motion and interaction of individual grains and has proven highly successful in modelling granular processes. However, tackling the next generation of challenges—such as multiphysics interactions and multiscale phenomena—requires coupling DPM with continuum solvers for fluids and deformable solids. Additionally, the growing complexity of industrial processes is pushing the limits of DEM, which remains computationally intensive. This calls for flexible, efficient coupling strategies to extend the capabilities of DEM. In this talk, we present the main types of DEM coupling currently used in the field. We focus on three key approaches: Surface coupling, which models the interaction between granular materials and soft or deformable boundaries; Volume coupling, which allows hybrid modelling where some regions are simulated with DEM and others with a continuum approach—enhancing scalability without sacrificing accuracy; Particle–fluid coupling, which models the interaction of particles with a background fluid or thermal field. We also introduce the newly funded European COST network ON-DEM (Open Network on DEM simulations), which aims to accelerate progress in this area. We conclude by discussing the integration of the coupling library preCICE, highlighting its potential as a key enabler for ON-DEM's goals and the broader future of particle simulation.</p>
+</details>
+
+<details class="workshop-event" id="talk-simonis"><br/>
+  <summary>Dynamic Meshes in preCICE
+  <p>Frédéric Simonis* (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Simonis/">webpage</a>, <a href="https://github.com/fsimonis">GitHub</a>), Benjamin Uekermann<br/>
+  University of Stuttgart, Germany</p>
+  </summary>
+  <p>preCICE is an open-source coupling library for partitioned multi-physics simulations. It provides a flexible framework for exchanging mesh-based data between different simulation codes, enabling the simulation of complex multi-physics problems involving multiple solvers. These solvers may run on massively parallel systems with large meshes partitioned among their ranks. To facilitate leveraging parallel systems, preCICE requires solver meshes to remain static during the simulation. This restricts users in need of moving geometries to either using ALE methods relying on a static reference domain, or to use direct-mesh access and handle data-mapping themselves. In this talk, I showcase the current state of dynamic meshes to preCICE as well as cost-effective use-cases. This includes the necessary orchestration to ensure a consistent state between solvers, the challenges of handling the shift of work from one-time to reoccurring operations, and open questions regarding implicit coupling.</p>
+</details>
+
+<details class="workshop-event" id="talk-steldermann"><br/>
+  <summary>Fluid-Fluid coupling across models and dimensions: From OpenFOAM to FEniCS
+  <p>Ingo Steldermann* (<a href="https://www.mbd.rwth-aachen.de/cms/mbd/Der-Lehrstuhl/Team/~qqpkz/Ingo-Steldermann/lidx/1/">webpage</a>), Julia Kowalski<br/>
+  RWTH Aachen University, Germany</p>
+  </summary>
+  <p>When designing simulation software for fluid-flow applications, it is usually not about 'how accurate can we go?' but rather about 'how accurate do we want to be given resource X?'.
+  One strategy to combine sophisticated models where they are needed with coarse-grained models when they are sufficient is coupling. In the field of free-surface fluid flow simulations, such ideas are hardly new. However, there are numerical challenges to overcome when coupling different flow models, which may also involve changes in their dimensionality.
+  The trio of preCICE, OpenFOAM and FEniCS enables modelers to quickly get where they need to be - at the coupling interface between existing solutions and new research ideas. In this talk, we showcase our journey with preCICE on how to couple a 3d RANS flow model of OpenFOAM, with our implementation of the shallow moment equations in 2d.
+  The shallow moment equations are a model hierarchy with the classical shallow water equations at its base. They are an interesting coupling partner as they allow for an adaptive resolution of the flow variables at the interface.
+  We analyze the impact of the projection error introduced at the coupling interface and how it changes across the model hierarchy, flow conditions, and flow direction.</p>
+</details>
+
+### Posters
+
+<details class="workshop-event" id="poster-bove"><br/>
+  <summary>
+    Multi-fidelity approaches for the non- linear aeroelastic assessment of the Pazy Wing<br/>
+    <p>Alessia Bove*, Claudio Giovanni Caccia, Giuseppe Quaranta, Pierangelo Masarati<br/>Politecnico di Milano, Italy</p>
+  </summary>
+  <p>The Pazy Wing was designed, built and tested with the objective of establishing a novel experimental standard to evaluate the validity of diverse numerical methodologies in accurately identifying the aeroelastic behaviour of a lifting surface undergoing deformations up to 50% of its span.
+  The present study is aimed at investigating the aeroelastic behavior of such wing,  addressing also the LCOs (limit cycle oscillations) nature by means of a series of coupled, time marching simulations. The structural model is implemented in MBDyn, while the fluid one leverages the capabilities of various aerodynamic methods, namely those of the:
+  <br/>
+  - Strip Theory, built in MBDyn used with and without a tip losses correction model;
+  - Panel Method (PM) and Vortex Lattice Method (VLM), both built in Dust software, coupled to MBDyn by means of preCICE;
+  - CFD, coupling OpenFoam to MBDyn by means of preCICE. The results obtained using the VLM and the PM were in good agreement with the data gathered in wind tunnel tests and allowed to address the LCOs nature to structural non linearities and 3D aerodynamics. The CFD was used to confirm the preceding outcomes. Owing to the substantial deformation of the wing, which would generate an excessive distortion of the fluid mesh, simulations were executed starting from a pre-deformed configuration reached by the wing through a sequence of preliminary iterations employing the strip theory (utilising MBDyn exclusively) prior to the initiation of the coupling.</p>
+</details>
+<details class="workshop-event" id="poster-desai"><br/>
+    <summary>
+      Micro Manager: a tool to faciliate multiscale coupling with preCICE<br/>
+      <p>Ishaan Desai* (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Desai/">webpage</a>, <a href="https://github.com/IshaanDesai">GitHub</a>), Carina Bringedal, Benjamin Uekermann<br/>
+      University of Stuttgart, Germany</p>
+    </summary>
+    <p>For many multiscale applications in simulation technology, micro-scale phenomena dominate macro-scale behavior. Accurately resolving micro-scale effects on the macro-scale involves a coupling between one macro-scale model to a large number of micro-scale models. In this work, we present the Micro Manager, a software solution to couple models at different length scales using preCICE. preCICE is designed to couple two or more simulations on the same scale. The Micro Manager creates a large number of micro simulations from a user-created library, and adaptively controls them. This approach reuses coupling functionality of preCICE while also preserving the black-box coupling philosophy. The Micro Manager has two adaptivity strategies. In the first strategy, the micro simulations are marked as active or inactive based on a user-tuned similarity criteria. To get the complete micro-scale solution field, the inactive simulations are associated to their most-similar active counterparts. In the second strategy, the user provides not just one model as a micro simulation, but instead a hierarchy of surrogate models. To create these surrogate models, the Micro Manager has a snapshot creation functionality. Based on a user-defined rule-set, the Micro Manager switches from a full-order model to a reduced-order model. In this poster, we show a diverse range of applications using the Micro Manager, and discuss scalability and HPC aspects of solving realistic multiscale scenarios.</p>
+</details>
+<details class="workshop-event" id="poster-hoen"><br/>
+  <summary>
+    Development of a preCICE adapter for foam-extend<br/>
+    <p>Patrick Höhn* (<a href="https://github.com/hoehnp">GitHub</a>)<br/>
+    University of Göttingen, Germany</p>
+  </summary>
+  <p>Drilling for sub-surface energy (oil, gas, geothermal heat) is crucial but expensive, accounting for large parts of project costs. Efficient transport of cuttings from the drill-bit to the surface is essential, but in-situ measurements of drilling parameters are challenging. Many investigations rely on simplified laboratory setups and software-based simulations. The research problem studied by the author aims to evaluate the influence of cuttings transport on the damping of lateral vibrations in drill strings. A simulation consisting of particle transport and fluid-structure interaction is required to understand the complex phenomena. The multiphysics library preCICE is used to achieve the coupling between the different physical processes. The presentation discusses the differences between OpenFOAM.org and foam-extend, and the adjustments made to the preCICE adapter for the different foam-extend versions. A test-case demonstration will be presented to showcase the capabilities of the preCICE adapter.</p>
+</details>
+<details class="workshop-event" id="poster-homs-pons"><br/>
+    <summary>
+      Coupled Multi-Physics Simulation of the Agonist-antagonist Myoneural Interface<br/>
+      <p>Carme Homs-Pons* (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Homs-Pons/">webpage</a>, <a href="https://github.com/carme-hp">GitHub</a>), Miriam Schulte<br/>
+      University of Stuttgart, Germany</p>
+    </summary>
+    <p>The agonist-antagonist myoneural interface (AMI) is a novel amputation technique that would benefit from in silico experiments to support the identification of optimal physiological and anatomical parameters.
+    We model the AMI as a two-muscle-one-tendon system. In particular, we model the mechanical coupling between the muscles, and the coupling through the sensory reflex pathways. We model each muscle using a coupled electrophysiology-mechanics model. This way, we are able to capture the main processes that influence the coupling between the muscles: neural activation, generation of force at the cellular level, propagation of electrical signals through the fibers, and macroscopic deformation.
+    We implement our model following a monolithic simulation approach, and compare it to a partition simulation approach using preCICE. We also show our updates in the OpenDiHu adapter in order to support the exchange sensory data. These updates are needed to model the sensory feedback loop between the agonist-antagonist muscle pairs, and allow us to run three-participant simulations including both mechanical and sensory coupling. In future work, we will model the AMI using a five-participant simulation approach with preCICE.</p>
+</details>
+<details class="workshop-event" id="poster-lesquoy"><br/>
+    <summary>
+      Investigating Data Mapping and Coupling Schemes in preCICE for Partitioned FSI<br/>
+      <p>Nicolas Lesquoy* (<a href="https://github.com/nicolaslesquoy">GitHub</a>), Guillaume de Nayer, Michael Breuer<br/>
+      Helmut Schmidt University Hamburg, Germany</p>
+    </summary>
+    <p>The partitioned approach to Fluid-Structure Interaction (FSI) simulation offers notable advantages over the monolithic approach, particularly in terms of development time, flexibility, and modularity. However, setting up such simulations can be challenging, especially in black-box coupling scenarios where limited information is provided by the solvers to the coupling library. This work aims to assess the characteristics and performance of the coupling procedures implemented in preCICE, focusing on its integration into the in-house CFD solver FASTEST-3D and the open-source structural solver CalculiX. Data mapping methods will be evaluated using the ASTE testing environment, with particular attention given to RBF-based approaches. Another key objective is to understand the coupling schemes available in preCICE, with an emphasis on quasi-Newton methods. The influence of different coupling configurations with regards to various mapping techniques and coupling scheme combinations, will be investigated using standard numerical benchmarks such as the flexible lid-driven cavity problem and the Hron/Turek FSI3 benchmark. These studies will enable a comprehensive performance evaluation on a modern computing cluster, focusing on runtime, scalability, and accuracy. Ultimately, this work aims to advance the understanding of partitioned coupling strategies for FSI problems and to identify best practices for achieving robust and efficient simulations using preCICE.</p>
+</details>
+<details class="workshop-event" id="poster-li"><br/>
+    <summary>
+      Isogeometric Analysis-Based Partitioned Fluid-Structure Interaction with Fully Coupled Mesh Generation<br/>
+      <p>Jingya Li* (<a href="https://www.tudelft.nl/en/eemcs/the-faculty/departments/applied-mathematics/people/j-jingya-li-msc">webpage</a>, <a href="https://github.com/Crazy-Rich-Meghan/">GitHub</a>), Ye Ji, Hugo Verhelst, Matthias Möller<br/>
+      Delft University of Technology, The Netherlands</p>
+    </summary>
+    <p>In fluid–structure interaction (FSI), the coupling between a deformable solid and a moving fluid takes place along a continuously evolving interface. Accurately and stably resolving this interaction becomes especially demanding when the structure undergoes large deformations, significantly affecting the surrounding fluid domain. Instead of relying on conventional mesh deformation techniques, we adopt a partitioned FSI approach that avoids continuous mesh motion.
+    <br/><br/>
+    In this framework, specialized solvers for the fluid and structural fields are coupled iteratively across their shared interface. At each time step, we generate a new high-order, analysis-suitable fluid mesh based on the latest interface configuration, eliminating the need for mesh-to-mesh projection. The interface geometry is provided by an Isogeometric Analysis (IGA)-based structural solver (G+Smo), and passed to the fluid solver through a spline-based coupling strategy that accommodates non-matching discretizations. This ensures smooth and accurate transfer of physical quantities—such as velocity, pressure, and displacement—across the interface. The resulting pipeline is both robust and efficient, particularly in simulations involving large structural motions and complex geometric evolution.</p>
+</details>
+<details class="workshop-event" id="poster-neubauer"><br/>
+    <summary>
+      Standardizing preCICE Adapters with MetaConfigurator<br/>
+      <p>Felix Neubauer* (<a href="https://www.ipvs.uni-stuttgart.de/de/institut/team/Neubauer-00007/">webpage</a>, <a href="https://github.com/Logende">GitHub</a>), Gerasimos Chourdakis, Benjamin Uekermann<br/>
+      University of Stuttgart, Germany</p>
+    </summary>
+    <p>Interoperability and standardization are essential for the growing ecosystem of preCICE adapters. We present a JSON Schema-based specification for preCICE adapter configurations, complemented by comprehensive guidelines for adapter development. By formalizing configuration structures, we enable automated validation, tooling support, and improved documentation, while ensuring that adapters themselves adhere to shared standards. As a central tool, MetaConfigurator provides a schema-driven web interface that simplifies the creation and validation of configuration files, lowering the entry barrier for both adapter developers and users. This approach supports the FAIR principles by promoting interoperability and reusability not only of configuration files, but of the adapters and coupling setups themselves, fostering a more robust and sustainable preCICE ecosystem.</p>
+</details>
+<details class="workshop-event" id="poster-palani"><br/>
+    <summary>
+      A preCICE coupled fire-structure framework for predicting smoke leakage in and progressive collapse of fire-exposed concrete structures<br/>
+      <p> Arulnambi Palani* (<a href="https://www.hsu-hh.de/pfs/wma">webpage</a>), Max Rottmann, Chaitanya Kandekar, Michael Breuer, Wolfgang E. Weber<br/>
+      Helmut Schmidt University Hamburg, Germany</p>
+    </summary>
+    <p>Modeling damage due to under mechanical loading is quite well understood for large structures, e.g., buildings; however, predicting structural integrity under fire exposure remains a complex task. Elevated temperatures significantly degrade load-bearing capacities, critically complicating rescue operations. Firefighters must accurately predict safe evacuation routes based on structural integrity assessments and smoke distributions within building. Addressing this issue necessitates a coupled multi-physics and multi-scale computational approach. This research introduces an enhanced partitioned framework integrating distinct simulation software packages, coupled via preCICE. The fluid flow and combustion processes and the resulting smoke propagation are simulated using the Fire Dynamics Simulator employing large-eddy simulation. Structural response and progressive collapse due to load redistribution across scales are calculated using Abaqus. Thermo-mechanical damage, including crack propagation are computed via a FEniCS-based phase-field solver with thermal boundary conditions stemming from the fire simulation and the displacement field stemming from the structural solver. The coupling framework dynamically updates the geometry in both simulations based on evolving structural damage, facilitating accurate predictions of smoke leakage and structural integrity. A numerical example demonstrates the framework’s capability in forecasting damage</p>
+</details>
+<details class="workshop-event" id="poster-schmiedel"><br/>
+    <summary>
+      Ice-sheet and subglacial-hydrology simulations coupled through preCICE<br/>
+      <p>Jeremie Schmiedel*, Roiy Sayag<br/>
+      Ben-Gurion University of the Negev, Israel</p>
+    </summary>
+    <p>Subglacial networks at the ice-bed interface are considered a key component of ice sheet dynamics with the potential to facilitate rapid ice flow and to trigger the formation of surges and ice streams. Various numerical methods have been developed to simulate the effects of such networks on ice flow. Validation of these models is crucial to ensure that the important subglacial physical processes are accurately captured. We investigate numerically the interaction of the subglacial network and the ice flow. We do that by coupling the Ice-sheet and Sea-level System Model (ISSM) with the confined–unconfined aquifer system (CUAS-MPI) hydrology model using preCICE. Having validated each of the numerical simulations separately, our goal in this study is to validate the coupled system using known solutions of lubricated gravity currents. These are, viscous flows driven by gravity that consist of two immiscible fluids that propagate along a solid substrate, and interact at their common interface. One fluid of lower viscosity, simulated by CUAS-MPI, lubricates the flow of a more viscous fluid, simulated by ISSM. Such flow system exhibits self-similar solutions, which we use for validation. The results of such a validated coupled approach are more credible and can consequently lead to more accurate predictions of ice sheets evolution.</p>
+</details>
+<details class="workshop-event" id="poster-schneider"><br/>
+    <summary>
+      Flexible mesh-particle coupling with preCICE<br/>
+      <p>David Schneider* (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Schneider-00056">webpage</a>, <a href="https://github.com/DavidSCN">GitHub</a>), Benjamin Uekermann<br/>
+      University of Stuttgart, Germany</p>
+    </summary>
+    <p>Recent efforts inside preCICE target specifically the coupling of mesh-based solvers with particle solvers. In earlier preCICE versions, these kind of coupling scenarios were intricate to realize due to the rigid mesh concept of preCICE. The traditional concept in preCICE requires users to define a coupling mesh initially once, before starting the simulation, and then use the defined coupling mesh throughout the simulation. This concept fundamentally contradicts the behavior of particle methods, which change their location within each timestep. With the newly developed just-in-time mapping or direct mesh access we are now able to loosen up the rigid concept and perform data mappings on variable spatial locations within each timestep. This poster shows the concept, its application and numerical results.</p>
+</details>
+<details class="workshop-event" id="poster-vidulejs"><br/>
+    <summary>
+      Coupling Neural Surrogates to Traditional Solvers using preCICE<br/>
+      <p>Dagis Daniels Vidulejs* (<a href="https://github.com/vidulejs">GitHub</a>), Benjamin Uekermann<br/>
+      University of Stuttgart, Germany</p>
+    </summary>
+    <p>Simulating systems of PDEs arising from physics often requires computationally intensive algorithms. While Neural Network (NN)-based surrogate models can accelerate solution times and reduce computational resource requirements, their current lack of reusability and solver modularity, where learned models often cannot be reused without re-training, hinders their adoption in scientific computing. We explore and develop an approach for coupling neural surrogate models with traditional solvers in a partitioned setup. Presenting - a new preCICE adapter for coupling neural surrogates, enabling the plug-and-play integration of data-driven and /or physics-informed models into larger simulation ecosystems.</p>
+</details>
+<details class="workshop-event" id="poster-vinnitschenko"><br/>
+    <summary>
+      Solving Partitioned Problems with FEniCSx and preCICE<br/>
+      <p> Niklas Vinnitchenko* (<a href="https://github.com/NiklasVin">GitHub</a>), Ishaan Desai, Angelika Humbert, Benjamin Uekermann, Benjamin Rodenberg<br/>
+      Technical University of Munich, Germany</p>
+    </summary>
+    <p>FEniCSx, the successor of FEniCS, is an open-source computation platform designed to solve partial differential equations with the finite element method. It offers a high-level interface that provides functionalities that cover most of the simulation pipeline. The Python-based interface DOLFINx, along with the UFL library, simplifies the translation of mathematical models into efficient code.
+    In this poster, we present the first feature-complete version of the FEniCSx-preCICE adapter, highlighting just-in-time mapping, communication of multiple data on multiple meshes and support for 3D coupling. With the partitioned heat equation solved with a FEniCSx-FEniCSx setup and a FEniCSx-OpenFOAM simulation of a fluid flowing over a heated plate we show potential use cases for the adapter and evaluate its performance.</p>
+</details>
 
 ## Travel awards
 

--- a/pages/community/precice-workshop-organizing.md
+++ b/pages/community/precice-workshop-organizing.md
@@ -91,6 +91,8 @@ The abstract submission form should collect:
 - Presenter
 - Authors
 - Affiliations
+- Webpage (optional)
+- GitHub handle (optional)
 - Contact email
 - Title
 - Abstract (plain text, max 1500 chars including spaces)


### PR DESCRIPTION
This PR:

- Extends the name of the host university and clarifies the context
- Updates the schedule to fit more news, but does not yet add schedule each talk
- Adds a list of (yet unscheduled) talk and posters
- Extends the organizing guide to ask for webpage and GitHub information in the abstract submission form

Each talk and poster is a collapsible element, including:

- Title, as submitted (mixed title/sentence case)
- List of authors
- An asterisk for the presenter
- A publicly known organization webpage and publicly known GitHub profile, to the best of my knowledge
- University, city (if not obvious), country. Not always in English ("Institut", "Göttingen", "Politecnico di Milano")
- Abstract (in the detailed view)

Rendered, the list looks as follows:

![Screenshot 2025-07-04 at 14-45-41 preCICE workshop 2025 preCICE - The Coupling Library](https://github.com/user-attachments/assets/cd3b194b-391e-4ce9-9ab9-0c163bb624b6)

