### PR TITLE
Fix typo in v2-v3 porting guide

### DIFF
--- a/content/docs/couple-your-code/porting/couple-your-code-porting-v2-3.md
+++ b/content/docs/couple-your-code/porting/couple-your-code-porting-v2-3.md
@@ -261,7 +261,7 @@ See the [tutorials](tutorials.html) for some examples, and the [configuration re
     - Using actions with multiple couping schemes and mixed time window sizes is not well defined!
 
 - Coupling schemes
-  - Remove `<extraplation-order value="..." />` in `<coupling-scheme>`. Contact us if you need this feature.
+  - Remove `<extrapolation-order value="..." />` in `<coupling-scheme>`. Contact us if you need this feature.
   - Replace `<min-iteration-convergence-measure min-iterations="3" ... />` by `<min-iterations value="3"/>`. Not defining convergence measures leads to iterations until `max-iterations` is reached.
   - We removed the plain `Broyden` acceleration. You could use `IQN-IMVJ` instead, which is a [multi-vector Broyden variant](http://hdl.handle.net/2117/191193).
 

--- a/tools/old-precice.txt
+++ b/tools/old-precice.txt
@@ -66,7 +66,7 @@ preallocation="estimate"
 preallocation="save"
 preallocation="off"
 use-qr-decomposition="true"
-extraplation-order
+extrapolation-order
 min-iteration-convergence-measure
 acceleration:broyden
 sync-mode="on"


### PR DESCRIPTION
Follow-up of https://github.com/precice/precice.github.io/pull/686 (I merged too fast).