### PR TITLE
Polish news/faq sections on the landing page

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -471,7 +471,7 @@ layout: landing_page
 
       <div class="row">
         <div class="col-lg-12">
-          <a href="https://precice.discourse.group/tag/faq?order=views" class="btn btn-primary no-icon" role="button">More questions &nbsp;<i class="fas fa-chevron-right"></i></a>
+          <a href="fundamentals-faq.html" class="btn btn-primary no-icon" role="button">More questions &nbsp;<i class="fas fa-chevron-right"></i></a>
         </div>
       </div>
 

--- a/content/index.html
+++ b/content/index.html
@@ -200,7 +200,7 @@ layout: landing_page
 <!-- Latest News Section -->
 <section id="latest-news" class="section">
   <div class="container">
-    <h2 class="section-header text-center">Latest News</h2>
+    <h2 class="section-header text-center">Latest news</h2>
 
     <div id="news-container" class="row equal">
       <!-- News cards will be inserted dynamically -->

--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -274,8 +274,8 @@ div.logo-holder > img {
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 4; 
-  line-clamp: 4;
+  -webkit-line-clamp: 5; 
+  line-clamp: 5;
   -webkit-box-orient: vertical;
 }
 

--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -89,7 +89,7 @@ div.image-holder.usp > img {
 }
 
 /* Adapter section */
-
+/* adapter class also used for news in the langing page */
 a.adapter {
   text-decoration: none;
 }

--- a/js/news-collect.js
+++ b/js/news-collect.js
@@ -22,6 +22,7 @@ for (const topic of topics.slice(0, 3)) {
   const card = document.createElement("div");
   card.className = "news-card";
 
+  // NOTE: The `adapter` class is used here as an already available card class, feel free to provide a new one.
   card.innerHTML = `<a href="${topic.url}" target="_blank" rel="noopener noreferrer" class="adapter no-external-marker">
     <h4><strong>${topic.title}</strong></h4>
     <p>${topic.description}</p>

--- a/js/news-collect.js
+++ b/js/news-collect.js
@@ -31,7 +31,7 @@ for (const topic of topics.slice(0, 3)) {
       </a>
     </p>
     <p class="text-muted"><small>
-      Last activity: ${new Date(topic.last_posted_at).toLocaleDateString()}
+      Last activity: ${new Date(topic.last_posted_at).toLocaleDateString("en-GB")}
     </small></p>
   `;
 

--- a/js/news-collect.js
+++ b/js/news-collect.js
@@ -22,14 +22,10 @@ for (const topic of topics.slice(0, 3)) {
   const card = document.createElement("div");
   card.className = "news-card";
 
-  card.innerHTML = `
+  card.innerHTML = `<a href="${topic.url}" target="_blank" rel="noopener noreferrer" class="adapter no-external-marker">
     <h4><strong>${topic.title}</strong></h4>
     <p>${topic.description}</p>
-    <p>
-      <a href="${topic.url}" target="_blank" rel="noopener noreferrer" class="no-external-marker">
-        Read more about this update
-      </a>
-    </p>
+    </a>
     <p class="text-muted"><small>
       Last activity: ${new Date(topic.last_posted_at).toLocaleDateString("en-GB")}
     </small></p>


### PR DESCRIPTION
Follow-up of #611. Addresses some of the issues discussed in #402.

- Makes cards clickable, removes "Read more about this update"
- FAQ: Links to the internal page instead of the forum (which links to the forum)
- Sets a locale for the date field in the latest news
- Provides a bit more content in the summary (5 lines, for more we need to get more data from Discourse, but I think this should be fine)
- Converts the `Latest News` to `Latest news`