### PR TITLE
Workshop 2025: Extend registration deadline

### DIFF
--- a/_includes/news_banner.html
+++ b/_includes/news_banner.html
@@ -9,7 +9,7 @@
     <div class="row no-margin">
       <div class="col-lg-12 banner">
         <p class="no-margin">
-          Register for the <a href="precice-workshop-2025.html">preCICE Workshop 2025, Hamburg, Sep 8-12 </a> till July 15.
+          Register for the <a href="precice-workshop-2025.html">preCICE Workshop 2025, Hamburg, Sep 8-12 </a> till July 29 (extended).
         </p>
       </div>
     </div>

--- a/pages/community/precice-workshop-2025.md
+++ b/pages/community/precice-workshop-2025.md
@@ -28,7 +28,7 @@ We are looking for talks and posters that could be beneficial for the wider preC
 - Abstract submission deadline: June 14 (extended)<br/>
   Expect news on your submission two weeks later.<br/>
   You don't need to submit a contribution in order to attend.
-- Registration deadline: July 15.
+- Registration deadline: July ~~15~~ 29 (extended).
 
 ## Registration
 


### PR DESCRIPTION
Extends the registration deadline to July 29 in the "important dates" and in the news header.

@uekerman feel free to adapt the date and merge whenever you want.