### PR TITLE
Update asciinema on the landing page and add next steps

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -542,10 +542,10 @@ layout: landing_page
       <div class="row">
         <div class="col-lg-12">
           <p>
-            In this <a href="tutorials-perpendicular-flap.html">tutorial case</a>, we couple OpenFOAM with CalculiX for FSI. OpenFOAM starts and waits for CalculiX. After they both start,
-            they find each other and start performing a serial-implicit coupling with interface quasi-Newton acceleration.
-            These options are set in the preCICE <a href="configuration-overview.html">configuration</a> file
-            <code>precice-config.xml</code>.
+            In this tutorial, we couple the CFD code OpenFOAM with a C++ rigid body solver for fluid-structure interaction, using a serial-explicit coupling, as defined in the <a href="configuration-overview.html">preCICE configuration file</a>.
+            OpenFOAM loads a ready-to-use <a href="adapter-openfoam-overview.html">adapter</a>, while the C++ code uses the <a href="couple-your-code-api.html">preCICE API</a>.
+            OpenFOAM starts and waits for the other code. After they both start,
+            they find each other perform a black-box coupled simulation.
           </p>
         </div>
       </div>
@@ -553,18 +553,22 @@ layout: landing_page
       <div class="row">
         <div class="col-lg-12">
           <div class="hidden-sm hidden-xs">
-            <script id="asciicast-341806" src="https://asciinema.org/a/341806.js" data-size="small" async></script>
+            <script id="asciicast-RqGhiiS8jf2fKTaXgiNn73B1G" src="https://asciinema.org/a/RqGhiiS8jf2fKTaXgiNn73B1G.js" data-size="small" async></script>
           </div>
           <div class="visible-sm visible-xs" style="margin-bottom: 5px;">
-            <a class="no-icon" href="https://asciinema.org/a/341806" target="_blank"><img class="img-responsive center-block" src="https://asciinema.org/a/341806.svg" alt="code animation"/></a>
+            <a class="no-icon" href="https://asciinema.org/a/RqGhiiS8jf2fKTaXgiNn73B1G" target="_blank"><img class="img-responsive center-block" src="https://asciinema.org/a/RqGhiiS8jf2fKTaXgiNn73B1G.svg" alt="code animation"/></a>
           </div>
         </div>
       </div>
 
       <div class="row">
         <div class="col-lg-12">
-          <a href="tutorials.html" class="btn btn-primary no-icon"
-            role="button">Run a tutorial yourself &nbsp;<i class="fas fa-chevron-right"></i></a>
+          <a href="community-channels.html" class="btn btn-default next-steps-link no-icon"
+            role="button">Follow preCICE &nbsp;<i class="fas fa-chevron-right"></i></a>
+          <a href="https://precice.discourse.group/c/what-is/9" class="btn btn-default next-steps-link no-icon"
+            role="button">Is preCICE for me? &nbsp;<i class="fas fa-chevron-right"></i></a>
+          <a href="quickstart.html" class="btn btn-primary next-steps-link no-icon"
+            role="button">Run this tutorial yourself &nbsp;<i class="fas fa-chevron-right"></i></a>
         </div>
       </div>
 

--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -181,6 +181,11 @@ img.testimonial {
   margin-right: 10px;
 }
 
+.next-steps-link {
+  margin-top: 20px;
+  margin-right: 10px;
+}
+
 /* preCICE support */
 
 img.precice-support {


### PR DESCRIPTION
At the bottom of the landing page, we currently have [this recording from 2020](https://asciinema.org/a/341806), which is very outdated (preCICE v1, old tutorials):

<img width="1211" height="1121" alt="Screenshot from 2026-01-02 22-47-54" src="https://github.com/user-attachments/assets/e653b55b-b0ce-4de1-a222-5c96f3820f7d" />

This PR replaces that with [a new recording](https://asciinema.org/a/RqGhiiS8jf2fKTaXgiNn73B1G):

<img width="1211" height="989" alt="Screenshot from 2026-01-02 22-47-20" src="https://github.com/user-attachments/assets/5aec80b8-e28e-4ad3-9483-714ab8ff2336" />

The new recording:

- Replaces the perpendicular flap with the Quickstart, to:
   - Be able to show the concept of calling preCICE in a code
   - Clarify that the focus is on coupling your own code
   - Give an impulse on actually trying it as a next step
- Restricts the coupling time to two time windows, to fit the complete log in one terminal on the Solid side
- Has section markers
- Has a voiceover
- Hides a lot of the setup and teardown shown in the rpevious video
- Is still ~2min
- Uses asciinema v3

This PR also modifies the buttons to give clear next steps (closes #86), pointing to:

- https://precice.org/community-channels.html
- https://precice.discourse.group/c/what-is/9 ("is preCICE for me?" category)
- Quickstart

I will add the recording on the Quickstart page in another PR.

## Why still asciinema?

- Very lightweight
- No cookies/tracking
- Some possibility for easy edits (in content, but also in color scheme, format, and more)
- Nice gimmick

## How-to

Hoping to find this information when I want to update this video again:

- Get the tutorials from the distribution, as a file, and build released versions. Especially for the OpenFOAM adapter, build it in release mode, to hide excessive output.
- Start asciinema with a tmux session prepared:

   ```shell
   asciinema record --title "Quickstart" --command "tmux new-session \; split-window -h \; select-pane -L"  /path/to/file.cast
   ```

- Add markers as events later (or with the keyboard shortcut)
- Upload the recording
- Play and write down a script of what to say
- Cut and adjust synchronization in Audacity
- Enhance audio with Adobe podcast
- Upload to https://github.com/MakisH/served, to not pollute this repo, and to still have it served from GitHub
- Link with the recording
- Fine-tune the synching

Shortcuts:

- tmux move panes: Ctrl-m-o
- tmux detach session: Ctrl-m-d
- end recording: Ctrl-d

The way I did it this time, tmux detached also the asciinema session, but I could still use the recording.