### PR TITLE
Add more links to source docs and solverdummies

### DIFF
--- a/content/docs/couple-your-code/porting/couple-your-code-porting-v1-2.md
+++ b/content/docs/couple-your-code/porting/couple-your-code-porting-v1-2.md
@@ -11,6 +11,10 @@ Reviving that old adapter? Good opportunity to learn about some best practices a
 There are [guidelines for adapters](community-guidelines-adapters.html) and [guidelines for application cases](community-guidelines-application-cases.html).
 {% endtip %}
 
+{% tip %}
+Also have a look at the [source documentation](dev-docs-sourcedocs.html) and [minimal reference implementations](couple-your-code-api.html#minimal-reference-implementations).
+{% endtip %}
+
 ## preCICE API
 
 ### Single-step setup

--- a/content/docs/couple-your-code/porting/couple-your-code-porting-v2-3.md
+++ b/content/docs/couple-your-code/porting/couple-your-code-porting-v2-3.md
@@ -15,6 +15,10 @@ Reviving that old adapter? Good opportunity to learn about some best practices a
 There are [guidelines for adapters](community-guidelines-adapters.html) and [guidelines for application cases](community-guidelines-application-cases.html).
 {% endtip %}
 
+{% tip %}
+Also have a look at the [source documentation](dev-docs-sourcedocs.html) and [minimal reference implementations](couple-your-code-api.html#minimal-reference-implementations).
+{% endtip %}
+
 ## preCICE API
 
 The following is a diff of how an adapter-port could look like. The guide continues underneath the code.

--- a/content/docs/couple-your-code/step-by-step/couple-your-code-preparing-your-solver.md
+++ b/content/docs/couple-your-code/step-by-step/couple-your-code-preparing-your-solver.md
@@ -49,7 +49,7 @@ Probably most solvers have such a structures: something in the beginning (readin
 In the following steps, we will slowly add more and more calls to the preCICE API in this code snippet. Some part of the preCICE API is briefly described in each step. More precisely (no pun intended :grin:), we use the native `C++` API of preCICE. The API is, however, also available in other scientific programming languages: plain `C`, `Fortran`, `Python`, `Matlab`, `Julia`, and `Rust` (see [Application Programming Interface](couple-your-code-api)).
 
 {% tip %}
-Also have a look at the [definite C++ API documentation](https://precice.org/doxygen/main/classprecice_1_1Participant.html).
+Also have a look at the [source documentation](dev-docs-sourcedocs.html) and [minimal reference implementations](couple-your-code-api.html#minimal-reference-implementations).
 {% endtip %}
 
 {% tip %}


### PR DESCRIPTION
Closes #320

Hints about the source/API documentation and solvedummies in:

- https://precice.org/couple-your-code-preparing-your-solver.html
- https://precice.org/couple-your-code-porting-v1-2.html
- https://precice.org/couple-your-code-porting-v2-3.html