### PR TITLE
Add time interpolation example using different time scales

### DIFF
--- a/pages/docs/couple-your-code/couple-your-code-waveform.md
+++ b/pages/docs/couple-your-code/couple-your-code-waveform.md
@@ -94,10 +94,10 @@ while (not simulationDone()){ // time loop
 ### Different time scales
 
 For solvers operating on different time-scales, the solver with the smaller time-step size may need smooth input data.
-In this case the solver with the smaller step size may call `readData()` with `dt=0` to sample data at the beginning of each of it's time steps.
+In this case the solver with the smaller step size may call `readData()` with `relativeReadTime=0` to sample data at the beginning of each of its time steps.
 By default, this results in piecewise linearly interpolated data.
 
-For parallel-implicit coupling, interpolation will be available starting from the second iteration.
+For parallel-implicit coupling, interpolation is available starting from the second iteration.
 For serial coupling schemes, the `second` solver will always have linear interpolation available.
 
 To achieve higher-order interpolation, let the solver with the larger time-steps perform multiple time-steps per time-window and increase the `waveform-degree="2"` of the data in question.

--- a/pages/docs/couple-your-code/couple-your-code-waveform.md
+++ b/pages/docs/couple-your-code/couple-your-code-waveform.md
@@ -66,11 +66,11 @@ This allows us to define the degree of the interpolant in the `read-data` tag of
 ## Availability
 
 Depending on the used coupling scheme, time interpolation may not always be available.
-The following table shows the availability, which without further changes means linear interpolation between the time samples at the beginning and the end of the window.
-Note that due to the staggered nature of serial schemes, time-interpolation is always available in the participant that goes second.
-This is the only instance where time-interpolation is available in an explicit scheme.
+The following table shows when it is available, which without further changes means linear interpolation between the data samples at the beginning and the end of the window.
+Note that due to the staggered nature of serial schemes, time interpolation is always available in the participant that goes second.
+This is the only instance where time-interpolation is available in an explicit coupling scheme.
 
-| Scheme            | first iteration | later iterations |
+| Coupling scheme | First iteration | Later iterations |
 | ---               | ---             | ---              |
 | serial-explicit   | second only     |                  |
 | serial-implicit   | second only     | yes              |
@@ -117,7 +117,7 @@ while (not simulationDone()){ // time loop
 
 ### Different time scales
 
-For solvers operating on different time-scales, the solver with the smaller time-step size may not be able to handle constant input data over the entire time-window.
+For solvers operating on different time scales, the solver with the smaller time-step size may not work with constant input data over the entire time-window.
 In cases where [time-interpolation is available](#availability), the solver with the smaller step size may call `readData()` with `relativeReadTime=0` to sample data at the beginning of each of its time steps.
 
 By default, this results in piecewise linearly interpolated data.

--- a/pages/docs/couple-your-code/couple-your-code-waveform.md
+++ b/pages/docs/couple-your-code/couple-your-code-waveform.md
@@ -63,7 +63,9 @@ This allows us to define the degree of the interpolant in the `read-data` tag of
 </precice-configuration>
 ```
 
-## Usage example
+## Usage examples
+
+### Implicit coupling
 
 We are now ready to extend the example from ["Step 6 - Implicit coupling"](couple-your-code-implicit-coupling.html) to use waveforms. Let us assume that our fluid solver uses a midpoint rule as time stepping method. In this case, only few changes are necessary to sample the `Displacements` at the middle of the time window:
 
@@ -88,6 +90,18 @@ while (not simulationDone()){ // time loop
 }
 ...
 ```
+
+### Different time scales
+
+For solvers operating on different time-scales, the solver with the smaller time-step size may need smooth input data.
+In this case the solver with the smaller step size may call `readData()` with `dt=0` to sample data at the beginning of each of it's time steps.
+By default, this results in piecewise linearly interpolated data.
+
+For parallel-implicit coupling, interpolation will be available starting from the second iteration.
+For serial coupling schemes, the `second` solver will always have linear interpolation available.
+
+To achieve higher-order interpolation, let the solver with the larger time-steps perform multiple time-steps per time-window and increase the `waveform-degree="2"` of the data in question.
+Serial-explicit schemes need to manually enable exchange of substeps from the `first` to the `second` participant using `<exchange substeps="true" />`.
 
 ## Literature
 

--- a/pages/docs/couple-your-code/couple-your-code-waveform.md
+++ b/pages/docs/couple-your-code/couple-your-code-waveform.md
@@ -86,7 +86,7 @@ For higher-order interpolation, some additional steps need to be taken:
 
 ## Usage examples
 
-### Implicit coupling
+### Midpoint rule
 
 We are now ready to extend the example from ["Step 6 - Implicit coupling"](couple-your-code-implicit-coupling.html) to use waveforms. Let us assume that our fluid solver uses a midpoint rule as time stepping method. In this case, only few changes are necessary to sample the `Displacements` at the middle of the time window:
 

--- a/pages/docs/couple-your-code/couple-your-code-waveform.md
+++ b/pages/docs/couple-your-code/couple-your-code-waveform.md
@@ -63,6 +63,27 @@ This allows us to define the degree of the interpolant in the `read-data` tag of
 </precice-configuration>
 ```
 
+## Availability
+
+Depending on the used coupling scheme, time interpolation may not always be available.
+The following table shows the availability, which without further changes means linear interpolation between the time samples at the beginning and the end of the window.
+Note that due to the staggered nature of serial schemes, time-interpolation is always available in the participant that goes second.
+This is the only instance where time-interpolation is available in an explicit scheme.
+
+| Scheme            | first iteration | later iterations |
+| ---               | ---             | ---              |
+| serial-explicit   | second only     |                  |
+| serial-implicit   | second only     | yes              |
+| parallel-explicit | no              |                  |
+| parallel-implicit | no              | yes              |
+| multi             | no              | yes              |
+
+For higher-order interpolation, some additional steps need to be taken:
+
+1. the solver writing the data needs to perform multiple sub-steps per time-window to generate samples to interpolate from,
+2. the coupling-scheme needs to exchange the substeps of data from the writing to the reading solver with `<exchange ... substeps="true" />`, and
+3. the data needs to use a higher waveform-degree, for example `<data... waveform-degree="3"/>`.
+
 ## Usage examples
 
 ### Implicit coupling

--- a/pages/docs/couple-your-code/couple-your-code-waveform.md
+++ b/pages/docs/couple-your-code/couple-your-code-waveform.md
@@ -80,9 +80,12 @@ This is the only instance where time-interpolation is available in an explicit s
 
 For higher-order interpolation, some additional steps need to be taken:
 
-1. the solver writing the data needs to perform multiple sub-steps per time-window to generate samples to interpolate from,
+1. The solver writing the data needs to perform multiple sub-steps per time-window to generate samples to interpolate from,
 2. the coupling-scheme needs to exchange the substeps of data from the writing to the reading solver with `<exchange ... substeps="true" />`, and
 3. the data needs to use a higher waveform-degree, for example `<data... waveform-degree="3"/>`.
+
+Note that preCICE generates an interpolant of lower degree if there are not enough samples available.
+Please ensure that the writing solver generates at least the amount of samples equal to the requested waveform-degree.
 
 ## Usage examples
 

--- a/pages/docs/couple-your-code/couple-your-code-waveform.md
+++ b/pages/docs/couple-your-code/couple-your-code-waveform.md
@@ -114,15 +114,11 @@ while (not simulationDone()){ // time loop
 
 ### Different time scales
 
-For solvers operating on different time-scales, the solver with the smaller time-step size may need smooth input data.
-In this case the solver with the smaller step size may call `readData()` with `relativeReadTime=0` to sample data at the beginning of each of its time steps.
+For solvers operating on different time-scales, the solver with the smaller time-step size may not be able to handle constant input data over the entire time-window.
+In cases where [time-interpolation is available](#availability), the solver with the smaller step size may call `readData()` with `relativeReadTime=0` to sample data at the beginning of each of its time steps.
+
 By default, this results in piecewise linearly interpolated data.
-
-For parallel-implicit coupling, interpolation is available starting from the second iteration.
-For serial coupling schemes, the `second` solver will always have linear interpolation available.
-
-To achieve higher-order interpolation, let the solver with the larger time-steps perform multiple time-steps per time-window and increase the `waveform-degree="2"` of the data in question.
-Serial-explicit schemes need to manually enable exchange of substeps from the `first` to the `second` participant using `<exchange substeps="true" />`.
+To achieve higher-order interpolation, the solver with the larger time-steps can now perform multiple time-steps per time-window to provide additional samples.
 
 ## Literature
 


### PR DESCRIPTION
This PR adds a basic explanation on how to use time interpolation to provide smooth input data for a solver operating on a smaller timescale.