### PR TITLE
Add Micro Manager adaptivity documentation page

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -274,6 +274,10 @@ entries:
           url: /tooling-micro-manager-logging.html
           output: web, pdf
 
+        - title: Adaptivity
+          url: /tooling-micro-manager-adaptivity.html
+          output: web, pdf
+
         - title: Snapshot Computation
           url: /tooling-micro-manager-snapshot-configuration.html
           output: web, pdf


### PR DESCRIPTION
https://github.com/precice/micro-manager/commit/b4f1c8694ad3686f4411cfedebd5949e171727e6 adds a dedicated page in the Micro Manager about the adaptivity algorithm and the different variants available. This PR adds the page to the sidebar such that it will be on the website.