### PR TITLE
Clarify CalculiX adapter versions in docs for -fallow-argument-mismatch

### DIFF
--- a/pages/docs/adapters/calculix/adapter-calculix-get-adapter.md
+++ b/pages/docs/adapters/calculix/adapter-calculix-get-adapter.md
@@ -81,7 +81,7 @@ You may also want to adjust the compiler `FC` from `mpifort` to `mpif90` or to a
 
 ### Compiling with GCC 10 or newer
 
-If you compile with GCC 10 or newer, you will get the following error, originating from CalculiX:
+If you compile the adapter (v2.20.1 or earlier) with GCC 10 or newer, you will get the following error, originating from CalculiX:
 
 ```text
 Error: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)


### PR DESCRIPTION
In the context of https://github.com/precice/calculix-adapter/pull/139