### PR TITLE
Add Micro Manager model adaptivity documentation page to sidebar

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -283,6 +283,10 @@ entries:
           url: /tooling-micro-manager-adaptivity.html
           output: web, pdf
 
+        - title: Model adaptivity
+          url: /tooling-micro-manager-model-adaptivity.html
+          output: web, pdf
+
         - title: Snapshot Computation
           url: /tooling-micro-manager-snapshot-configuration.html
           output: web, pdf


### PR DESCRIPTION
The title is self-explanatory.