### PR TITLE
Add a compatibility notes alert

### DIFF
--- a/_data/alerts.yml
+++ b/_data/alerts.yml
@@ -3,6 +3,7 @@ note: '<div class="alert alert-info" role="alert"><i class="fa fa-info-circle"><
 important: '<div class="alert alert-warning" role="alert"><i class="fa fa-warning"></i> <b>Important: </b>'
 warning: '<div class="alert alert-danger" role="alert"><i class="fa fa-exclamation-circle"></i> <b>Warning: </b>'
 disclaimer: '<div class="alert alert-info" role="alert"><i class="fa fa-fa-hands-wash"></i> <b>Disclaimer: </b>'
+compatibility: '<div class="alert alert-warning" role="alert"><i class="fa fa-fa-puzzle-piece"></i> <b>Compatibility note: </b>'
 end: '</div>'
 
 callout_danger: '<div class="bs-callout bs-callout-danger">'
@@ -12,6 +13,7 @@ callout_success: '<div class="bs-callout bs-callout-success">'
 callout_info: '<div class="bs-callout bs-callout-info">'
 callout_warning: '<div class="bs-callout bs-callout-warning">'
 callout_disclaimer: '<div class="bs-callout bs-callout-disclaimer">'
+callout_compatibility: '<div class="bs-callout bs-callout-compatibility">'
 
 hr_faded: '<hr class="faded"/>'
 hr_shaded: '<hr class="shaded"/>'

--- a/_includes/compatibility.html
+++ b/_includes/compatibility.html
@@ -1,0 +1,1 @@
+<div markdown="span" class="alert alert-warning" role="alert"><i class="fa fa-hands-wash"></i> <b>Compatibility note:</b> {{include.content}}</div>

--- a/_plugins/customblocks.rb
+++ b/_plugins/customblocks.rb
@@ -34,6 +34,13 @@ module Jekyll
     end
   end
 
+  class CompatibilityBlock < Liquid::Block
+    def render(context)
+      text = super
+      '<div markdown="span" class="alert alert-warning" role="alert"><i class="fas fa-puzzle-piece"></i> <b>Compatibility note:</b> ' + text + '</div>'
+    end
+  end
+
   class VersionBlock < Liquid::Block
     def initialize(tag_name, markup, parse_context)
       super

--- a/pages/docs/docs-meta/docs-meta-cheatsheet.md
+++ b/pages/docs/docs-meta/docs-meta-cheatsheet.md
@@ -81,6 +81,10 @@ This is an experimental feature.
 {% disclaimer %}
 This is my important info.
 {% enddisclaimer %}{%endraw%}
+
+{% compatibility %}
+This is a compatibility note.
+{% endcompatibility %}{%endraw%}
 ```
 
 {% note %}
@@ -106,6 +110,10 @@ This is an experimental feature.
 {% disclaimer %}
 This is my important info.
 {% enddisclaimer %}
+
+{% compatibility %}
+This is a compatibility note.
+{% endcompatibility %}{%endraw%}
 
 ## Version information
 


### PR DESCRIPTION
We already have the `version` alert: https://precice.org/docs-meta-cheatsheet.html#version-information, which I only re-discovered after starting to work on this feature.

This is connected to the preCICE version (and checks whether this is a new or old release), but it can also be used without a version argument.

I am not sure if this new compatibility note is needed on top, but we could use it for more than the version-specific incompatibilities, and it would let the `version` alert evolve independently.

I have not yet tested if this works as expected.