### PR TITLE
Add more links to the adapter and application case guidelines

### DIFF
--- a/content/community/contribute/community-contribute-to-precice.md
+++ b/content/community/contribute/community-contribute-to-precice.md
@@ -205,6 +205,10 @@ Look for [contributing guidelines](https://github.com/precice/precice/blob/devel
 Read on our [Roadmap](fundamentals-roadmap.html) what is already in our to-do list before starting to write large parts of code.
 {% endtip %}
 
+{% tip %}
+There are [guidelines for adapters](community-guidelines-adapters.html) and [guidelines for application cases](community-guidelines-application-cases.html).
+{% endtip %}
+
 ## Helping other users
 
 We would really appreciate it if you followed our [community channels](community-channels.html) and joined us in answering questions.

--- a/content/docs/couple-your-code/couple-your-code-overview.md
+++ b/content/docs/couple-your-code/couple-your-code-overview.md
@@ -22,6 +22,10 @@ There is a [step-by-step guide](couple-your-code-preparing-your-solver.html), wh
 
 There is a list of advanced topics. These topics are not all relevant to every user. They deal with specific problems for certain types of codes: how to handle FEM meshes, how to handle moving meshes, etc.  
 
+## What best practices should I follow?
+
+There are standardized [guidelines for adapters](community-guidelines-adapters.html) and [guidelines for application cases](https://precice.org/community-guidelines-application-cases.html).
+
 ## You want to port your adapter to a newer preCICE version?
 
 There are specific pages on [porting adapters from preCICE between major versions](couple-your-code-porting-overview.html).

--- a/content/docs/couple-your-code/porting/couple-your-code-porting-v1-2.md
+++ b/content/docs/couple-your-code/porting/couple-your-code-porting-v1-2.md
@@ -6,6 +6,11 @@ summary: "This guide helps you to upgrade from preCICE 1.x to preCICE 2.x."
 redirect_from: couple-your-code-porting-adapters.html
 ---
 
+{% tip %}
+Reviving that old adapter? Good opportunity to learn about some best practices and make it easier to reuse and maintain!
+There are [guidelines for adapters](community-guidelines-adapters.html) and [guidelines for application cases](community-guidelines-application-cases.html).
+{% endtip %}
+
 ## preCICE API
 
 ### Single-step setup

--- a/content/docs/couple-your-code/porting/couple-your-code-porting-v2-3.md
+++ b/content/docs/couple-your-code/porting/couple-your-code-porting-v2-3.md
@@ -10,6 +10,11 @@ Missing:
 #1352
 -->
 
+{% tip %}
+Reviving that old adapter? Good opportunity to learn about some best practices and make it easier to reuse and maintain!
+There are [guidelines for adapters](community-guidelines-adapters.html) and [guidelines for application cases](community-guidelines-application-cases.html).
+{% endtip %}
+
 ## preCICE API
 
 The following is a diff of how an adapter-port could look like. The guide continues underneath the code.

--- a/content/docs/couple-your-code/step-by-step/couple-your-code-preparing-your-solver.md
+++ b/content/docs/couple-your-code/step-by-step/couple-your-code-preparing-your-solver.md
@@ -52,6 +52,11 @@ In the following steps, we will slowly add more and more calls to the preCICE AP
 Also have a look at the [definite C++ API documentation](https://precice.org/doxygen/main/classprecice_1_1Participant.html).
 {% endtip %}
 
+{% tip %}
+Looking for best practices? There are [guidelines for adapters](community-guidelines-adapters.html) and [guidelines for application cases](community-guidelines-application-cases.html).
+{% endtip %}
+
+
 {% note %}
 This example refers to preCICE v3.x: [see the differences from preCICE v2.x](couple-your-code-porting-v2-3.html).
 {% endnote %}

--- a/content/docs/couple-your-code/step-by-step/couple-your-code-preparing-your-solver.md
+++ b/content/docs/couple-your-code/step-by-step/couple-your-code-preparing-your-solver.md
@@ -56,7 +56,6 @@ Also have a look at the [definite C++ API documentation](https://precice.org/dox
 Looking for best practices? There are [guidelines for adapters](community-guidelines-adapters.html) and [guidelines for application cases](community-guidelines-application-cases.html).
 {% endtip %}
 
-
 {% note %}
 This example refers to preCICE v3.x: [see the differences from preCICE v2.x](couple-your-code-porting-v2-3.html).
 {% endnote %}


### PR DESCRIPTION
Closes #600.

Adds links to the adapter and application guidelines in:

- https://precice.org/community-contribute-to-precice.html
- https://precice.org/couple-your-code-overview.html
- https://precice.org/couple-your-code-preparing-your-solver.html
- https://precice.org/couple-your-code-porting-v1-2.html
- https://precice.org/couple-your-code-porting-v2-3.html

#663 also updated the FAQ item on the landing page:

- https://precice.org/#frequently-asked-questions-faq