### PR TITLE
Remove preCICE mailing list

### DIFF
--- a/pages/community/community-channels.md
+++ b/pages/community/community-channels.md
@@ -22,7 +22,6 @@ Apart from Matrix & Discourse, you can also:
 - Follow us on [Mastodon](https://fosstodon.org/@precice) and on [Bluesky](https://bsky.app/profile/precice.org).
 - Subscribe to our [YouTube channel](https://www.youtube.com/c/preCICECoupling/).
 - Join our [LinkedIn group](https://www.linkedin.com/groups/9073912/).
-- Subscribe to our [mailing list](https://mailman.informatik.uni-stuttgart.de/mailman/listinfo/precice) (only a few announcement emails per year).
 - Create an alert on Google Scholar for citations to our reference papers: [v1, 2016](https://scholar.google.de/scholar?cites=5053469347483527186&as_sdt=2005&sciodt=0,5&hl=en), [v2, 2021](https://scholar.google.com/scholar?hl=en&cites=17974677460269868025).
 
 Apart from the above channels, we hope to see you in one of our [preCICE workshops](precice-workshop.html).

--- a/pages/community/precice-workshop-organizing.md
+++ b/pages/community/precice-workshop-organizing.md
@@ -140,7 +140,6 @@ Further places where we typically advertise are:
 
 - preCICE channels:
   - forum
-  - mailing list (phasing out)
   - chatroom
   - [social media](https://precice.org/community-channels.html)
 - Local communities:

--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -46,13 +46,11 @@ editme: false
 
 ## 5.  Providing your personal data to others
 
-5.1 Your contact and communication data will be collected, processed and stored using the mailman system of the [Department of Computer Science at the University of Stuttgart](https://www.f05.uni-stuttgart.de/en/cs/). You can manage your subscription preferences for the preCICE mailing list at [https://mailman.informatik.uni-stuttgart.de/mailman/listinfo/precice](https://mailman.informatik.uni-stuttgart.de/mailman/listinfo/precice).
+5.1 Your contact and communication data when using the preCICE online forum [precice.discourse.group](https://precice.discourse.group/) will be collected, processed and stored by Civilized Discourse Construction Kit, Inc. You can find information about the online forum providers' privacy policies and practices at [https://www.discourse.org/privacy](https://www.discourse.org/privacy).
 
-5.2 Your contact and communication data when using the preCICE online forum [precice.discourse.group](https://precice.discourse.group/) will be collected, processed and stored by Civilized Discourse Construction Kit, Inc. You can find information about the online forum providers' privacy policies and practices at [https://www.discourse.org/privacy](https://www.discourse.org/privacy).
+5.2   Your registration data will be stored on a secure and access-restricted instance of Nextcloud hosted by the [Institute for Parallel and Distributed Systems (IPVS) at the University of Stuttgart]( https://www.ipvs.uni-stuttgart.de/).
 
-5.3   Your registration data will be stored on a secure and access-restricted instance of Nextcloud hosted by the [Institute for Parallel and Distributed Systems (IPVS) at the University of Stuttgart]( https://www.ipvs.uni-stuttgart.de/).
-
-5.4 In addition to the specific disclosures of personal data set out in this Section 5, we may disclose your personal data to others where such disclosure is necessary for compliance with a legal obligation to which we are subject, or in order to protect your vital interests or the vital interests of another natural person. We may also disclose your personal data where such disclosure is necessary for the establishment, exercise, or defence of legal claims, whether in court proceedings or in an administrative or out-of-court procedure.
+5.3 In addition to the specific disclosures of personal data set out in this Section 5, we may disclose your personal data to others where such disclosure is necessary for compliance with a legal obligation to which we are subject, or in order to protect your vital interests or the vital interests of another natural person. We may also disclose your personal data where such disclosure is necessary for the establishment, exercise, or defence of legal claims, whether in court proceedings or in an administrative or out-of-court procedure.
 
 ## 6. International transfers of your personal data
 


### PR DESCRIPTION
Removes mentions of the mailing list from the website.
I have also removed it from the privacy policy: https://precice.org/privacy.html#5--providing-your-personal-data-to-others

Subscribing and posting to the mailing list now requires admin approval.