### PR TITLE
Update installation packages documentation

### DIFF
--- a/content/docs/installation/installation-overview.md
+++ b/content/docs/installation/installation-overview.md
@@ -34,11 +34,13 @@ Linux is the easiest option, see figure above. We provide [binary packages](inst
 
 **macOS**
 
-The recommended way is to [use Homebrew to install the preCICE dependencies](installation-source-dependencies.html#macos) and then [compile preCICE from source](installation-source-preparation.html). You can alternatively [build preCICE using Spack](https://precice.org/installation-spack.html).
+The recommended way is to [use Homebrew to install preCICE](installation-packages.html#macos).
 
 **Microsoft Windows**
 
-We are currently working on native builds of preCICE on Windows. Until then, you can [Ubuntu on Windows](https://www.microsoft.com/en-us/p/ubuntu/9nblggh4msv6) via the Windows subsystem for Linux (WSL). You can then follow all the instructions for Ubuntu, and all codes that work on Linux, also work under WSL. Coupling between a code running on Windows and a code running on Linux should be at least complicated.
+The recommended way is to [use MYSYS2 to install preCICE](installation-packages.html#msys2).
+
+Alternatively, you can use [Ubuntu on Windows](https://www.microsoft.com/en-us/p/ubuntu/9nblggh4msv6) via the Windows subsystem for Linux (WSL). You can then follow all the instructions for Ubuntu, and all codes that work on Linux, also work under WSL. Coupling between a code running on Windows and a code running on Linux should be at least complicated.
 
 <details markdown="1"><summary>In case you want to use "Ubuntu on Windows", note the following: (click to reveal)</summary>
 - You first need to [enable WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10). Both WSL 1 and 2 are fine. Simplest option: in your system settings, find the menu `Turn Windows features on or off` and activate WSL there.
@@ -48,8 +50,6 @@ We are currently working on native builds of preCICE on Windows. Until then, you
 </details>
 
 ![Running preCICE on Windows via WSL, while post-processing in the Windows Desktop](images/docs/install-wsl.png)
-
-Alternatively, you can get [preCICE built with MinGW from MSYS2](https://packages.msys2.org/base/mingw-w64-precice) (package [maintained by the community](https://precice.discourse.group/t/precice-and-mingw-packages/382)). See how we use it in our [continuous integration tests](https://github.com/precice/precice/blob/develop/.github/workflows/build-and-test.yml).
 
 ### Use cases
 

--- a/content/docs/installation/installation-packages.md
+++ b/content/docs/installation/installation-packages.md
@@ -8,9 +8,11 @@ For some systems, preCICE is available in the form of a pre-built package or a p
 These packages are built with enabled Python actions, MPI communication, and PETSc mapping.
 This section lists systems and instructions on how to install these packages.
 
-An incomplete package version overview of preCICE can be found on repology:
+[Repology](https://repology.org/project/precice/versions) compiles a list of packages and versions in distribution repositories.
+This contains a good overview of packages also in community repositories.
+Note, however that Ubuntu and Debian are absent from this list as official packages for those Distros would lack too far behind in time.
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/precice.svg?header=&columns=2&exclude_sources=site)](https://repology.org/project/precice/versions)
+![Packaging status](https://repology.org/badge/vertical-allrepos/precice.svg?header=&columns=2&exclude_sources=site)
 
 ## Ubuntu
 

--- a/content/docs/installation/installation-packages.md
+++ b/content/docs/installation/installation-packages.md
@@ -91,7 +91,7 @@ pacman -Ss precice
 Then install it with:
 
 ```bash
-pacman -S precice/
+pacman -S <package name>
 ```
 
 ## Something else

--- a/content/docs/installation/installation-packages.md
+++ b/content/docs/installation/installation-packages.md
@@ -87,6 +87,7 @@ The community maintains a preCICE package for [MSYS2](https://packages.msys2.org
 To use Microsoft MPI, first make sure to install the [latest release of MSMPI](https://github.com/microsoft/Microsoft-MPI/releases/latest) (the `msmpisetup.exe`).
 Then, enable path inheritance in the environment configuration of your choice.
 To enable it for MSYS64 UCRT, edit the file `C:/msys64/ucrt.ini` and uncomment the line `MSYS2_PATH_TYPE=inherit` by removing the leading `#`. You should now be able to run `mpiexec` in the ucrt environment.
+
 To search for a suitable package use:
 
 ```bash

--- a/content/docs/installation/installation-packages.md
+++ b/content/docs/installation/installation-packages.md
@@ -84,6 +84,9 @@ brew install --head precice
 ## Windows
 
 The community maintains a preCICE package for [MSYS2](https://packages.msys2.org/base/mingw-w64-precice).
+To use Microsoft MPI, first make sure to install the [latest release of MSMPI](https://github.com/microsoft/Microsoft-MPI/releases/latest) (the `msmpisetup.exe`).
+Then, enable path inheritance in the environment configuration of your choice.
+To enable it for MSYS64 UCRT, edit the file `C:/msys64/ucrt.ini` and uncomment the line `MSYS2_PATH_TYPE=inherit` by removing the leading `#`. You should now be able to run `mpiexec` in the ucrt environment.
 To search for a suitable package use:
 
 ```bash

--- a/content/docs/installation/installation-packages.md
+++ b/content/docs/installation/installation-packages.md
@@ -70,7 +70,7 @@ For macOS, we maintain a [homebrew package/formula](https://formulae.brew.sh/for
 To install the latest version use:
 
 ```bash
-brew install --only-dependencies precice
+brew install precice
 ```
 
 It also provides a way of installing the latest develop version from source using the head flag:

--- a/content/docs/installation/installation-packages.md
+++ b/content/docs/installation/installation-packages.md
@@ -42,6 +42,8 @@ Please have a look at the official [AUR wiki page](https://wiki.archlinux.org/in
 
 The community also maintains a [development version](https://aur.archlinux.org/packages/precice-git) and [several other packages](https://aur.archlinux.org/packages?&K=precice).
 
+Furthermore, the [arch4edu](https://github.com/arch4edu/arch4edu/wiki) initiative provides pre-built binaries for preCICE and related packages.
+
 ## Nix / NixOS
 
 In addition to the community efforts listed above, preCICE and several of the bindings and adapters are available for Nix in the [precice/nix-packages repository](https://github.com/precice/nix-packages/).

--- a/content/docs/installation/installation-packages.md
+++ b/content/docs/installation/installation-packages.md
@@ -103,7 +103,6 @@ For other systems, you need to either use [Spack](installation-spack.html) or [b
 These packages are maintained by the preCICE community and may be occasionally outdated or not fully working.
 However, we appreciate the effort, and you may be able to contribute to them.
 
-
 - [EasyBuild](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/p/preCICE)
 - [Conda](https://github.com/conda-forge/precice-feedstock) (see also packages [pyprecice](https://github.com/conda-forge/pyprecice-feedstock) and [fenicsprecice](https://github.com/conda-forge/fenicsprecice-feedstock)). We recommend using [Miniforge](https://conda-forge.org/download/) (see https://www.fz-juelich.de/en/rse/the_latest/the-anaconda-is-squeezing-us for reasons why).
 - [FreeBSD](https://www.freshports.org/science/precice)

--- a/content/docs/installation/installation-packages.md
+++ b/content/docs/installation/installation-packages.md
@@ -8,6 +8,10 @@ For some systems, preCICE is available in the form of a pre-built package or a p
 These packages are built with enabled Python actions, MPI communication, and PETSc mapping.
 This section lists systems and instructions on how to install these packages.
 
+An incomplete package version overview of preCICE can be found on repology:
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/precice.svg?header=&columns=2&exclude_sources=site)](https://repology.org/project/precice/versions)
+
 ## Ubuntu
 
 You can download version-specific Ubuntu (Debian) packages from each [GitHub release](https://github.com/precice/precice/releases/latest).
@@ -25,6 +29,11 @@ Check the [official release-cyle](https://ubuntu.com/about/release-cycle) for mo
 As an example, change `noble` to `jammy` for 22.04.
 
 Is a newer preCICE release out, and have we not yet updated the above links? Please edit this page.
+
+## Debian
+
+Similar to the Ubuntu packages, we generate Debian packages for at least the latest stable release of Debian.
+You can download version-specific Debian packages from the respective release [GitHub release](https://github.com/precice/precice/releases/latest).
 
 ## Arch Linux / Manjaro
 
@@ -55,6 +64,36 @@ For more options, have a look at the [readme](https://github.com/precice/nix-pac
 
 For all packages available upstream, see the [NixOS search](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&query=precice).
 
+## macOS
+
+For macOS, we maintain a [homebrew package/formula](https://formulae.brew.sh/formula/precice).
+To install the latest version use:
+
+```bash
+brew install --only-dependencies precice
+```
+
+It also provides a way of installing the latest develop version from source using the head flag:
+
+```bash
+brew install --head precice
+```
+
+## Windows
+
+The community maintains a preCICE package for [MSYS2](https://packages.msys2.org/base/mingw-w64-precice).
+To search for a suitable package use:
+
+```bash
+pacman -Ss precice
+```
+
+Then install it with:
+
+```bash
+pacman -S precice/
+```
+
 ## Something else
 
 For other systems, you need to either use [Spack](installation-spack.html) or [build from source](installation-source-preparation.html).
@@ -64,7 +103,7 @@ For other systems, you need to either use [Spack](installation-spack.html) or [b
 These packages are maintained by the preCICE community and may be occasionally outdated or not fully working.
 However, we appreciate the effort, and you may be able to contribute to them.
 
-- [MSYS2](https://packages.msys2.org/base/mingw-w64-precice) (for Windows, built with MinGW), [thread on our forum](https://precice.discourse.group/t/precice-and-mingw-packages/382)
+
 - [EasyBuild](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/p/preCICE)
 - [Conda](https://github.com/conda-forge/precice-feedstock) (see also packages [pyprecice](https://github.com/conda-forge/pyprecice-feedstock) and [fenicsprecice](https://github.com/conda-forge/fenicsprecice-feedstock)). We recommend using [Miniforge](https://conda-forge.org/download/) (see https://www.fz-juelich.de/en/rse/the_latest/the-anaconda-is-squeezing-us for reasons why).
 - [FreeBSD](https://www.freshports.org/science/precice)


### PR DESCRIPTION
Added installation instructions for macOS and Windows, including Homebrew and MSYS2 package details. Also added repology overview