### PR TITLE
Update remaining in.tum.de URLs

### DIFF
--- a/_data/developer.yaml
+++ b/_data/developer.yaml
@@ -10,7 +10,7 @@ leads:
     img: Miriam_Mehl
   - fullname: Hans-Joachim Bungartz
     institution: Technical University of Munich
-    url: https://www.in.tum.de/i05/personen/personen/hans-joachim-bungartz/
+    url: https://www.cs.cit.tum.de/en/sccs/people/univ-prof-dr-hans-joachim-bungartz/
     img: Hans_Bungartz
 
 main:

--- a/collections/_publications/2015-Shukaev.md
+++ b/collections/_publications/2015-Shukaev.md
@@ -1,6 +1,6 @@
 ---
 title: "A Fully Parallel Process-to-Process Intercommunication Technique for preCICE"
-pub-url: http://www5.in.tum.de/pub/Shukaev2015_MasterThesis.pdf
+pub-url: http:/mediatum.ub.tum.de/1461672
 year: 2015
 authors: "Alexander Shukaev"
 ---

--- a/collections/_publications/2016-Cheung.md
+++ b/collections/_publications/2016-Cheung.md
@@ -1,6 +1,6 @@
 ---
 title: "Conjugate Heat Transfer with the Multiphysics Coupling Library preCICE"
-pub-url: http://www5.in.tum.de/pub/Cheung2016_Thesis.pdf
+pub-url: https://mediatum.ub.tum.de/1461907
 year: 2016
 authors: "Lucia Cheung Yau"
 ---

--- a/collections/_publications/2016-Uekermann2.md
+++ b/collections/_publications/2016-Uekermann2.md
@@ -1,6 +1,6 @@
 ---
 title: "The Coupling Library preCICE -- Past, Present and Future"
-pub-url: https://www5.in.tum.de/quartl/2016/quartl80_n.pdf
+pub-url: https://www.cs.cit.tum.de/fileadmin/w00cfj/sccs/_my_direct_uploads/quartl80_n.pdf
 year: 2016
 authors: "Benjamin Uekermann"
 ---

--- a/collections/_testimonials/14-Espinosa.md
+++ b/collections/_testimonials/14-Espinosa.md
@@ -3,7 +3,7 @@ title: "Coupling of Shallow Water Equations and OpenFOAM"
 author: "Francisco Espinosa"
 author_link: "https://github.com/pachesp/"
 organisation: "Chair of Scientific Computing, Technical University of Munich, Germany"
-organisation_link: https://www.in.tum.de/en/i05/home/
+organisation_link: hhttps://www.cs.cit.tum.de/en/sccs/home/
 img: testimonial-espinosa.png
 ---
 As a Master's thesis project at TUM, we used preCICE for coupling the 3D Navier-Stokes model and the 2D Shallow Water Equations model, using the OpenFOAM framework for the Navier-Stokes model and a stand-alone Shallow Water Equations solver written in C++. Such a coupling is interesting e.g. in flood simulations or simulation of sea waves near structures. The black-box coupling approach of preCICE made such a geometric multiscale coupling easier without any changes on the OpenFOAM side. [Learn more](http://mediatum.ub.tum.de/node?id=1577072)

--- a/content/community/workshops/precice-workshop-2020.md
+++ b/content/community/workshops/precice-workshop-2020.md
@@ -17,7 +17,7 @@ Thank you everybody who helped or participated in the workshop. After all the po
 
 [![Group photo](images/events/precice2020-group-cropped.jpg)](images/events/precice2020-group.jpeg)
 
-February 17-18, 2020 at the [Technical University of Munich](https://www.tum.de/), [Department of Informatics](http://www.in.tum.de/en/) (campus Garching), [Lecture Hall 2](https://portal.mytum.de/campus/roomfinder/roomfinder_viewmap?mapid=142&roomid=00.04.011@5604). [Register](https://www5.in.tum.de/workshops/precice-workshop/) until February 7.
+February 17-18, 2020 at the [Technical University of Munich](https://www.tum.de/), [Department of Informatics](http://www.in.tum.de/en/) (campus Garching), [Lecture Hall 2](https://portal.mytum.de/campus/roomfinder/roomfinder_viewmap?mapid=142&roomid=00.04.011@5604). Registeration closed.
 
 After meeting you at invited sessions in conferences around Europe,
 it is time that we meet at home, where everything started.
@@ -74,7 +74,7 @@ More details have been sent to registered participants.
 ## Program details
 
 <details class="workshop-event" id="workshop"><summary>Hands-on introductory workshop</summary>
-<p>Instructors: <a href="https://www5.in.tum.de/wiki/index.php/Gerasimos_Chourdakis,_M.Sc.">Gerasimos Chourdakis</a>, <a href="https://www5.in.tum.de/wiki/index.php/Dr._rer._nat._Benjamin_Uekermann">Benjamin Uekermann</a><br/>
+<p>Instructors: <a href="https://www.cs.cit.tum.de/en/sccs/people/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://github.com/uekerman">Benjamin Uekermann</a><br/>
 Affiliation: Technical Univerisy of Munich, Eindhoven University of Technology, preCICE developers.</p>
 <p>A hands-on introduction to preCICE, recommended for new users that want to learn how to couple their own codes.</p>
 <p>We will couple two simple Python codes, discussing the basic methods of the preCICE API and the structure of the configuration file. We will then also look into tools useful for developing and debugging coupled simulations.</p>
@@ -92,7 +92,7 @@ Affiliation: University of Stuttgart</p>
 </details>
 
 <details class="workshop-event" id="Simonis"><summary>Frédéric Simonis: preCICE v2.0 and beyond</summary>
-<p>Speaker: <a href="https://www5.in.tum.de/wiki/index.php/Fr%C3%A9d%C3%A9ric_Simonis,_M.Sc.">Frédéric Simonis</a><br/>
+<p>Speaker: <a href="https://www.cs.cit.tum.de/en/sccs/people/frederic-simonis/">Frédéric Simonis</a><br/>
 Affiliation: Technical University of Munich, preCICE developer</p>
 <p>preCICE 2.0 brings many changes and improvements at the price of breaking backwards compatibility.
 This talk presents an overview on what has changed in this major release and presents a comprehensive guide on how to painlessly upgrade adapters and configurations. Furthermore, we will have a brief overview of upcoming features.</p>
@@ -141,7 +141,7 @@ Affiliation: Indian Institute of Technology</p>
 </details>
 
 <details class="workshop-event" id="Rueth"><summary>Benjamin Rüth: High-order and multi-rate time stepping with preCICE</summary>
-<p>Authors: <a href="https://www5.in.tum.de/wiki/index.php/Benjamin_R%C3%BCth,_M.Sc._(hons)">Benjamin Rüth</a><br/>
+<p>Authors: <a href="https://www.cs.cit.tum.de/en/sccs/people/benjamin-rueth/">Benjamin Rüth</a><br/>
 Affiliation: Technical University of Munich, preCICE developer</p>
 <p>Many multi-physics applications have solver components that come with their respective scale in time and space. The spatial mapping of preCICE already allows to consequently connect different scales in space, i.e. different mesh resolutions. However, for the time dimension, only a very limited subcycling scheme is implemented to support different scales in time and timestep sizes.</p>
 <p>In this talk, we present a coupling scheme that utilizes waveform iteration and interpolates between time steps of each component to reach high order in time. We present a draft for the future implementation in preCICE and give usage examples. Finally, we want to discuss possible effects on the preCICE API and configuration.</p>
@@ -163,7 +163,7 @@ This is an academic, non-profit conference. However, we still have to collect a 
 
 For early registrations (until November 29), the registration fee is 100€, which covers the catering and the workshop dinner. A later registration (until February 7) is also possible, with a registration fee of 150€.
 
-Please use the [registration form](https://www5.in.tum.de/workshops/precice-workshop/) to register.
+The registration has closed.
 
 ## Getting there
 
@@ -203,7 +203,7 @@ This is a no-profit, academic conference. A big "thank you" to <a href="http://w
 </ul>
 </p>
 
-<p>Please use the <a href="https://www5.in.tum.de/workshops/precice-workshop/">registration form</a> if you would like to submit a talk.</p>
+<p>The registration has closed.</p>
 </details>
 
 ## Important dates

--- a/content/community/workshops/precice-workshop-2021.md
+++ b/content/community/workshops/precice-workshop-2021.md
@@ -27,7 +27,7 @@ The workshop stretches from Monday noon to Thursday evening.
 * 15:00 - 17:00 preCICE Course I (Main Hall)
 
   <details class="workshop-event" id="courseI"><summary>preCICE Course I: Basics and Tools</summary>
-  <p>Instructors: <a href="https://www.in.tum.de/en/i05/people/personen/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://www.simtech.uni-stuttgart.de/exc/people/Uekermann/">Benjamin Uekermann</a><br/>
+  <p>Instructors: <a href="https://www.cs.cit.tum.de/en/sccs/people/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://www.simtech.uni-stuttgart.de/exc/people/Uekermann/">Benjamin Uekermann</a><br/>
   Affiliation: Technical University of Munich, University of Stuttgart, preCICE developers.</p>
   <p>A hands-on introduction to preCICE, recommended for new users that want to learn how to couple their own codes.</p>
   <p>We will couple two simple Python codes, discussing the basic methods of the preCICE API and the structure of the configuration file. We will then also look into tools useful for developing and debugging coupled simulations.</p>
@@ -88,7 +88,7 @@ The workshop stretches from Monday noon to Thursday evening.
 * 14:15 - 16:15 preCICE Course II (Main Hall)
 
   <details class="workshop-event" id="courseII"><summary>preCICE Course II: Implicit coupling for Conjugate Heat Transfer</summary>
-  <p>Instructors: <a href="https://www.in.tum.de/en/i05/people/personen/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://www.simtech.uni-stuttgart.de/exc/people/Uekermann/">Benjamin Uekermann</a><br/>
+  <p>Instructors: <a href="https://www.cs.cit.tum.de/en/sccs/people/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://www.simtech.uni-stuttgart.de/exc/people/Uekermann/">Benjamin Uekermann</a><br/>
   Affiliation: Technical University of Munich, University of Stuttgart, preCICE developers.</p>
   <p>A hands-on introduction to implicit coupling details in preCICE, recommended for new users that want to learn how to make their coupled simulations more accurate and numerically efficient.</p>
   <p>We will couple OpenFOAM and Nutils for Conjugate Heat Transfer, discussing the basic methods of the preCICE API and the structure of the configuration file. We will then also look into tools useful for developing and debugging coupled simulations.</p>

--- a/content/community/workshops/precice-workshop-2022.md
+++ b/content/community/workshops/precice-workshop-2022.md
@@ -27,7 +27,7 @@ The workshop stretches from Monday noon CET to Thursday evening CET.
 * 13:00 - 14:30 CET Developer talks
 
     <details class="workshop-event" id="Chourdakis and Simonis"><summary> Gerasimos Chourdakis and Frédéric Simonis: What's new in preCICE?</summary>
-    <p>Authors: <a href="https://www.in.tum.de/en/i05/people/personen/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://www.in.tum.de/en/i05/people/personen/frederic-simonis/">Frédéric Simonis</a><br/>
+    <p>Authors: <a href="https://www.cs.cit.tum.de/en/sccs/people/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://www.cs.cit.tum.de/en/sccs/people/frederic-simonis/">Frédéric Simonis</a><br/>
     Affiliation: Technical University of Munich, Germany</p>
     <p>The core library became more robust, user-, and resource-friendly, while we restructured the tutorials and polished both bindings and adapters.
     In this talk, we will explore released as well as upcoming changes to both the library and the ecosystem as a whole.</p>
@@ -44,7 +44,7 @@ The workshop stretches from Monday noon CET to Thursday evening CET.
 * 15:30 - 17:00 CET preCICE Course I (Main Hall)
 
   <details class="workshop-event" id="courseI"><summary>preCICE Course I: Basics</summary>
-  <p>Instructors: <a href="https://www.in.tum.de/en/i05/people/personen/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://www.simtech.uni-stuttgart.de/exc/people/Uekermann/">Benjamin Uekermann</a><br/>
+  <p>Instructors: <a href="https://www.cs.cit.tum.de/en/sccs/people/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://www.simtech.uni-stuttgart.de/exc/people/Uekermann/">Benjamin Uekermann</a><br/>
   Affiliation: Technical University of Munich, University of Stuttgart, preCICE developers.</p>
   <p>A hands-on introduction to preCICE, recommended for new users that want to learn how to couple their own codes.</p>
   <p>In this first part, we couple two simple Python codes, discussing the basic methods of the preCICE API.</p>
@@ -153,7 +153,7 @@ The workshop stretches from Monday noon CET to Thursday evening CET.
 * 15:00 - 16:30 CET preCICE Course II (Main Hall)
 
   <details class="workshop-event" id="courseII"><summary>preCICE Course II: Tools</summary>
-  <p>Instructors: <a href="https://www.in.tum.de/en/i05/people/personen/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://www.simtech.uni-stuttgart.de/exc/people/Uekermann/">Benjamin Uekermann</a><br/>
+  <p>Instructors: <a href="https://www.cs.cit.tum.de/en/sccs/people/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://www.simtech.uni-stuttgart.de/exc/people/Uekermann/">Benjamin Uekermann</a><br/>
   Affiliation: Technical University of Munich, University of Stuttgart, preCICE developers.</p>
   <p>A hands-on introduction to preCICE, recommended for new users that want to learn how to couple their own codes.</p>  
   <p>In this second part, we take a tour over available tools to configure, understand, and post-process preCICE simulations. More specifically, we have a look at the preCICE logger, config visualizer, mesh exports, and watchpoints of preCICE. We also discuss common tips for visualizing partitioned simulations in ParaView.</p>
@@ -177,12 +177,12 @@ The workshop stretches from Monday noon CET to Thursday evening CET.
    </details>
 
    <details class="workshop-event" id="Chourdakis"><summary>Gerasimos Chourdakis: Testing the multi‐component preCICE ecosystem </summary>
-   <p>Authors: <a href="https://www.in.tum.de/en/i05/people/personen/gerasimos-chourdakis/">Gerasimos Chourdakis</a><br/> Affiliation: Technical University of Munich, Germany</p>
+   <p>Authors: <a href="https://www.cs.cit.tum.de/en/sccs/people/gerasimos-chourdakis/">Gerasimos Chourdakis</a><br/> Affiliation: Technical University of Munich, Germany</p>
    <p>With several bindings, adapters, tutorials, and more components now in its arsenal, preCICE is now much more than a coupling library: it is a rapidly growing multiphysics ecosystem. One small code contribution in any of the involved repositories can have side-effects on the building, running, and computations of any downstream component. Creating a sustainable testing framework for such a complex ecosystem is not trivial. This talk will discuss the status quo of testing complete coupled simulations for regressions, the ideal system for all the involved stakeholders, challenges specific to preCICE, and novel solutions that will lead us to the new preCICE system tests.</p>
    </details>
 
     <details class="workshop-event" id="Rodenberg"><summary>Benjamin Rodenberg: From low-order to high-order coupling schemes </summary>
-    <p>Authors: <a href="https://www.in.tum.de/en/i05/people/personen/benjamin-rueth/">Benjamin Rodenberg</a><br/>Affiliation: Technical University of Munich, Germany</p>
+    <p>Authors: <a href="https://www.cs.cit.tum.de/en/sccs/people/benjamin-rueth/">Benjamin Rodenberg</a><br/>Affiliation: Technical University of Munich, Germany</p>
     <p>preCICE offers explicit and implicit coupling schemes. They often can only reach first-order accuracy in time. We currently develop an extended coupling scheme that allows time interpolation of coupling data. With this coupling scheme one can generally reach higher order. In this talk I give a practical introduction for low-order and high-order coupling schemes in preCICE.</p>
     </details>
 
@@ -196,7 +196,7 @@ The workshop stretches from Monday noon CET to Thursday evening CET.
 * 13:30 - 15:00 CET preCICE Course III (Main Hall)
 
   <details class="workshop-event" id="courseIII"><summary>preCICE Course III: Implicit Coupling</summary>
-  <p>Instructors: <a href="https://www.in.tum.de/en/i05/people/personen/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://www.simtech.uni-stuttgart.de/exc/people/Uekermann/">Benjamin Uekermann</a><br/>
+  <p>Instructors: <a href="https://www.cs.cit.tum.de/en/sccs/people/gerasimos-chourdakis/">Gerasimos Chourdakis</a>, <a href="https://www.simtech.uni-stuttgart.de/exc/people/Uekermann/">Benjamin Uekermann</a><br/>
   Affiliation: Technical University of Munich, University of Stuttgart, preCICE developers.</p>
   <p>A hands-on introduction to preCICE, recommended for new users that want to learn how to couple their own codes.</p>  
   <p>In this third part, we use a conjugate heat conduction scenario coupling OpenFOAM with Nutils to study implicit coupling.</p>

--- a/content/docs/adapters/calculix/adapter-calculix-overview.md
+++ b/content/docs/adapters/calculix/adapter-calculix-overview.md
@@ -21,7 +21,7 @@ The latest supported CalculiX version is {{site.calculix_version}}. If you alrea
 
 ## History
 
-The adapter was initially developed for conjugate heat transfer (CHT) simulations via preCICE by Lucia Cheung in the scope of her master’s thesis [[1]](https://www5.in.tum.de/pub/Cheung2016_Thesis.pdf) in cooperation with [SimScale](https://www.simscale.com/). For running the adapter for CHT simulations refer to this thesis. The adapter was extended to fluid-structure interaction by Alexander Rusch [[2]](https://doi.org/10.18419/opus-9334).
+The adapter was initially developed for conjugate heat transfer (CHT) simulations via preCICE by Lucia Cheung in the scope of her master’s thesis [[1]](https://mediatum.ub.tum.de/1461907) in cooperation with [SimScale](https://www.simscale.com/). For running the adapter for CHT simulations refer to this thesis. The adapter was extended to fluid-structure interaction by Alexander Rusch [[2]](https://doi.org/10.18419/opus-9334).
 
 ## References
 

--- a/content/docs/adapters/code_aster/adapter-code_aster.md
+++ b/content/docs/adapters/code_aster/adapter-code_aster.md
@@ -163,4 +163,4 @@ There are two methods to visualize the results for Code_Aster:
 
 ## History
 
-The adapter was implemented as part of the [master thesis of Lucia Cheung](https://www5.in.tum.de/pub/Cheung2016_Thesis.pdf) in cooperation with [SimScale](https://www.simscale.com/). For quick access: [an excerpt of Lucia's thesis focusing on the adapter](https://github.com/precice/code_aster-adapter/blob/master/cht/documentation-excerpt.pdf)
+The adapter was implemented as part of the [master thesis of Lucia Cheung](https://mediatum.ub.tum.de/1461907) in cooperation with [SimScale](https://www.simscale.com/). For quick access: [an excerpt of Lucia's thesis focusing on the adapter](https://github.com/precice/code_aster-adapter/blob/master/cht/documentation-excerpt.pdf)

--- a/content/docs/couple-your-code/advanced/couple-your-code-adapter-software-engineering.md
+++ b/content/docs/couple-your-code/advanced/couple-your-code-adapter-software-engineering.md
@@ -30,7 +30,7 @@ This method is particularly useful for adapters used in frameworks that the user
 Examples here include the [FEniCS adapter](./adapter-fenics.html) and the [deal.II adapter](https://github.com/precice/dealii-adapter).
 
 Even when directly modifying the code, it makes sense to hide as many changes as possible behind a class API.
-Examples for this include the [CalculiX adapter](./adapter-calculix-overview.html) and the [SU2 adapter for v6 and earlier](./adapter-su2-overview.html) (as described in [Alexander Rusch's thesis](https://www5.in.tum.de/pub/Rusch2016_BA.pdf)).
+Examples for this include the [CalculiX adapter](./adapter-calculix-overview.html) and the [SU2 adapter for v6 and earlier](./adapter-su2-overview.html) (as described in [Alexander Rusch's thesis](https://mediatum.ub.tum.de/1461810)).
 
 Adapter classes can still be provided as optional modules of the main codebase. Examples include the [deal.II adapter](./adapter-dealii-overview.html), the [G+smo adapter](./adapter-gismo.html), the [DUNE adapter](./adapter-dune.html), and the [DuMux adapter](./adapter-dumux-get.html)
 
@@ -55,7 +55,7 @@ The solver needs to provide the following functionality via the plugin interface
 
 The trickiest part is typically the checkpointing. However, in some cases, this can alternatively be implemented as (a) controlling when the solver moves to the next time step or discards the current solution and tries again, (b) storing restart files and restarting from them (inefficient, but might not be an issue in some cases).
 
-Examples of adapters implemented as plugins include the [OpenFOAM adapter](./adapter-openfoam-overview.html) (with the plugin approach explained in detail in [Gerasimos Chourdakis' thesis](https://www5.in.tum.de/pub/Chourdakis2017_Thesis.pdf)) and the [Fluent adapter](https://github.com/precice/fluent-adapter).
+Examples of adapters implemented as plugins include the [OpenFOAM adapter](./adapter-openfoam-overview.html) (with the plugin approach explained in detail in [Gerasimos Chourdakis' thesis](https://mediatum.ub.tum.de/1462269)) and the [Fluent adapter](https://github.com/precice/fluent-adapter).
 
 ### Adapter wrapper
 

--- a/content/docs/fundamentals/fundamentals-literature-guide.md
+++ b/content/docs/fundamentals/fundamentals-literature-guide.md
@@ -175,7 +175,7 @@ and the story continues by the [current team](about.html).
   * For details regarding gradient-based data mapping schemes, see [Second-order projection-based mapping methods for coupled multi-physics simulations](https://elib.uni-stuttgart.de/bitstream/11682/12145/1/Bachelorthesis_Ariguib.pdf).
   * For details regarding volume-coupling with cell-interpolation, see [Robust and Efficient Barycentric Cell-Interpolation for Volumetric Coupling with preCICE](https://mediatum.ub.tum.de/1685618).
 
-* **Communication** For an introduction to the various techniques, have a look at the dissertation of Bernhard Gatzhammer (Section 4.3). Have a look also at the master's thesis of Alexander Shukaev: "[A Fully Parallel Process-to-Process Intercommunication Technique for preCICE](https://www5.in.tum.de/pub/Shukaev2015_MasterThesis.pdf)".
+* **Communication** For an introduction to the various techniques, have a look at the dissertation of Bernhard Gatzhammer (Section 4.3). Have a look also at the master's thesis of Alexander Shukaev: "[A Fully Parallel Process-to-Process Intercommunication Technique for preCICE](https://mediatum.ub.tum.de/1461672)".
 
 * **Time interpolation** This feature was developed in the context of [Benjamin Rodenberg's dissertation](https://mediatum.ub.tum.de/1763172). The method was described in [Quasi-Newton waveform iteration for partitioned surface-coupled multiphysics applications](https://doi.org/10.1002/nme.6443).
 

--- a/content/index.html
+++ b/content/index.html
@@ -296,12 +296,12 @@ layout: landing_page
 
     <div class="row">
       <div class="col-md-6">
-        <p>preCICE has been developed by three generations of doctoral candidates from the <a href="https://www.in.tum.de/i05">Chair of Scientific Computing</a> at the <strong>Technical University of Munich</strong> and from the <a href="https://www.ipvs.uni-stuttgart.de/">Institute for Parallel and Distributed Systems</a> at the <strong>University of Stuttgart</strong>. We develop everything openly on GitHub, the preCICE library is licensed under LGPLv3, and every other component is developed under compatible free software licenses. <a href="fundamentals-license.html">More information.</a></p>
+        <p>preCICE has been developed by three generations of doctoral candidates from the <a href="https://www.cs.cit.tum.de/en/sccs/home/">Chair of Scientific Computing</a> at the <strong>Technical University of Munich</strong> and from the <a href="https://www.ipvs.uni-stuttgart.de/">Institute for Parallel and Distributed Systems</a> at the <strong>University of Stuttgart</strong>. We develop everything openly on GitHub, the preCICE library is licensed under LGPLv3, and every other component is developed under compatible free software licenses. <a href="fundamentals-license.html">More information.</a></p>
         <p>You can <strong>cite the preCICE library</strong> using the following paper. Please also consider citing the adapters you use, as well as the <a href="installation-distribution.html">preCICE Distribution</a> for <strong>reproducibility</strong>. You can find the respective references in our <a href="fundamentals-literature-guide.html">literature guide</a>.</p>
       </div>
       <div class="col-md-6 equal vertical-align">
         <div class="col-md-4 col-xs-4 col-flex">
-          <a class="no-icon" href="https://www.in.tum.de/i05"><img class="img-responsive center-block uni-logo" src="images/logo/logo_tum_400px.png" alt="TUM logo"></a>
+          <a class="no-icon" href="https://www.cs.cit.tum.de/en/sccs/home/"><img class="img-responsive center-block uni-logo" src="images/logo/logo_tum_400px.png" alt="TUM logo"></a>
         </div>
         <div class="col-md-4 col-xs-4 col-flex">
           <a class="no-icon" href="https://www.ipvs.uni-stuttgart.de/"><img class="img-responsive center-block uni-logo" src="images/logo/logo_stuttgart_400px.png" alt="Uni Stuttgart logo"></a>


### PR DESCRIPTION
The in.tum.de was replaced by cs.cit.tum.de, and many pages do not redirect correctly. This PR updates all such URLs.

Moreover, many links to theses point directly to the PDF, hosted on www5.in.tum.de. These links are already included in the (new, since) MediaTUM, which also provided metadata and BibTeX export.

Also removed the URL to the workshop 2020 registration form.