### PR TITLE
CalculiX: Document potential SPOOLES patches

### DIFF
--- a/content/docs/adapters/calculix/adapter-calculix-get-calculix.md
+++ b/content/docs/adapters/calculix/adapter-calculix-get-calculix.md
@@ -64,6 +64,8 @@ CC = gcc
 #CC = /usr/lang-4.0/bin/cc 
 ```
 
+With recent compilers, [more patches might be needed](https://github.com/precice/precice.github.io/issues/608).
+
 Now build the library:
 
 ```bash


### PR DESCRIPTION
Add a link to https://github.com/precice/precice.github.io/issues/608 in https://precice.org/adapter-calculix-get-calculix.html

closes #608