### PR TITLE
Move news section up on landing page

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -50,95 +50,119 @@ layout: landing_page
   </div> <!-- main -->
 </div> <!-- container -->
 
-<!-- USP Section, full blead layout  -->
-
-<div class="background-light">
+<!-- Latest News Section -->
+<div id="latest-news" class="section">
   <div class="container">
-    <div class="section">
+    <h2 class="section-header text-center">Latest news</h2>
 
-      <div class="row">
-        <div class="col-lg-12">
-          <h2 class="section-header">Prepared for the next generation of multi-physics simulations</h2>
-        </div>
+    <div id="news-container" class="row equal">
+      <!-- News cards will be inserted dynamically -->
+      <p id="loading-news">Loading latest news...</p>
+    </div>
+
+    
+    <div class="row" style="margin-top: 25px;">
+      <div class="col-lg-12 text-center">
+        <a href="https://precice.discourse.group/c/news/5"
+           class="btn btn-primary no-icon"
+           role="button"
+           target="_blank"
+           rel="noopener noreferrer">
+          More news &nbsp;<i class="fas fa-chevron-right"></i>
+        </a>
       </div>
+    </div>
 
-      <div class="row equal">
-        <div class="col-md-3 col-sm-6 col-flex">
-          <div class="image-holder usp">
-            <img class="img-responsive center-block" src="images/usp/usp-minimal.svg" alt="non-invasive integration">
-          </div>
-          <div class="panel panel-primary panel-precice usp">
-            <div class="panel-heading-precice text-left">
-              <strong>Minimally invasive integration</strong>
-            </div>
-            <div class="panel-body">
-              <ul class="usp">
-                <li class="usp">Elegant library approach</li>
-                <li class="usp">High-level API in C++, C, Fortran, Python, Matlab</li>
-              </ul>
-              <a href="couple-your-code-overview.html">Learn more &nbsp;<i class="fas fa-chevron-right"></i></a>
-            </div>
-          </div>
+  </div>
+</div>
+
+<!-- USP Section, full blead layout  -->
+<div class="container">
+  <div class="section">
+
+    <div class="row">
+      <div class="col-lg-12">
+        <h2 class="section-header">Prepared for the next generation of multi-physics simulations</h2>
+      </div>
+    </div>
+
+    <div class="row equal">
+      <div class="col-md-3 col-sm-6 col-flex">
+        <div class="image-holder usp">
+          <img class="img-responsive center-block" src="images/usp/usp-minimal.svg" alt="non-invasive integration">
         </div>
-        <div class="col-md-3 col-sm-6 col-flex">
-          <div class="image-holder usp">
-            <img class="img-responsive center-block" src="images/usp/usp-arbitrary.svg" alt="Coupling of programs">
+        <div class="panel panel-primary panel-precice usp">
+          <div class="panel-heading-precice text-left">
+            <strong>Minimally invasive integration</strong>
           </div>
-          <div class="panel panel-primary panel-precice usp">
-            <div class="panel-heading-precice text-left">
-              <strong>Coupling of arbitrary many programs</strong>
-            </div>
-            <div class="panel-body">
-              <ul class="usp">
-                <li class="usp">Arbitrary combinations of strong and weak interactions</li>
-                <li class="usp">Arbitrary many solvers</li>
-              </ul>
-              <a href="configuration-coupling-multi.html">Learn more &nbsp;<i class="fas fa-chevron-right"></i></a>
-            </div>
-          </div>
-        </div>
-        <div class="col-md-3 col-sm-6 col-flex">
-          <div class="image-holder usp">
-            <img class="img-responsive center-block" src="images/usp/usp-numerics.svg" alt="numerical methods">
-          </div>
-          <div class="panel panel-primary panel-precice usp">
-            <div class="panel-heading-precice text-left">
-              <strong>State-of-the-art numerical methods</strong>
-            </div>
-            <div class="panel-body">
-              <ul class="usp">
-                <li class="usp">Robust quasi-Newton acceleration</li>
-                <li class="usp">Radial-basis function data mapping</li>
-              </ul>
-              <a href="fundamentals-literature-guide.html">Learn more &nbsp;<i class="fas fa-chevron-right"></i></a>
-            </div>
-          </div>
-        </div>
-        <div class="col-md-3 col-sm-6 col-flex">
-          <div class="image-holder usp">
-            <img class="img-responsive center-block" src="images/usp/usp-scalability.svg" alt="scalability">
-          </div>
-          <div class="panel panel-primary panel-precice usp">
-            <div class="panel-heading-precice text-left">
-              <strong>Scalability up to complete supercomputers</strong>
-            </div>
-            <div class="panel-body">
-              <ul class="usp">
-                <li class="usp">Pure peer-to-peer approach</li>
-                <li class="usp">Support of heterogenous hardware (CPU/GPU)</li>
-                <li class="usp">Efficient also on a laptop</li>
-              </ul>
-              <a href="fundamentals-literature-guide.html#parallel-and-high-performance-computing">Learn more &nbsp;<i class="fas fa-chevron-right"></i></a>
-            </div>
+          <div class="panel-body">
+            <ul class="usp">
+              <li class="usp">Elegant library approach</li>
+              <li class="usp">High-level API in C++, C, Fortran, Python, Matlab</li>
+            </ul>
+            <a href="couple-your-code-overview.html">Learn more &nbsp;<i class="fas fa-chevron-right"></i></a>
           </div>
         </div>
       </div>
+      <div class="col-md-3 col-sm-6 col-flex">
+        <div class="image-holder usp">
+          <img class="img-responsive center-block" src="images/usp/usp-arbitrary.svg" alt="Coupling of programs">
+        </div>
+        <div class="panel panel-primary panel-precice usp">
+          <div class="panel-heading-precice text-left">
+            <strong>Coupling of arbitrary many programs</strong>
+          </div>
+          <div class="panel-body">
+            <ul class="usp">
+              <li class="usp">Arbitrary combinations of strong and weak interactions</li>
+              <li class="usp">Arbitrary many solvers</li>
+            </ul>
+            <a href="configuration-coupling-multi.html">Learn more &nbsp;<i class="fas fa-chevron-right"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3 col-sm-6 col-flex">
+        <div class="image-holder usp">
+          <img class="img-responsive center-block" src="images/usp/usp-numerics.svg" alt="numerical methods">
+        </div>
+        <div class="panel panel-primary panel-precice usp">
+          <div class="panel-heading-precice text-left">
+            <strong>State-of-the-art numerical methods</strong>
+          </div>
+          <div class="panel-body">
+            <ul class="usp">
+              <li class="usp">Robust quasi-Newton acceleration</li>
+              <li class="usp">Radial-basis function data mapping</li>
+            </ul>
+            <a href="fundamentals-literature-guide.html">Learn more &nbsp;<i class="fas fa-chevron-right"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3 col-sm-6 col-flex">
+        <div class="image-holder usp">
+          <img class="img-responsive center-block" src="images/usp/usp-scalability.svg" alt="scalability">
+        </div>
+        <div class="panel panel-primary panel-precice usp">
+          <div class="panel-heading-precice text-left">
+            <strong>Scalability up to complete supercomputers</strong>
+          </div>
+          <div class="panel-body">
+            <ul class="usp">
+              <li class="usp">Pure peer-to-peer approach</li>
+              <li class="usp">Support of heterogenous hardware (CPU/GPU)</li>
+              <li class="usp">Efficient also on a laptop</li>
+            </ul>
+            <a href="fundamentals-literature-guide.html#parallel-and-high-performance-computing">Learn more &nbsp;<i class="fas fa-chevron-right"></i></a>
+          </div>
+        </div>
+      </div>
+    </div>
 
-    </div> <!-- section -->
-  </div> <!-- container -->
-</div> <!-- background-light -->
+  </div> <!-- section -->
+</div> <!-- container -->
 
 <!-- Adapter section  -->
+<div class="background-light">
 <div class="container">
   <div class="section">
 
@@ -196,32 +220,7 @@ layout: landing_page
 
   </div> <!-- section -->
 </div> <!-- container -->
-
-<!-- Latest News Section -->
-<section id="latest-news" class="section">
-  <div class="container">
-    <h2 class="section-header text-center">Latest news</h2>
-
-    <div id="news-container" class="row equal">
-      <!-- News cards will be inserted dynamically -->
-      <p id="loading-news">Loading latest news...</p>
-    </div>
-
-    
-    <div class="row" style="margin-top: 25px;">
-      <div class="col-lg-12 text-center">
-        <a href="https://precice.discourse.group/c/news/5"
-           class="btn btn-primary no-icon"
-           role="button"
-           target="_blank"
-           rel="noopener noreferrer">
-          More news &nbsp;<i class="fas fa-chevron-right"></i>
-        </a>
-      </div>
-    </div>
-
-  </div>
-</section>
+</div> <!-- background-light -->
 
 <!-- Testimonials, full bleed layout -->
 


### PR DESCRIPTION
Moves the "latest news" section further up in the landing page (follow up of #611).

This also converts a `<section class="section">` to a `<div class="section">`, for consistency. Apparently, switching the order between the divs `section` and `container` breaks the layout, but I would look at the "why" in a separate PR.

The succession of colors could be better (too much blunt light blue), but it is also ok. Currently, it looks like this:

<img width="1407" height="3126" alt="Screenshot 2025-12-01 at 15-55-50 preCICE - The Coupling Library preCICE - The Coupling Library" src="https://github.com/user-attachments/assets/28140c6e-79e8-4d6a-9348-1526df88bf8e" />

