### PR TITLE
Update minisymposia/workshops: Link proceedings and add/fix slides URLs

### DIFF
--- a/content/community/minisymposia/community-events-wccm-2021.md
+++ b/content/community/minisymposia/community-events-wccm-2021.md
@@ -8,6 +8,8 @@ toc: false
 
 The [ECCOMAS WCCM 2020](https://web.archive.org/web/20201203110253/https://www.wccm-eccomas2020.org/frontal/MSList.as) was originally scheduled for summer 2020 in Paris, but was moved to January 11-15, 2021 in a virtual format. Continuing the tradition, we organized a minisymposium (MS202) "[Multiphysics simulations with the coupling library preCICE](https://web.archive.org/web/20220517234111/http://wccm-eccomas2020.org/admin/Files/FileAbstract/a202.pdf)".
 
+ [Conference proceedings](https://www.scipedia.com/sj/wccm-eccomas2020)
+
 ## The minisymposium
 
 Thanks to the WCCM organizers, authors were given access to their recorded talks to be shared with the public. The links of the titles below lead to the recordings on SlideLive.

--- a/content/community/minisymposia/community-events-wccm-2021.md
+++ b/content/community/minisymposia/community-events-wccm-2021.md
@@ -6,7 +6,7 @@ permalink: community-events-wccm-eccomas-2020.html
 toc: false
 ---
 
-The [ECCOMAS WCCM 2020](https://www.wccm-eccomas2020.org/frontal/introduction.asp) ([archive](https://web.archive.org/web/20201203110253/https://www.wccm-eccomas2020.org/frontal/MSList.asp)) was originally scheduled for summer 2020 in Paris, but was moved to January 11-15, 2021 in a virtual format. Continuing the tradition, we organized a minisymposium (MS202) "[Multiphysics simulations with the coupling library preCICE](https://www.wccm-eccomas2020.org/admin/Files/FileAbstract/a202.pdf)".
+The [ECCOMAS WCCM 2020](https://web.archive.org/web/20201203110253/https://www.wccm-eccomas2020.org/frontal/MSList.as) was originally scheduled for summer 2020 in Paris, but was moved to January 11-15, 2021 in a virtual format. Continuing the tradition, we organized a minisymposium (MS202) "[Multiphysics simulations with the coupling library preCICE](https://web.archive.org/web/20220517234111/http://wccm-eccomas2020.org/admin/Files/FileAbstract/a202.pdf)".
 
 ## The minisymposium
 
@@ -23,7 +23,7 @@ If you gave a talk at the minisymposium, please contact us and we will include i
 - 3999 - [Fluid-Structure Interaction Analysis for Martian Exploration Parafoil with Deployable Structure by Coupling Library preCICE](https://slideslive.com/38944341) by Kunihiro Ishida
 - 5180 - Eulerian--Lagrangian momentum coupling between XDEM and OpenFOAM using preCICE by Alban Rousset
 
-You can find all the abstracts in the [book of WCCM abstracts](https://www.wccm-eccomas2020.org/frontal/docs/WCCM-XIV-ECCOMAS-2020.pdf).
+You can find all the abstracts in the [book of WCCM abstracts](https://hal.science/hal-03136370v1), and related papers in the [conference proceedings](https://www.scipedia.com/sj/wccm-eccomas2020).
 
 Our (rather small) minisymposium was not included in the live sessions, but we organized our own live session, which was a nice chance to discuss with the speakers. Read more and comment in [the forum](https://precice.discourse.group/t/precice-minisymposium-at-eccomas-wccm-2020-this-week/416).
 

--- a/content/community/minisymposia/eccomas-congress-2022.md
+++ b/content/community/minisymposia/eccomas-congress-2022.md
@@ -6,7 +6,9 @@ permalink: eccomas-congress-2022.html
 toc: false
 ---
 
-The [ECCOMAS Congress 2022](http://www.eccomas2022.org/frontal/default.asp) is scheduled for June 5-9, 2022, and will take place in Oslo, Norway. Similar to previous ECCOMAS conferences, we are again organizing a minisymposium [Multi-physics simulations with the coupling library preCICE](http://www.eccomas2022.org/admin/Files/FileAbstract/MS46.pdf).
+The [ECCOMAS Congress 2022](http://www.eccomas2022.org/frontal/default.asp) took place between June 5-9, 2022, in Oslo, Norway. Similar to previous ECCOMAS conferences, we organized a minisymposium [Multi-physics simulations with the coupling library preCICE](http://www.eccomas2022.org/admin/Files/FileAbstract/MS46.pdf).
+
+[Conference proceedings](https://www.scipedia.com/sj/eccomas2022)
 
 ## The invited session
 

--- a/content/community/minisymposia/eccomas-congress-2022.md
+++ b/content/community/minisymposia/eccomas-congress-2022.md
@@ -22,7 +22,7 @@ Session: [MS46A](https://www.eccomas2022.org/frontal/ProgSesion.asp?id=117)
 [An introduction to the preCICE coupling library](https://ipvs.informatik.uni-stuttgart.de/cloud/s/iJFHgb6pXJxdfyk)
 
 * **Alexander Jaust et al.**:
-[Simulation of multi-physics porous-media applications using partitioned black-box methods](https://ipvs.informatik.uni-stuttgart.de/cloud/s/3GWfdZ33Z4bH7tf)
+[Simulation of multi-physics porous-media applications using partitioned black-box methods](https://ipvscloud.informatik.uni-stuttgart.de/s/ojKra5GQAy8qEra)
 
 * **Prasad Adhav et al.**:
 Heat and mass transfer between XDEM \& OPENFOAM using preCICE coupling library
@@ -31,10 +31,10 @@ Heat and mass transfer between XDEM \& OPENFOAM using preCICE coupling library
 [Coupling 1D thermohydraulics with 3D CFD via preCICE](https://mediatum.ub.tum.de/node?id=1662597)
 
 * **Ishaan Desai et al.**:
-[Adaptive and flexible macro-micro coupling software](https://ipvs.informatik.uni-stuttgart.de/cloud/s/BSA9B4gKLd3LHBk)
+[Adaptive and flexible macro-micro coupling software](https://ipvscloud.informatik.uni-stuttgart.de/s/QbJg62H9y9ftFHG)
 
 * **Louis Viot et al.**:
-[MaMiCo-preCICE coupling for hybrid molecular-continuum flow simulations](https://ipvs.informatik.uni-stuttgart.de/cloud/s/5HLfGPTrizbpKD2)
+[MaMiCo-preCICE coupling for hybrid molecular-continuum flow simulations](https://ipvscloud.informatik.uni-stuttgart.de/s/4HNEs8JqSPtFk9L)
 
 ### Thursday, June 9, 2021, 16:30–18:30
 
@@ -48,13 +48,13 @@ Session: [MS46B](https://www.eccomas2022.org/frontal/ProgSesion.asp?id=240)
 A Benchmark for Fluid-Structure Interaction in Hybrid Manufacturing: Simulation with preCICE in OpenFOAM
 
 * **Jurgen Kersschot et al.**:
-[Simulation of the flow-acoustic-structural interaction in flow ducts using a partitioned approach in the time domain](https://ipvs.informatik.uni-stuttgart.de/cloud/s/WsrHdGGqcHWQi9H)
+[Simulation of the flow-acoustic-structural interaction in flow ducts using a partitioned approach in the time domain](https://ipvscloud.informatik.uni-stuttgart.de/s/y4Zss7KqsXgs4Mf)
 
 * **Kyle Davis et al.**:
-[Evaluation of Radial Basis Function Mapping for Fluid-Structure Interaction Simulations](https://ipvs.informatik.uni-stuttgart.de/cloud/s/gMEQ4nd6BaQFetp)
+[Evaluation of Radial Basis Function Mapping for Fluid-Structure Interaction Simulations](https://ipvscloud.informatik.uni-stuttgart.de/s/FJoeTgi2xG9q9Gp)
 
 * **Rachael Smith et al.**:
-[A fluid structure interaction study of a large-scale wind turbine blade using preCICE](https://ipvs.informatik.uni-stuttgart.de/cloud/s/7yN6K7zkQR5NqWH)
+[A fluid structure interaction study of a large-scale wind turbine blade using preCICE](https://ipvscloud.informatik.uni-stuttgart.de/s/jZBxFiiMomGBNj7)
 
 ## Further talks about preCICE
 

--- a/content/community/minisymposia/eccomas-coupled-2019.md
+++ b/content/community/minisymposia/eccomas-coupled-2019.md
@@ -10,6 +10,8 @@ The [ECCOMAS Coupled Problems 2019](https://congress.cimne.com/coupled2019/) too
 
 We organized the minisymposium _Multi-physics Simulations with the Coupling Library preCICE_, which had three sessions.
 
+[Conference proceedings](https://www.scipedia.com/sj/coupled2019)
+
 ## Schedule of the Minisymposium
 
 ### Wednesday, June 5, 11:30 - 13:30

--- a/content/community/minisymposia/eccomas-coupled-2021.md
+++ b/content/community/minisymposia/eccomas-coupled-2021.md
@@ -6,8 +6,7 @@ permalink: eccomas-coupled-2021.html
 toc: false
 ---
 
-The [ECCOMAS COUPLED 2021](https://congress.cimne.com/coupled2021/frontal/default.asp)
-([archive](https://web.archive.org/web/20201027054315/https://congress.cimne.com/coupled2021/frontal/InvitedSessions.asp))
+The [ECCOMAS COUPLED 2021](https://web.archive.org/web/20201027054315/https://congress.cimne.com/coupled2021/frontal/InvitedSessions.asp)
 was originally scheduled for summer 2021 in Chia Laguna, South Sardinia, Italy but was changed to a virtual format.
 Continuing the tradition, we are organizing an invited session [Multi-physics simulations with the coupling library preCICE](https://congress.cimne.com/coupled2021/frontal/doc/IS/MultiPhysicsSimulationsWithCouplingLibraryPreCICE.pdf).
 

--- a/content/community/minisymposia/eccomas-coupled-2021.md
+++ b/content/community/minisymposia/eccomas-coupled-2021.md
@@ -33,4 +33,3 @@ Follow the discussion on [the forum](https://precice.discourse.group/t/precice-i
 ## Further talks about preCICE
 
 Large conferences like this are an ideal opportunity to discuss with other groups and change our perspective. For this reason, we often participate with talks in different sessions.
-

--- a/content/community/minisymposia/eccomas-coupled-2021.md
+++ b/content/community/minisymposia/eccomas-coupled-2021.md
@@ -8,11 +8,11 @@ toc: false
 
 The [ECCOMAS COUPLED 2021](https://web.archive.org/web/20201027054315/https://congress.cimne.com/coupled2021/frontal/InvitedSessions.asp)
 was originally scheduled for summer 2021 in Chia Laguna, South Sardinia, Italy but was changed to a virtual format.
-Continuing the tradition, we are organizing an invited session [Multi-physics simulations with the coupling library preCICE](https://congress.cimne.com/coupled2021/frontal/doc/IS/MultiPhysicsSimulationsWithCouplingLibraryPreCICE.pdf).
+Continuing the tradition, we organized an invited session [Multi-physics simulations with the coupling library preCICE](https://congress.cimne.com/coupled2021/frontal/doc/IS/MultiPhysicsSimulationsWithCouplingLibraryPreCICE.pdf).
 
 ## The invited session
 
-Preliminary schedule (to be confirmed by the conference organizers):
+Schedule:
 
 ### Wednesday June 16, 2021, 14:00–16:00
 
@@ -34,4 +34,3 @@ Follow the discussion on [the forum](https://precice.discourse.group/t/precice-i
 
 Large conferences like this are an ideal opportunity to discuss with other groups and change our perspective. For this reason, we often participate with talks in different sessions.
 
-Stay tuned for more details.

--- a/content/community/minisymposia/eccomas-coupled-2023.md
+++ b/content/community/minisymposia/eccomas-coupled-2023.md
@@ -6,9 +6,11 @@ permalink: eccomas-coupled-2023.html
 toc: false
 ---
 
-The [ECCOMAS Coupled Problems 2023](https://coupled2023.cimne.com/) will take place on Crete from June 5 to June 7.
+The [ECCOMAS Coupled Problems 2023](https://coupled2023.cimne.com/) took place on Crete from June 5 to June 7.
 
-We are again organizing a preCICE minisymposium: [Multi-Physics and Multi-Scale Simulations with the Coupling Library preCICE](https://coupled2023.cimne.com/area/d41c23af-2df5-11ed-8e5b-000c29ddfc0c) (IS14).
+We organized a preCICE minisymposium: [Multi-Physics and Multi-Scale Simulations with the Coupling Library preCICE](https://coupled2023.cimne.com/area/d41c23af-2df5-11ed-8e5b-000c29ddfc0c) (IS14).
+
+[Conference proceedings](https://www.scipedia.com/sj/coupled2023)
 
 Feel free to ask questions in the [corresponding thread of the forum](https://precice.discourse.group/t/call-for-contributions-eccomas-coupled-problems-2023/1278).
 

--- a/content/community/minisymposia/eccomas-coupled-2025.md
+++ b/content/community/minisymposia/eccomas-coupled-2025.md
@@ -8,13 +8,15 @@ toc: false
 
 The [ECCOMAS Coupled Problems 2025](https://coupled2025.cimne.com/) will take place on Sardinia, Italy from May 26 to 29.
 
-We are again organizing a preCICE minisymposium: [Multi-Physics and Multi-Scale Simulations with the Coupling Library preCICE](https://coupled2025.cimne.com/event/session/e430d14b-0b28-11f0-9835-000c29ddfc0c) ([abstract](https://coupled2025.cimne.com/event/area/3dec3ef1-70ff-11ef-bbc6-000c29ddfc0c)) (IS042).
+We organized a preCICE minisymposium: [Multi-Physics and Multi-Scale Simulations with the Coupling Library preCICE](https://coupled2025.cimne.com/event/session/e430d14b-0b28-11f0-9835-000c29ddfc0c) ([abstract](https://coupled2025.cimne.com/event/area/3dec3ef1-70ff-11ef-bbc6-000c29ddfc0c)) (IS042).
+
+[Conference proceedings](https://www.scipedia.com/sj/coupled2025)
 
 Feel free to ask questions in the [corresponding thread of the forum](https://precice.discourse.group/t/call-for-contributions-eccomas-coupled-problems-2025/2197).
 
 ## Schedule of the Minisymposium
 
-Our minisymposium is scheduled as one session (IS042A) on Tuesday, May 27, 14:00-16:00 in the "Samarcanda" room. Presentations:
+Our minisymposium took one session (IS042A) on Tuesday, May 27, 14:00-16:00 in the "Samarcanda" room. Presentations:
 
 - [A quick introduction to the coupling library preCICE](https://coupled2025.cimne.com/event/contribution/39120852-c766-11ef-94cb-000c29ddfc0c) (Felix Neubauer, University of Stuttgart, Germany)
 - [Magnetothermal Coupling with preCICE for Multiphysical Simulations of Electric Machines](https://coupled2025.cimne.com/event/contribution/02bae26f-c438-11ef-94cb-000c29ddfc0c) (Michael Wieshau, Technical University of Darmstadt, Germany)
@@ -26,7 +28,7 @@ If you are a speaker, see the documentation page [Talk about your work](communit
 
 ## Related talks in other sessions
 
-Let us know if you are talking about preCICE in another session. We already know of the following:
+Let us know if you talked about preCICE in another session. We already know of the following:
 
 In [IS006B Advances in Computational Methods for Digital Twins in Coupled Systems II](https://coupled2025.cimne.com/event/session/c383c2a3-2cc3-a10b-2611-c3b0c2983500) (Monday 14:00-16:00):
 
@@ -50,4 +52,4 @@ In [IS049B Numerical methods that enable the heterogeneous coupling of conventio
 
 ## Further events
 
-We are organizing a coming together of the preCICE community on Monday evening, advertised among participants of the preCICE minisymposium. Let us know if you would like to join as well.
+We are organized a coming together of the preCICE community on Monday evening, advertised among participants of the preCICE minisymposium.

--- a/content/community/minisymposia/iacm-wccm-2024.md
+++ b/content/community/minisymposia/iacm-wccm-2024.md
@@ -6,9 +6,9 @@ permalink: iacm-wccm-2024.html
 toc: false
 ---
 
-The [WCCM 2024 / PANACM 2024](https://wccm2024.usacm.org/) will take place in Vancouver, Canada, between July 21-26.
+The [WCCM 2024 / PANACM 2024](https://wccm2024.usacm.org/) took place in Vancouver, Canada, between July 21-26.
 
-We are again organizing a preCICE minisymposium: [Multi-Physics and Multi-Scale Simulations with the Coupling Library preCICE](https://storage.googleapis.com/usacm_static_shared/wccm2024/MS_0415.pdf) (0415). Preliminary schedule:
+We organized a preCICE minisymposium: [Multi-Physics and Multi-Scale Simulations with the Coupling Library preCICE](https://storage.googleapis.com/usacm_static_shared/wccm2024/MS_0415.pdf) (0415). Schedule:
 
 - [Session 1](https://events.rdmobile.com/Sessions/Details/2422120) (TS7, Wed 9:45-11:45):
   - A quick introduction to the coupling library preCICE and the minisymposium (Gerasimos Chourdakis, University of Stuttgart)
@@ -20,7 +20,7 @@ We are again organizing a preCICE minisymposium: [Multi-Physics and Multi-Scale 
   - Flexible macro-micro coupling for spatial simulation of the liver (Steffen Gerhäusser, University of Stuttgart)
   - A coupled two-muscle-one-tendon model of the agonist-antagonist myoneural interface (Carme Homs Pons, University of Stuttgart)
 
-Next to the minisymposium, we are also organizing a [full-day training course](https://wccm2024.usacm.org/short-courses) in the context of the conference and we are contributing a general poster about preCICE and the new [preECO project](https://precice.discourse.group/t/shape-the-future-of-the-precice-ecosystem-the-preeco-project/2019/1).
+Next to the minisymposium, we organized a [full-day training course](https://wccm2024.usacm.org/short-courses) in the context of the conference and we contributed a general poster about preCICE and the new [preECO project](https://precice.discourse.group/t/shape-the-future-of-the-precice-ecosystem-the-preeco-project/2019/1).
 
 Other talks mentioning preCICE in their abstract:
 

--- a/content/community/workshops/precice-workshop-2025.md
+++ b/content/community/workshops/precice-workshop-2025.md
@@ -111,7 +111,7 @@ Preliminary schedule:
       <summary>
       News on the preCICE coupling library<br/>
       <p>Frédéric Simonis (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Simonis/">webpage</a>, <a href="https://github.com/fsimonis">GitHub</a>)<br/>
-      University of Stuttgart, Germany</p>
+      University of Stuttgart, Germany - <a href="https://doi.org/10.5281/zenodo.17349449">slides</a></p>
       </summary>
       <p>New features, fixes, and plans in the core library. A deeper look into the <a href="https://github.com/precice/precice/releases/tag/v3.2.0">v3.2.0</a> release notes and further developments since (<a href="https://github.com/precice/precice/tree/develop/docs/changelog">changelog entries</a>, <a href="https://github.com/precice/precice/milestone/27?closed=1">v3.3.0 milestone</a>, <a href="./fundamentals-roadmap.html">roadmap</a>).</p>
     </details>
@@ -119,7 +119,7 @@ Preliminary schedule:
       <summary>
       News on the preCICE coupling ecosystem<br/>
       <p>Gerasimos Chourdakis (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Chourdakis/">webpage</a>, <a href="https://github.com/MakisH">GitHub</a>)<br/>
-      University of Stuttgart, Germany</p>
+      University of Stuttgart, Germany - <a href="https://doi.org/10.5281/zenodo.17307038">slides</a></p>
       </summary>
       <p>Updates on the available bindings, adapters, tutorials, and further tools built on top of the core library and included in the <a href="./installation-distribution.html">preCICE distribution</a>.</p>
     </details>
@@ -127,7 +127,7 @@ Preliminary schedule:
       <summary>
       News on the standardization process<br/>
       <p>Benjamin Uekermann (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Uekermann-00001/">webpage</a>, <a href="https://github.com/uekerman">GitHub</a>)<br/>
-      University of Stuttgart, Germany</p>
+      University of Stuttgart, Germany - <a href="https://doi.org/10.5281/zenodo.17310236">slides</a></p>
       </summary>
       <p>Updates on the standardization process and the DFG project preECO, including <a href="https://precice.org/community-guidelines-adapters.html">guidelines for adapters</a> and <a href="https://precice.org/community-guidelines-application-cases.html">guidelines for application cases</a>.</p>
     </details>
@@ -170,7 +170,7 @@ Preliminary schedule:
       <summary>
       News on the automation tools<br/>
       <p>Felix Neubauer (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Neubauer-00007/">webpage</a>, <a href="https://github.com/Logende">GitHub</a>)<br/>
-      University of Stuttgart, Germany</p>
+      University of Stuttgart, Germany - <a href="https://doi.org/10.5281/zenodo.17104911">slides</a></p>
       </summary>
       <p>Overview of new automation tools such as the <a href="https://github.com/precice/cli">preCICE command-line interface</a>, <a href="https://github.com/precice/case-generate">configuration generator</a>, <a href="https://github.com/precice/config-check">configuration checker</a>, and more.</p>
     </details>
@@ -181,7 +181,7 @@ Preliminary schedule:
     <details class="workshop-event" id="talk-thornton"><br/>
       <summary>Coupling Particle Simulations: Challenges, Strategies, and the ON-DEM Vision
       <p>Anthony Thornton*, Thomas Weinhart, Daniel Barreto<br/>
-      University of Manchester, UK</p>
+      University of Manchester, UK - <a href="https://doi.org/10.5281/zenodo.17258370">slides</a></p>
       </summary>
       <p>The Discrete Particle Method (DPM), aka Discrete Element Method (DEM), simulates the motion and interaction of individual grains and has proven highly successful in modelling granular processes. However, tackling the next generation of challenges—such as multiphysics interactions and multiscale phenomena—requires coupling DPM with continuum solvers for fluids and deformable solids. Additionally, the growing complexity of industrial processes is pushing the limits of DEM, which remains computationally intensive. This calls for flexible, efficient coupling strategies to extend the capabilities of DEM. In this talk, we present the main types of DEM coupling currently used in the field. We focus on three key approaches: Surface coupling, which models the interaction between granular materials and soft or deformable boundaries; Volume coupling, which allows hybrid modelling where some regions are simulated with DEM and others with a continuum approach—enhancing scalability without sacrificing accuracy; Particle–fluid coupling, which models the interaction of particles with a background fluid or thermal field. We also introduce the newly funded European COST network ON-DEM (Open Network on DEM simulations), which aims to accelerate progress in this area. We conclude by discussing the integration of the coupling library preCICE, highlighting its potential as a key enabler for ON-DEM's goals and the broader future of particle simulation.</p>
     </details>
@@ -208,7 +208,7 @@ Preliminary schedule:
     <details class="workshop-event" id="talk-simonis"><br/>
       <summary>Dynamic Meshes in preCICE
       <p>Frédéric Simonis* (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Simonis/">webpage</a>, <a href="https://github.com/fsimonis">GitHub</a>), Benjamin Uekermann<br/>
-      University of Stuttgart, Germany</p>
+      University of Stuttgart, Germany - <a href="https://doi.org/10.5281/zenodo.17349604">slides</a></p>
       </summary>
       <p>preCICE is an open-source coupling library for partitioned multi-physics simulations. It provides a flexible framework for exchanging mesh-based data between different simulation codes, enabling the simulation of complex multi-physics problems involving multiple solvers. These solvers may run on massively parallel systems with large meshes partitioned among their ranks. To facilitate leveraging parallel systems, preCICE requires solver meshes to remain static during the simulation. This restricts users in need of moving geometries to either using ALE methods relying on a static reference domain, or to use direct-mesh access and handle data-mapping themselves. In this talk, I showcase the current state of dynamic meshes to preCICE as well as cost-effective use-cases. This includes the necessary orchestration to ensure a consistent state between solvers, the challenges of handling the shift of work from one-time to reoccurring operations, and open questions regarding implicit coupling.</p>
     </details>
@@ -228,7 +228,7 @@ Preliminary schedule:
     <details class="workshop-event" id="talk-chen"><br/>
       <summary>Bound-Aware Quasi-Newton Strategies for Partitioned Coupling in preCICE
       <p>Jun Chen* (<a href="https://www.ipvs.uni-stuttgart.de/institute/team/Chen-00029/">webpage</a>, <a href="https://github.com/Fujikawas">GitHub</a>), Miriam Schulte<br/>
-      University of Stuttgart, Germany</p>
+      University of Stuttgart, Germany - <a href="https://doi.org/10.5281/zenodo.17340016">slides</a></p>
       </summary>
       <p>In partitioned multi-physics simulations and in preCICE, quasi-Newton (QN) methods are widely used to accelerate convergence at the coupling interface. However, standard QN schemes often disregard bound constraints arising from the underlying physic-such as saturation or pressure limits in porous media-resulting in physical values exceeding the prescribed bounds and reduced robustness. In this talk, we present and compare several bound-aware QN approaches designed to handle such constraints effectively within the preCICE framework.
       We focus on modular methods that balance step length control, projection techniques, and space-splitting strategies that separate trusted and extrapolated components of the update. These methods aim to balance convergence speed with physical feasibility, especially in strongly nonlinear or ill-scaled settings. The fundamental principles and the trade-offs between the various methods will be discussed, with conclusions drawn from experiments in designed scenarios involving bounded variables.

--- a/content/community/workshops/precice-workshop-2025.md
+++ b/content/community/workshops/precice-workshop-2025.md
@@ -9,13 +9,11 @@ redirect_from: /preCICE2025/
 
 <img class="img-responsive center-block" src="images/events/precice2025/precice2025.svg" alt="preCICE Workshop banner" style="max-width: 500px; width: 100%; margin:auto;">
 
-The 6th preCICE Workshop will be held at the [Helmut Schmidt University / University of the German Federal Armed Forces Hamburg](https://www.hsu-hh.de/) on September 8-12, 2025, co-organized by the local user group. The workshop is a coming together of the preCICE community to share ideas, experiences and knowledge about using preCICE, and to learn from others in the process. Like always, we plan to have user and developer talks, hands-on training sessions, discussions with the developers about your applications and use cases, and plenty of opportunities for networking. Read more about [how a preCICE workshop looks like](precice-workshop.html).
+The 6th preCICE Workshop was held at the [Helmut Schmidt University / University of the German Federal Armed Forces Hamburg](https://www.hsu-hh.de/) on September 8-12, 2025, co-organized by the local user group. The workshop is a coming together of the preCICE community to share ideas, experiences and knowledge about using preCICE, and to learn from others in the process. Like always, we had user and developer talks, hands-on training sessions, discussions with the developers about your applications and use cases, and plenty of opportunities for networking. Read more about [how a preCICE workshop looks like](precice-workshop.html).
 
-The workshop will include a hands-on [training course](community-training.html). The course is suited for both beginners and current preCICE users, since advanced topics will also be covered. This year, we are extending the course by a new module on HPC.
+The workshop included a hands-on [training course](community-training.html). The course is suited for both beginners and current preCICE users, since advanced topics will also be covered. This year, we extended the course by a new module on HPC.
 
-In the developer talks, the maintainer team will present recent updates on dynamic meshes, mesh-particle coupling, and macro-micro coupling – to only mention a few highlights. And we will continue the standardization process of adapters and application cases, where you can help shaping the future.
-
-Keep watching this space for updates on registration, the workshop program, and more. For any organizational questions (for example, visa-related requests), please contact `precice` at `hsu-hh.de`.
+In the developer talks, the maintainer team presented recent updates on dynamic meshes, mesh-particle coupling, and macro-micro coupling – to only mention a few highlights. And we continued the standardization process of adapters and application cases, where you can help shaping the future.
 
 ## Call for contributions
 


### PR DESCRIPTION
Closes #541.

Updates URLs in:

- https://precice.org/eccomas-congress-2022.html (issues new Nextcloud URLs, not sure why the old ones did not work anymore)
- https://precice.org/eccomas-coupled-2021.html (replaces conference URL with web archive)
- https://precice.org/community-events-wccm-eccomas-2020.html (replaces conference URL with web archive, adds book of abstracts on HAL, adds proceedings on Scipedia).

Also adds links to the slides on Zenodo to the Workshop 2025 page. Recordings could follow once the playlist is complete.

Also converts the language from present to past for the past minisymposia.