### PR TITLE
Remove abandoned QR generator over chart.googleapis.com

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -90,16 +90,5 @@ href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.6.0/dist/instantsearch.min.css">
 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.6.0/dist/instantsearch-theme-algolia.min.css">
 
-<!-- QR code to retrieve printed page -->
-<style>
-@media print {
-    div.post-header:before {
-    	content: url('https://chart.googleapis.com/chart?cht=qr&chs=100x100&chl=https://precice.org{{page.url}}&choe=UTF-8');
-        margin-top: -25px;
-        float: right;
-    }
-}
-</style>
-
 <!-- Plausible Analytics -->
 <script async defer data-domain="precice.org" src="https://plausible.io/js/plausible.js"></script>


### PR DESCRIPTION
The service has been shut down since a while.

Originally, this was used to add a QR code at every printed page.

Related to #656. Keeping that open, since the feature is, in principle, nice to have.