### PR TITLE
Contributors: Update broken GitHub URLs

### DIFF
--- a/_data/developer.yaml
+++ b/_data/developer.yaml
@@ -248,7 +248,7 @@ contributors:
   - fullname: Qunsheng Huang
     name: Huang
     institution: Technical University of Munich
-    github: huangq1234553
+    github: keefehuang
   - fullname: Konrad Eder
     name: Eder
     institution: Technical University of Munich

--- a/_data/developer.yaml
+++ b/_data/developer.yaml
@@ -151,7 +151,7 @@ contributors:
   - fullname: Pavel Kharitenko
     name: Kharitenko
     institution: University of Stuttgart
-    github: pavelkharetenko
+    github: pavelkharitenko
   - fullname: Erik Scheurer
     name: Scheurer
     institution:  University of Stuttgart


### PR DESCRIPTION
Updates the GitHub name of @keefehuang and @pavelkharitenko

Still broken:

- https://github.com/gilbertolem (no replacement known, please contribute in another PR)

(reported as a broken URL)