### PR TITLE
Revamp previous versions page

### DIFF
--- a/content/docs/fundamentals/fundamentals-previous-versions.md
+++ b/content/docs/fundamentals/fundamentals-previous-versions.md
@@ -11,23 +11,23 @@ We only support the latest version of preCICE, but upgrading is easy: See our [p
 
 We archive the documentation into a citable PDF file, while the [Wayback Machine](https://web.archive.org/) archives this website:
 
-| Date    | preCICE | Docs | Website |
-| ---     | ---     | --- | --- |
-| 2024-04 | v3.1.1  | [PDF](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-4167/4&version=1.0)  | [Archive](https://web.archive.org/web/20240415175559/https://precice.org/) |
-| 2022-11 | v2.5.0  | [PDF](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-3576/3&version=1.0)  | [Archive](https://web.archive.org/web/20221204210218/https://precice.org/) |
-| 2022-02 | v2.3.0  | [PDF](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-2613/4&version=1.0)  | [Archive](https://web.archive.org/web/20220223051319/http://precice.org/) |
-| 2021-04 | v2.2.0  | [PDF](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-2125/15&version=1.1) | [Archive](https://web.archive.org/web/20210428101248/http://precice.org/) |
-| 2020-10 | v2.1.1  | [Wiki](https://github.com/precice/precice/wiki/Home/f6bfac33aa878ab3e89e60720894e4fe0a547ab4)        | [Archive](https://web.archive.org/web/20201018162618/https://www.precice.org/) |
-| 2019-10 | v1.6.1  | [Wiki](https://github.com/precice/precice/wiki/Home/05df6896b25f6b79e364c86befb4f4a00b3baebe)        | [Archive](https://web.archive.org/web/20191121140032/https://www.precice.org/) |
-| 2019-07 | v1.5.2  | [Wiki](https://github.com/precice/precice/wiki/Home/7a7ba28a760c1351e4a998228d4463b75451e171)        | [Archive](https://web.archive.org/web/20190904131115/https://www.precice.org/) |
-| 2019-04 | v1.4.1  | [Wiki](https://github.com/precice/precice/wiki/Home/8a7f236b7e63c1c1083a4c6720a5afd98e1e6558)        | [Archive](https://web.archive.org/web/20190904131115/https://www.precice.org/) |
-| 2018-11 | v1.3.0  | [Wiki](https://github.com/precice/precice/wiki/Home/d42969b39a4ecb9b079681c6ef87f084218008eb)        | [Archive](https://web.archive.org/web/20181116031228/https://www.precice.org/) |
-| 2018-08 | v1.2.0  | [Wiki](https://github.com/precice/precice/wiki/Home/45cbc46d9538321b4b6cfa589e9305a7f37b94e8)        | [Archive](https://web.archive.org/web/20180814194446/precice.org) |
-| 2018-04 | v1.1.1  | [Wiki](https://github.com/precice/precice/wiki/Home/0ee082ce45fc2ee6864a4ad08cae28980d6c4884)        | [Archive](https://web.archive.org/web/20180409090831/http://www.precice.org/) |
-| 2018-03 | v1.0.3  | [Wiki](https://github.com/precice/precice/wiki/Home/3473c633f5e24be96ee5c8e230efe25414b114e8)        | [Archive](https://web.archive.org/web/20180309040600/http://www.precice.org/) |
-| 2017-11 | v1.0.0  | [Wiki](https://github.com/precice/precice/wiki/Home/91b37e813b55c6a97cf9077efb9b15f3d7e0973c)        | [Archive](https://web.archive.org/web/20171203212904/http://www.precice.org/) |
-| 2016-05 | v0.x    | [Wiki](https://github.com/precice/precice/wiki/Home/1c800ca60691e5f48655a545bda653b096f8ed7b)        | [Archive](https://web.archive.org/web/20160529052152/http://www.precice.org/) |
-| 2015-05 | v0.x    | [Wiki](https://github.com/precice/precice/wiki/Home/deb981d17dbb61edf1c1b48b000f3eb140f0fff4)        | N/A | 
+| Date    | preCICE | Docs                                                                                                 | Website                                                                         |
+| ---     | ---     | ---                                                                                                  | ---                                                                             |
+| 2024-04 | v3.1.1  | [PDF](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-4167/4&version=1.0)  | [Archive](https://web.archive.org/web/20240415175559/https://precice.org/)      |
+| 2022-11 | v2.5.0  | [PDF](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-3576/3&version=1.0)  | [Archive](https://web.archive.org/web/20221204210218/https://precice.org/)      |
+| 2022-02 | v2.3.0  | [PDF](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-2613/4&version=1.0)  | [Archive](https://web.archive.org/web/20220223051319/http://precice.org/)       |
+| 2021-04 | v2.2.0  | [PDF](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-2125/15&version=1.1) | [Archive](https://web.archive.org/web/20210428101248/http://precice.org/)       |
+| 2020-10 | v2.1.1  | [Wiki](https://github.com/precice/precice/wiki/Home/f6bfac33aa878ab3e89e60720894e4fe0a547ab4)        | [Archive](https://web.archive.org/web/20201018162618/https://www.precice.org/)  |
+| 2019-10 | v1.6.1  | [Wiki](https://github.com/precice/precice/wiki/Home/05df6896b25f6b79e364c86befb4f4a00b3baebe)        | [Archive](https://web.archive.org/web/20191121140032/https://www.precice.org/)  |
+| 2019-07 | v1.5.2  | [Wiki](https://github.com/precice/precice/wiki/Home/7a7ba28a760c1351e4a998228d4463b75451e171)        | [Archive](https://web.archive.org/web/20190904131115/https://www.precice.org/)  |
+| 2019-04 | v1.4.1  | [Wiki](https://github.com/precice/precice/wiki/Home/8a7f236b7e63c1c1083a4c6720a5afd98e1e6558)        | [Archive](https://web.archive.org/web/20190904131115/https://www.precice.org/)  |
+| 2018-11 | v1.3.0  | [Wiki](https://github.com/precice/precice/wiki/Home/d42969b39a4ecb9b079681c6ef87f084218008eb)        | [Archive](https://web.archive.org/web/20181116031228/https://www.precice.org/)  |
+| 2018-08 | v1.2.0  | [Wiki](https://github.com/precice/precice/wiki/Home/45cbc46d9538321b4b6cfa589e9305a7f37b94e8)        | [Archive](https://web.archive.org/web/20180814194446/precice.org)               |
+| 2018-04 | v1.1.1  | [Wiki](https://github.com/precice/precice/wiki/Home/0ee082ce45fc2ee6864a4ad08cae28980d6c4884)        | [Archive](https://web.archive.org/web/20180409090831/http://www.precice.org/)   |
+| 2018-03 | v1.0.3  | [Wiki](https://github.com/precice/precice/wiki/Home/3473c633f5e24be96ee5c8e230efe25414b114e8)        | [Archive](https://web.archive.org/web/20180309040600/http://www.precice.org/)   |
+| 2017-11 | v1.0.0  | [Wiki](https://github.com/precice/precice/wiki/Home/91b37e813b55c6a97cf9077efb9b15f3d7e0973c)        | [Archive](https://web.archive.org/web/20171203212904/http://www.precice.org/)   |
+| 2016-05 | v0.x    | [Wiki](https://github.com/precice/precice/wiki/Home/1c800ca60691e5f48655a545bda653b096f8ed7b)        | [Archive](https://web.archive.org/web/20160529052152/http://www.precice.org/)   |
+| 2015-05 | v0.x    | [Wiki](https://github.com/precice/precice/wiki/Home/deb981d17dbb61edf1c1b48b000f3eb140f0fff4)        | N/A                                                                             |
 
 The dates refer to the documentation snapshot, the website archives do not align, but are listed as starting points.
 

--- a/content/docs/fundamentals/fundamentals-previous-versions.md
+++ b/content/docs/fundamentals/fundamentals-previous-versions.md
@@ -5,11 +5,18 @@ keywords: pdf, export, v1, v2
 summary: "Archives of this documentation"
 ---
 
-In regular intervals, we archive PDF exports of this documentation. Refer to those when you are looking for information regarding previous versions:
-
-- For preCICE v2.x: [libprecice2_2.2.5_docs_v202211.0.0.pdf](https://github.com/precice/precice.github.io/releases/download/v202211.0.0/libprecice2_2.2.5_docs_v202211.0.0.pdf)
-- Before preCICE v2.x, the documentation was hosted in a [GitHub Wiki](https://github.com/precice/precice/wiki/Home/f6bfac33aa878ab3e89e60720894e4fe0a547ab4). For each page you want to visit, look at the previous revisions.
-
 We only support the latest version of preCICE, but upgrading is easy: See our [porting guides](./couple-your-code-porting-overview.html).
 
-The PDF exports of the documentation are part of the [preCICE Distribution](./installation-distribution.html). Alternatively, you can build [previous states of this website](https://github.com/precice/precice.github.io).
+In regular intervals, we archive PDF exports of this documentation. Refer to those when you are looking for information regarding previous versions:
+
+| Date    | preCICE | URL |
+| ---     | ---     | --- |
+| 2024-04 | v3.1.1  | [PDF on DaRUS](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-4167/4&version=1.0) |
+| 2022-11 | v2.5.0  | [PDF on DaRUS](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-3576/3&version=1.0) |
+| 2022-02 | v2.3.0  | [PDF on DaRUS](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-2613/4&version=1.0) |
+| 2021-04 | v2.2.0  | [PDF on DaRUS](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-2125/15&version=1.1) |
+| 2020-10 | v1.x    | [GitHub Wiki](https://github.com/precice/precice/wiki/Home/f6bfac33aa878ab3e89e60720894e4fe0a547ab4) |
+
+The PDF exports of the documentation are part of the citable [preCICE Distribution](./installation-distribution.html). Alternatively, you can build [previous states of this website](https://github.com/precice/precice.github.io/tags) or see snapshots on the [Wayback Machine](https://web.archive.org/web/20250000000000*/precice.org).
+
+Before preCICE v2.x, the documentation was hosted in a [GitHub Wiki](https://github.com/precice/precice/wiki/Home/f6bfac33aa878ab3e89e60720894e4fe0a547ab4). For each page you want to visit, look at the previous revisions.

--- a/content/docs/fundamentals/fundamentals-previous-versions.md
+++ b/content/docs/fundamentals/fundamentals-previous-versions.md
@@ -1,22 +1,38 @@
 ---
 title: Previous versions
 permalink: fundamentals-previous-versions.html
-keywords: pdf, export, v1, v2
+keywords: pdf, export, archive, v1, v2
 summary: "Archives of this documentation"
 ---
 
+{% tip %}
 We only support the latest version of preCICE, but upgrading is easy: See our [porting guides](./couple-your-code-porting-overview.html).
+{% endtip  %}
 
-In regular intervals, we archive PDF exports of this documentation. Refer to those when you are looking for information regarding previous versions:
+We archive the documentation into a citable PDF file, while the [Wayback Machine](https://web.archive.org/) archives this website:
 
-| Date    | preCICE | URL |
-| ---     | ---     | --- |
-| 2024-04 | v3.1.1  | [PDF on DaRUS](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-4167/4&version=1.0) |
-| 2022-11 | v2.5.0  | [PDF on DaRUS](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-3576/3&version=1.0) |
-| 2022-02 | v2.3.0  | [PDF on DaRUS](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-2613/4&version=1.0) |
-| 2021-04 | v2.2.0  | [PDF on DaRUS](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-2125/15&version=1.1) |
-| 2020-10 | v1.x    | [GitHub Wiki](https://github.com/precice/precice/wiki/Home/f6bfac33aa878ab3e89e60720894e4fe0a547ab4) |
+| Date    | preCICE | Docs | Website |
+| ---     | ---     | --- | --- |
+| 2024-04 | v3.1.1  | [PDF](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-4167/4&version=1.0)  | [Archive](https://web.archive.org/web/20240415175559/https://precice.org/) |
+| 2022-11 | v2.5.0  | [PDF](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-3576/3&version=1.0)  | [Archive](https://web.archive.org/web/20221204210218/https://precice.org/) |
+| 2022-02 | v2.3.0  | [PDF](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-2613/4&version=1.0)  | [Archive](https://web.archive.org/web/20220223051319/http://precice.org/) |
+| 2021-04 | v2.2.0  | [PDF](https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-2125/15&version=1.1) | [Archive](https://web.archive.org/web/20210428101248/http://precice.org/) |
+| 2020-10 | v2.1.1  | [Wiki](https://github.com/precice/precice/wiki/Home/f6bfac33aa878ab3e89e60720894e4fe0a547ab4)        | [Archive](https://web.archive.org/web/20201018162618/https://www.precice.org/) |
+| 2019-10 | v1.6.1  | [Wiki](https://github.com/precice/precice/wiki/Home/05df6896b25f6b79e364c86befb4f4a00b3baebe)        | [Archive](https://web.archive.org/web/20191121140032/https://www.precice.org/) |
+| 2019-07 | v1.5.2  | [Wiki](https://github.com/precice/precice/wiki/Home/7a7ba28a760c1351e4a998228d4463b75451e171)        | [Archive](https://web.archive.org/web/20190904131115/https://www.precice.org/) |
+| 2019-04 | v1.4.1  | [Wiki](https://github.com/precice/precice/wiki/Home/8a7f236b7e63c1c1083a4c6720a5afd98e1e6558)        | [Archive](https://web.archive.org/web/20190904131115/https://www.precice.org/) |
+| 2018-11 | v1.3.0  | [Wiki](https://github.com/precice/precice/wiki/Home/d42969b39a4ecb9b079681c6ef87f084218008eb)        | [Archive](https://web.archive.org/web/20181116031228/https://www.precice.org/) |
+| 2018-08 | v1.2.0  | [Wiki](https://github.com/precice/precice/wiki/Home/45cbc46d9538321b4b6cfa589e9305a7f37b94e8)        | [Archive](https://web.archive.org/web/20180814194446/precice.org) |
+| 2018-04 | v1.1.1  | [Wiki](https://github.com/precice/precice/wiki/Home/0ee082ce45fc2ee6864a4ad08cae28980d6c4884)        | [Archive](https://web.archive.org/web/20180409090831/http://www.precice.org/) |
+| 2018-03 | v1.0.3  | [Wiki](https://github.com/precice/precice/wiki/Home/3473c633f5e24be96ee5c8e230efe25414b114e8)        | [Archive](https://web.archive.org/web/20180309040600/http://www.precice.org/) |
+| 2017-11 | v1.0.0  | [Wiki](https://github.com/precice/precice/wiki/Home/91b37e813b55c6a97cf9077efb9b15f3d7e0973c)        | [Archive](https://web.archive.org/web/20171203212904/http://www.precice.org/) |
+| 2016-05 | v0.x    | [Wiki](https://github.com/precice/precice/wiki/Home/1c800ca60691e5f48655a545bda653b096f8ed7b)        | [Archive](https://web.archive.org/web/20160529052152/http://www.precice.org/) |
+| 2015-05 | v0.x    | [Wiki](https://github.com/precice/precice/wiki/Home/deb981d17dbb61edf1c1b48b000f3eb140f0fff4)        | N/A | 
 
-The PDF exports of the documentation are part of the citable [preCICE Distribution](./installation-distribution.html). Alternatively, you can build [previous states of this website](https://github.com/precice/precice.github.io/tags) or see snapshots on the [Wayback Machine](https://web.archive.org/web/20250000000000*/precice.org).
+The dates refer to the documentation snapshot, the website archives do not align, but are listed as starting points.
 
-Before preCICE v2.x, the documentation was hosted in a [GitHub Wiki](https://github.com/precice/precice/wiki/Home/f6bfac33aa878ab3e89e60720894e4fe0a547ab4). For each page you want to visit, look at the previous revisions.
+The PDF exports of the documentation are part of the citable [preCICE Distribution](./installation-distribution.html) and correspond to [website repository tags](https://github.com/precice/precice.github.io/tags).
+
+Before preCICE v2.2.0, the documentation was hosted in a [GitHub Wiki](https://github.com/precice/precice/wiki/Home/f6bfac33aa878ab3e89e60720894e4fe0a547ab4). For each page you want to visit, append the revision id to the page URL.
+
+preCICE found its own home on GitHub and this website in late 2015, moving from a [TUM website](https://web.archive.org/web/20160101233101/http://www5.in.tum.de/wiki/index.php/PreCICE_Webpage) and forge.


### PR DESCRIPTION
The current page on [previous versions](https://precice.org/fundamentals-previous-versions.html) is a bit unstructured and mainly serves as an explanation of the situation.

<img width="1212" height="586" alt="image" src="https://github.com/user-attachments/assets/e16c09f3-f5b4-410a-b34a-47ace8f00a0b" />

This PR adds a table with explicit date-version-URL entries, links to the tags of the repository, adds links to the Wayback Machine, and even a link to the old page on the TUM SCCS website.

It also moves the porting guides URL up, to make them more prominent.

While the entries could become out-of-date, they should be updated in the same PR as the one listing a new distribution publication on DaRUS. And they make the page much more useful than before.

<img width="1212" height="1258" alt="image" src="https://github.com/user-attachments/assets/631464a8-6ab1-4bf4-a56a-bd53d753978a" />

One could argue that the wiki URLs are nowadays useless, but I think they are showcasing the evolution of the project and save quite some time in finding fitting snapshots on the Wayback Machine. They would have at least been useful for me.