### PR TITLE
Add newsletter sign-up

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
 
 {% if page.layout != "landing_page" %}
     <div class="row equal">
-      <div class="col-md-6" style="background:white;border-radius:1rem;padding:0 3rem;margin:2rem auto;">
+      <div class="col-md-4" style="background:white;border-radius:1rem;padding:0 3rem;margin:0 auto 50px auto;">
         <h2> The preCICE newsletter </h2>
         {% include newsletter.html %}
         </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,7 @@
     </div>
 {% endif %}
 
-    <div class="row equal">
+    <div class="row equal text-center">
       <div class="col-md-4">
         <nav aria-label="Footer left">
           <ul class="list-unstyled">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,15 @@
 <footer class="background-dark">
   <div class="container">
+
+{% if page.layout != "landing_page" %}
+    <div class="row equal">
+      <div class="col-md-6" style="background:white;border-radius:1rem;padding:0 3rem;margin:2rem auto;">
+        <h2> The preCICE newsletter </h2>
+        {% include newsletter.html %}
+        </div>
+    </div>
+{% endif %}
+
     <div class="row equal">
       <div class="col-md-4">
         <nav aria-label="Footer left">

--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -1,0 +1,9 @@
+<script charset="utf-8" type="text/javascript" src="https://js.mailercloud.com/form/form.js"></script>
+<script>
+(function() {
+  mcform.create({
+    formId: "V3dEdUAzMTQ0NkAwMDAwMA==",
+    targetElement: "form_element_id"
+  })
+})();
+</script>

--- a/content/community/community.md
+++ b/content/community/community.md
@@ -13,6 +13,8 @@ editme: true
 
 Do you want to meet the community and learn what is new in preCICE? There is no better way than to join [one of our workshops](precice-workshop.html) or [trainings](community-training.html)!
 
+<img class="img-responsive center-block img-rounded" src="images/events/precice2023-group.jpg" alt="preCICE Workshop group picture">
+
 ## The preCICE forum
 
 Meet the community online, ask questions, and help others at the [preCICE forum on Discourse](https://precice.discourse.group/). Structured conversations, which help the future reader. We also post [announcements](https://precice.discourse.group/c/news/5) from time to time, so make sure to register to be the first one to learn about new workshops and releases.

--- a/content/index.html
+++ b/content/index.html
@@ -366,38 +366,23 @@ layout: landing_page
             <li>Report issues on <a href="https://github.com/precice/">GitHub</a> and help us solve them for everyone.</li>
             <li><a href="community-contribute-to-precice.html">Contribute</a> code and simulation examples - we help you with guidelines, tools, and reviews.</li>
             <li><strong>Meet the community</strong> in one of the <a href="community.html">preCICE workshops and conference sessions</a>.</li>
+            <li>
+              Subscribe to our <b>quarterly newsletter</b> including:
+              <ul>
+                <li>New publications</li>
+                <li>New features</li>
+                <li>New adapters, bindings, tools, tutorials, and more</li>
+                <li>Upcoming events and news from the community</li>
+              </ul>
+        </p>
+            </li>
           </ul>
         </div>
         <div class="col-md-4 col-flex">
-          <a href="community.html">
-            <img class="img-responsive center-block img-rounded" src="images/events/precice2023-group.jpg" alt="preCICE Workshop group picture">
-          </a>
-        </div>
-      </div>
-
-      <div class="row">
-        <div class="col-lg-12">
-          <h2 class="section-header">Do you want to stay informed?</h2>
-        </div>
-      </div>
-
-      <div class="row equal">
-        <div class="col-md-8 col-flex">
-          <p>
-          Receive a <b>quarterly newsletter</b> including:
-          <ul>
-            <li>New publications</li>
-            <li>New features</li>
-            <li>New adapters, bindings, tools, tutorials, and more</li>
-            <li>Upcoming events and news from the community</li>
-          </ul>
-          </p>
-        </div>
-        <div class="col-md-4 col-flex">
+          <b>The quarterly preCICE newsletter</b>
           {% include newsletter.html %}
         </div>
       </div>
-
       </div><!-- main -->
     </div> <!-- section -->
   </div> <!-- container -->

--- a/content/index.html
+++ b/content/index.html
@@ -374,6 +374,30 @@ layout: landing_page
           </a>
         </div>
       </div>
+
+      <div class="row">
+        <div class="col-lg-12">
+          <h2 class="section-header">Do you want to stay informed?</h2>
+        </div>
+      </div>
+
+      <div class="row equal">
+        <div class="col-md-8 col-flex">
+          <p>
+          Receive a <b>quarterly newsletter</b> including:
+          <ul>
+            <li>New publications</li>
+            <li>New features</li>
+            <li>New adapters, bindings, tools, tutorials, and more</li>
+            <li>Upcoming events and news from the community</li>
+          </ul>
+          </p>
+        </div>
+        <div class="col-md-4 col-flex">
+          {% include newsletter.html %}
+        </div>
+      </div>
+
       </div><!-- main -->
     </div> <!-- section -->
   </div> <!-- container -->


### PR DESCRIPTION
This PR adds the newsletter signup form to the landing page as part of the "join the community" section and on other pages in the footer.

## Landing page

Adding the form to the existing content looks very janky, so I created a "subsection".

<img width="1920" height="975" alt="image" src="https://github.com/user-attachments/assets/54e2aa1e-a6cf-4267-bfdf-f798c203fe9a" />

## Footer

This doesn't show on the landing page. The form can only load once per page.

<img width="1920" height="792" alt="image" src="https://github.com/user-attachments/assets/4f1442b6-7521-4c87-9b88-c7a9c4d6df57" />
