### PR TITLE
Update social links in topnav and community channels

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -85,11 +85,11 @@
                     <a class="no-icon nav-external" href="https://github.com/precice" target="_blank" data-show-count="false" aria-label="Star precice/precice on GitHub"><i class="fab fa-github"></i></a>
                 </li>
                 <li>
-                    <!-- rel="me" required by Mastodon for verification -->
-                    <a rel="me" class="no-icon nav-external" href="https://fosstodon.org/@precice" target="_blank" data-show-count="false" aria-label="Follow us on Mastodon"><i class="fab fa-mastodon"></i></a>
+                    <a class="no-icon nav-external" href="https://www.linkedin.com/company/precice" target="_blank" data-show-count="false" aria-label="Follow us on LinkedIn"><i class="fab fa-linkedin"></i></a>
                 </li>
                 <li>
-                    <a class="no-icon nav-external" href="https://bsky.app/profile/precice.org" target="_blank" data-show-count="false" aria-label="Follow us on Bluesky"><i class="fab fa-bluesky"></i></a>
+                    <!-- rel="me" required by Mastodon for verification -->
+                    <a rel="me" class="no-icon nav-external" href="https://fosstodon.org/@precice" target="_blank" data-show-count="false" aria-label="Follow us on Mastodon"><i class="fab fa-mastodon"></i></a>
                 </li>
                 <li>
                     <a class="no-icon nav-external" href="https://www.youtube.com/c/preCICECoupling/" target="_blank" data-show-count="false" aria-label="Subscribe on Youtube"><i class="fab fa-youtube"></i></a>

--- a/content/community/community-channels.md
+++ b/content/community/community-channels.md
@@ -19,9 +19,10 @@ You can find us in a few different places, mainly on our [preCICE forum on Disco
 
 Apart from Matrix & Discourse, you can also:
 
+- Follow us on [GitHub](https://github.com/precice/) and star the repositories of your interest.
+- Follow us on [LinkedIn](https://www.linkedin.com/company/precice).
 - Follow us on [Mastodon](https://fosstodon.org/@precice) and on [Bluesky](https://bsky.app/profile/precice.org).
 - Subscribe to our [YouTube channel](https://www.youtube.com/c/preCICECoupling/).
-- Follow us on [LinkedIn](https://www.linkedin.com/company/precice).
 - Create an alert on Google Scholar for citations to our reference papers: [v1, 2016](https://scholar.google.de/scholar?cites=5053469347483527186&as_sdt=2005&sciodt=0,5&hl=en), [v2, 2021](https://scholar.google.com/scholar?hl=en&cites=17974677460269868025).
 
 Apart from the above channels, we hope to see you in one of our [preCICE workshops](precice-workshop.html).


### PR DESCRIPTION
- Add LinkedIn to the topnav
- For space reasons, replace Bluesky (still in the community channels)
- Move LInkedIn higher up in community channels
- Add a prompt to follow the GitHub organization and star repositories