### PR TITLE
Bump preCICE version to v3.3.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -313,7 +313,7 @@ subprojects:
 # We use these versions to centrally update links
 # and other version-specific information.
 # Note that Jekyll cuts off trailing zeros: https://stackoverflow.com/questions/37862167/trailing-zeros-in-jekyll-liquid
-precice_version: 3.3.0
+precice_version: 3.3.1
 calculix_version: "2.20"
 calculix_adapter_version: "2.20.1"
 

--- a/_includes/xmlreference.md
+++ b/_includes/xmlreference.md
@@ -1,4 +1,4 @@
-<!-- generated with preCICE 3.3.0 -->
+<!-- generated with preCICE 3.3.1 -->
 # precice-configuration
 
 Main tag containing preCICE configuration.


### PR DESCRIPTION
Updates:

- `_config.yml`
- the XML reference (content identical, checked)

Does not update the Roadmap (bugfix release).

@fsimonis FYI