### PR TITLE
Update citation data, add v1 paper

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -320,5 +320,13 @@ calculix_adapter_version: "2.20.0"
 # This url is so bugprone that we keep it centrally here
 matrix_url: "https://matrix.to/#/#precice_lobby:gitter.im?web-instance[element.io]=app.gitter.im"
 
-# Latest known number of Google scholar citations, used as fallback
-precice_citations: 222
+# Latest known number of Google scholar citations, manually updated
+# For an automated solution (currently unused), see
+#   _plugins/googlescholar.rb
+#   https://github.com/precice/precice.github.io/pull/527
+#
+# Date: 30.12.2025
+precice_v1_citations: 432
+precice_v1_citations_url: https://scholar.google.com/scholar?cites=5053469347483527186&as_sdt=2005&sciodt=0,5&hl=en
+precice_v2_citations: 187
+precice_v2_citations_url: https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17974677460269868025,12004404035922881061

--- a/content/index.html
+++ b/content/index.html
@@ -336,7 +336,8 @@ layout: landing_page
             <a href="assets/precice-v2.bib">Download BibTeX &nbsp;<i class="fas fa-download"></i></a>
           </div>
         </div>
-        <a href="https://scholar.google.com/scholar?hl=en&cites={{ site.data.scholar.id }}" class="btn btn-default no-icon literature-link" role="button">Citations of preCICE v2 paper {% if site.data.scholar.citations %}({{ site.data.scholar.citations }}){% else %}({{ site.precice_citations }}){% endif %} &nbsp;<i class="fas fa-chevron-right"></i></a>
+        <a href="{{ site.precice_v2_citations_url }}" class="btn btn-default no-icon literature-link" role="button">Citations of preCICE v2 paper ({{ site.precice_v2_citations }}) &nbsp;<i class="fas fa-chevron-right"></i></a>
+        <a href="{{ site.precice_v1_citations_url }}" class="btn btn-default no-icon literature-link" role="button">preCICE v1 ({{ site.precice_v1_citations }}) &nbsp;<i class="fas fa-chevron-right"></i></a>
         <a href="fundamentals-literature-guide.html" class="btn btn-primary literature-link" role="button">Literature guide &nbsp;<i class="fas fa-chevron-right"></i></a>
       </div>
     </div>


### PR DESCRIPTION
Updates the citation data and URL, partially overlapping with #527. Also adds a link to the v1 paper citations, as decided in #527.

Hard-coding till that is merged, since the data is currently wrong and the URL is broken.
Google Scholar seems to have changed which works it includes in this list.

Adds a reference to the now unused automatic solution, but does not remove it, hoping to fix it soon.

Related to #522