### PR TITLE
Fix markdown-lint issues in G+Smo adapter docs

### DIFF
--- a/content/docs/adapters/gismo/adapter-gismo.md
+++ b/content/docs/adapters/gismo/adapter-gismo.md
@@ -10,6 +10,7 @@ summary: "The G+Smo adapter can be used to couple G+Smo to CFD solvers for FSI a
 G+Smo (pronounced gismo or gizmo) is a C++ library for isogeometric analysis (IGA). Geometry plus simulation modules aims at the seamless integration of Computer-aided Design (CAD) and Finite Element Analysis (FEA).
 
 ## What can it do?
+
 This adapter can read/write the following fields in a surface coupling setup:
 
 - Temperature (read + write)
@@ -22,8 +23,7 @@ This adapter can read/write the following fields in a surface coupling setup:
 - Velocity (write)
 - Velocity surface-normal gradient (write)
   
-All features of preCICE are supported, including implicit coupling, nearest-projection mapping and radial basis function based mapping. 
-
+All features of preCICE are supported, including implicit coupling, nearest-projection mapping and radial basis function based mapping.
 
 ## Aim of the adapter
 


### PR DESCRIPTION
Follow-up of https://github.com/precice/precice.github.io/pull/597

Not sure why the auto-merge worked in that case, but this is now discussed in https://github.com/precice/precice/issues/2361