### PR TITLE
Add a new page for open projects (GSoC ideas)

### DIFF
--- a/_data/sidebars/community_sidebar.yaml
+++ b/_data/sidebars/community_sidebar.yaml
@@ -115,6 +115,10 @@ entries:
       url: /community-contribute-to-precice.html
       output: web
     
+    - title: Open projects
+      url: /community-contribute-open-projects.html
+      output: web
+    
     - title: Adapter guidelines
       url: /community-guidelines-adapters.html
       output: web

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -114,7 +114,7 @@ Then, locate and modify the error message in the source code, to provide more in
 The core library parses its [configuration file](configuration-overview.html) using the [libxml2 library](https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home).
 The way this currently works is a bit rigid and the configuration of objects is directly tied to this parsing.
 Instead, we could do this in multiple stages, introducing an additional abstract syntax tree, which we could then use as a layer for additional checks,
-or to parse the configuration in any order.
+or to parse the configuration in a predefined order.
 In this project, we want to refactor the configuration code to introduce an XML AST built with libxml2.
 See the [related issue](https://github.com/precice/precice/issues/982).
 

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -108,8 +108,8 @@ Then, locate and modify the error message in the source code, to provide more in
 
 ## General guidelines
 
-Be creative, be proactive, make your project your own, and write like appealing to colleagues with the same questions as you when you started.
-
-We welcome all kinds of modern tools for assisting with code development, but we do value the human factor:
+1. Be creative, be proactive, make your project your own.
+2. When writing (e.g., a pull request description), think of writing to colleagues with the same questions as you when you started.
+3. We welcome all kinds of modern tools for assisting with code development, but we do value the human factor:
 we want to see your work, in your own words, and we trust that you understand what you contribute.
 No need to impress, we are happy to help understand every concept together!

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -67,6 +67,28 @@ Be creative!
 - Difficulty: Intermediate
 - Mentors: [Frédéric Simonis](https://github.com/fsimonis) and [Gerasimos Chourdakis](https://github.com/MakisH)
 
+### Project: Error messages with configuration context
+
+A coupled simulation needs a [preCICE configuration file](configuration-overview.html),
+which currently needs to be written directly (we are working on higher-level configuration tools as well).
+When one configures something wrong, preCICE throws an error message with details and recommendations (think git).
+Writing these error messages is, however, rather cumbersome at the moment,
+while they might sometimes miss important context for the user.
+In this project, we want to refactor the code to provide context directly from the configuration file:
+see the [related issue](https://github.com/precice/precice/issues/751).
+
+To figure out if this is for you, try [building preCICE from source](https://precice.org/installation-source-preparation.html),
+running the [elastic tube 1D tutorial](https://precice.org/tutorials-elastic-tube-1d.html),
+and modifying the [configuration file](https://github.com/precice/tutorials/blob/master/elastic-tube-1d/precice-config.xml)
+to trigger an error (e.g., remove one of the `<data>` tags).
+Then, locate and modify the error message in the source code, to provide more information.
+
+- Skills required: C++
+- Project size: Small (90h)
+- Difficulty: Intermediate
+- Mentors: [Frédéric Simonis](https://github.com/fsimonis) and [Gerasimos Chourdakis](https://github.com/MakisH)
+
+
 ## General guidelines
 
 Be creative, be proactive, make your project your own, and write like appealing to colleagues with the same questions as you when you started.

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -83,7 +83,7 @@ To figure out if this is for you, [run the system tests locally](dev-docs-system
 - Skills required: Python, Docker, GitHub Actions
 - Project size: Medium (175h) - Depending on the availability, small or large are also possible
 - Difficulty: Intermediate - Requires combining multiple technologies and has an impact in multiple repositories, but includes mostly small and clear work packages.
-- Mentors: [Gerasimos Chourdakis](https://github.com/MakisH) and [Frédéric Simonis](https://github.com/fsimonis)
+- Mentors: [Gerasimos Chourdakis](https://github.com/MakisH) - Fallback: [Frédéric Simonis](https://github.com/fsimonis)
 
 ### Project: Error messages with configuration context
 
@@ -104,7 +104,7 @@ Then, locate and modify the error message in the source code, to provide more in
 - Skills required: C++
 - Project size: Small (90h)
 - Difficulty: Intermediate - Requires significant modifications to the C++ codebase, but with limited impact to/from other work.
-- Mentors: [Frédéric Simonis](https://github.com/fsimonis) and [Gerasimos Chourdakis](https://github.com/MakisH)
+- Mentors: [Frédéric Simonis](https://github.com/fsimonis) - Fallback: [Gerasimos Chourdakis](https://github.com/MakisH)
 
 ### Project: Clean multi-step configuration
 
@@ -119,11 +119,11 @@ To figure out if this is for you, try the same as in the [project idea above](#p
 - Skills required: C++
 - Project size: Medium (175h)
 - Difficulty: Intermediate/Hard - Requires refactoring or modifying large parts of the C++ codebase, but with limited impact to/from other work.
-- Mentors: [Frédéric Simonis](https://github.com/fsimonis) and [Gerasimos Chourdakis](https://github.com/MakisH)
+- Mentors: [Frédéric Simonis](https://github.com/fsimonis) - Fallback: [Gerasimos Chourdakis](https://github.com/MakisH)
 
 ## General guidelines
 
-1. Be creative, be proactive, make your project your own.
+1. Be creative, be proactive, and make your project your own.
 2. When writing (e.g., a pull request description), think of writing to colleagues with the same questions as you when you started.
 3. We welcome all kinds of modern tools for assisting with code development, but we do value the human factor:
 we want to see your work, in your own words, and we trust that you understand what you contribute.

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -27,7 +27,7 @@ we encourage participation in team events such as our coding days,
 and several students have so far participated in workshops, conferences, and publications.
 
 If you want to contribute with a student project (typically a thesis), see the [university groups behind preCICE](https://precice.org/about.html).
-This page highlights a few specific projects that are not directly suitable for a thesis.
+This page highlights a few specific projects that are not directly suitable for a thesis ([thesis-suitable issues in the core library](https://github.com/precice/precice/issues?q=is%3Aissue%20state%3Aopen%20label%3Athesis)), but are also a bit more than a [good first issue](https://github.com/precice/precice/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
 Some of these projects we advertise publicly, in programs such as the Google Summer of Code.
 
 {% tip %}

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -64,7 +64,7 @@ Be creative!
 
 - Skills required: Web development (Jekyll/Hugo + CSS, JS)
 - Project size: Medium (175h)
-- Difficulty: Intermediate
+- Difficulty: Easy/Intermediate - Requires porting existing content from one framework and stack to another, but will be driven primarily by you on the "how".
 - Mentors: [Frédéric Simonis](https://github.com/fsimonis) and [Gerasimos Chourdakis](https://github.com/MakisH)
 
 ### Project: System tests improvements
@@ -73,7 +73,7 @@ TODO
 
 - Skills required: Python, Bash, Docker, Git
 - Project size: Medium (175h)
-- Difficulty: Intermediate
+- Difficulty: Intermediate - Requires combining multiple technologies and has an impact in multiple repositories, but includes mostly small and clear work packages.
 - Mentors: [Gerasimos Chourdakis](https://github.com/MakisH) and [Frédéric Simonis](https://github.com/fsimonis)
 
 ### Project: Error messages with configuration context
@@ -94,7 +94,7 @@ Then, locate and modify the error message in the source code, to provide more in
 
 - Skills required: C++
 - Project size: Small (90h)
-- Difficulty: Intermediate
+- Difficulty: Intermediate - Requires significant modifications to the C++ codebase, but with limited impact to/from other work.
 - Mentors: [Frédéric Simonis](https://github.com/fsimonis) and [Gerasimos Chourdakis](https://github.com/MakisH)
 
 ### Project: Clean multi-step configuration
@@ -103,7 +103,7 @@ Then, locate and modify the error message in the source code, to provide more in
 
 - Skills required: C++
 - Project size: Medium (175h)
-- Difficulty: Intermediate
+- Difficulty: Intermediate/Hard - Requires refactoring or modifying large parts of the C++ codebase, but with limited impact to/from other work.
 - Mentors: [Frédéric Simonis](https://github.com/fsimonis) and [Gerasimos Chourdakis](https://github.com/MakisH)
 
 ## General guidelines

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -52,6 +52,7 @@ but now starts to feel a bit restrictive
 ([GitHub repository](https://github.com/precice/precice.github.io), [documentation]docs-meta-overview.html)).
 We envy the dark theme, the nice footer that showcases contributions, and the nice search engine support
 when we look at the documentation of other community projects, such as [GitLab](https://docs.gitlab.com/user/) or [Docker](https://docs.docker.com/get-started/).
+We also required some hacky jekyll plugins to integrate multiple repositories into one jekyll website, which are a bit error-prone.
 Our technology stack is also a bit outdated:
 For example, the front-end is using [Bootstrap](https://getbootstrap.com/docs/) 3.3.7, with some custom CSS on top.
 We have done some [preliminary work](https://github.com/orgs/precice/projects/22/views/1),

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -115,7 +115,7 @@ The core library parses its [configuration file](configuration-overview.html) us
 The way this currently works is a bit rigid and the configuration of objects is directly tied to this parsing.
 Instead, we could do this in multiple stages, introducing an additional abstract syntax tree, which we could then use as a layer for additional checks,
 or to parse the configuration in a predefined order.
-In this project, we want to refactor the configuration code to introduce an XML AST built with libxml2.
+In this project, we want to refactor the configuration code to introduce a confguration AST (structured types), generated from the XML AST (nested tags and their attributes) built with libxml2.
 See the [related issue](https://github.com/precice/precice/issues/982).
 
 To figure out if this is for you, try the same as in the [project idea above](#project-error-messages-with-configuration-context).

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -67,7 +67,7 @@ Be creative!
 
 - Skills required: Web development (Jekyll/Hugo + CSS, JS)
 - Project size: Medium (175h)
-- Difficulty: Easy/Intermediate - Requires porting existing content from one framework and stack to another, but will be driven primarily by you on the "how".
+- Difficulty: Easy/Intermediate - Requires upgrading the front-end framework and porting existing content from one framework and stack to another, but will be driven primarily by you on the "how".
 - Mentors: [Frédéric Simonis](https://github.com/fsimonis) and [Gerasimos Chourdakis](https://github.com/MakisH)
 
 ### Project: System tests improvements

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -2,8 +2,10 @@
 title: Contribute to preCICE - Open projects
 keywords: contribute, GSoC, google summer of code, student
 summary: Open opportunities for contributing to preCICE
-permalink: community-contribute-open-projects.html
 toc: true
+permalink: community-contribute-open-projects.html
+redirect_from:
+  - /gsoc/
 ---
 
 ## Context

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -78,7 +78,7 @@ TODO
 
 ### Project: Error messages with configuration context
 
-A coupled simulation needs a [preCICE configuration file](configuration-overview.html),
+The core library needs a [preCICE configuration file](configuration-overview.html),
 which currently needs to be written directly (we are working on higher-level configuration tools as well).
 When one configures something wrong, preCICE throws an error message with details and recommendations (think git).
 Writing these error messages is, however, rather cumbersome at the moment,
@@ -99,7 +99,13 @@ Then, locate and modify the error message in the source code, to provide more in
 
 ### Project: Clean multi-step configuration
 
-[Related issue](https://github.com/precice/precice/issues/982)
+The core library parses its [configuration file](configuration-overview.html) using the [libxml2 library](https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home).
+The way this currently works is a bit rigid and the configuration of objects is directly tied to this parsing.
+Instead, we could do this in multiple stages, first creating an abstract syntax tree, which we could then use as a layer for additional checks, for example.
+In this project, we want to refactor the configuration code to introduce an XML AST built with libxml2.
+See the [related issue](https://github.com/precice/precice/issues/982).
+
+To figure out if this is for you, try the same as in the [project idea above](#project-error-messages-with-configuration-context).
 
 - Skills required: C++
 - Project size: Medium (175h)

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -26,7 +26,7 @@ We review pull requests trying to improve their quality together and bring them 
 which can sometimes be a long but rewarding experience.
 In the university context, we also closely mentor students,
 we encourage participation in team events such as our coding days,
-and several students have so far participated in workshops, conferences, and publications.
+and several students have so far participated in workshops, conferences, and publications, or even done their PhD in the team.
 
 If you want to contribute with a student project (typically a thesis), see the [university groups behind preCICE](about.html).
 This page highlights a few specific projects that are not directly suitable for a thesis ([thesis-suitable issues in the core library](https://github.com/precice/precice/issues?q=is%3Aissue%20state%3Aopen%20label%3Athesis)), but are also a bit more than a [good first issue](https://github.com/precice/precice/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -91,7 +91,7 @@ To figure out if this is for you, [run the system tests locally](dev-docs-system
 ### Project: Error messages with configuration context
 
 The core library needs a [preCICE configuration file](configuration-overview.html),
-which currently needs to be written directly (we are working on higher-level configuration tools as well).
+which currently needs to be written manually (we are working on higher-level configuration tools as well).
 When one configures something wrong, preCICE throws an error message with details and recommendations (think git).
 Writing these error messages is, however, rather cumbersome at the moment,
 while they might sometimes miss important context for the user.

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -67,6 +67,15 @@ Be creative!
 - Difficulty: Intermediate
 - Mentors: [Frédéric Simonis](https://github.com/fsimonis) and [Gerasimos Chourdakis](https://github.com/MakisH)
 
+### Project: System tests improvements
+
+TODO
+
+- Skills required: Python, Bash, Docker, Git
+- Project size: Medium (175h)
+- Difficulty: Intermediate
+- Mentors: [Gerasimos Chourdakis](https://github.com/MakisH) and [Frédéric Simonis](https://github.com/fsimonis)
+
 ### Project: Error messages with configuration context
 
 A coupled simulation needs a [preCICE configuration file](configuration-overview.html),
@@ -88,6 +97,14 @@ Then, locate and modify the error message in the source code, to provide more in
 - Difficulty: Intermediate
 - Mentors: [Frédéric Simonis](https://github.com/fsimonis) and [Gerasimos Chourdakis](https://github.com/MakisH)
 
+### Project: Clean multi-step configuration
+
+[Related issue](https://github.com/precice/precice/issues/982)
+
+- Skills required: C++
+- Project size: Medium (175h)
+- Difficulty: Intermediate
+- Mentors: [Frédéric Simonis](https://github.com/fsimonis) and [Gerasimos Chourdakis](https://github.com/MakisH)
 
 ## General guidelines
 

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -112,7 +112,8 @@ Then, locate and modify the error message in the source code, to provide more in
 
 The core library parses its [configuration file](configuration-overview.html) using the [libxml2 library](https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home).
 The way this currently works is a bit rigid and the configuration of objects is directly tied to this parsing.
-Instead, we could do this in multiple stages, first creating an abstract syntax tree, which we could then use as a layer for additional checks, for example.
+Instead, we could do this in multiple stages, introducing an additional abstract syntax tree, which we could then use as a layer for additional checks,
+or to parse the configuration in any order.
 In this project, we want to refactor the configuration code to introduce an XML AST built with libxml2.
 See the [related issue](https://github.com/precice/precice/issues/982).
 

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -69,10 +69,19 @@ Be creative!
 
 ### Project: System tests improvements
 
-TODO
+While the core library has several unit and integration tests,
+some issues only show up when running complete simulations.
+For this reason, preCICE has [system tests](dev-docs-system-tests.html),
+which choose and install components from the ecosystem in Docker containers,
+run complete simulations, and compare the numerical results against references.
+These tests are integrated into the [GitHub Actions](https://docs.github.com/en/actions) CI infrastructure of preCICE.
+While the system tests are already running every night and on many pull requests, several improvements are possible ([related issues](https://github.com/precice/tutorials/issues?q=is%3Aissue%20state%3Aopen%20label%3Asystemtests)):
+running (much) faster test cases, running multiple test cases in parallel, better communicating what went wrong, integrating more repositories, and the list of possibilities goes on.
 
-- Skills required: Python, Bash, Docker, Git
-- Project size: Medium (175h)
+To figure out if this is for you, [run the system tests locally](dev-docs-system-tests.html#running-specific-test-suites) and [add one more tutorial to the tests](dev-docs-system-tests.html#adding-tutorials).
+
+- Skills required: Python, Docker, GitHub Actions
+- Project size: Medium (175h) - Depending on the availability, small or large are also possible
 - Difficulty: Intermediate - Requires combining multiple technologies and has an impact in multiple repositories, but includes mostly small and clear work packages.
 - Mentors: [Gerasimos Chourdakis](https://github.com/MakisH) and [Frédéric Simonis](https://github.com/fsimonis)
 

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -38,7 +38,8 @@ Are you looking for or offering a thesis / PhD / other related job? Have a look 
 
 The [Google Summer of Code](https://summerofcode.withgoogle.com/) is _"a global, online program focused on bringing new contributors into open source software development. GSoC Contributors work with an open source organization on a 12+ week programming project under the guidance of mentors."_.
 
-For 2026 (our first year), we have prepared the following topics.
+For 2026, we have prepared the following topics, for different sets of skills.
+Since this is our first year, and since we are a rather small project, we might not be able to accommodate applicants to all of these projects.
 Introduce yourself in the [forum](https://precice.discourse.group/c/jobs/gsoc/15) and let us know more about your background and motivation, so that we can find out together if these topics are a good fit.
 
 ### Project: Website modernization

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -104,7 +104,7 @@ Then, locate and modify the error message in the source code, to provide more in
 - Skills required: C++
 - Project size: Small (90h)
 - Difficulty: Intermediate - Requires significant modifications to the C++ codebase, but with limited impact to/from other work.
-- Mentors: [Frédéric Simonis](https://github.com/fsimonis) - Fallback: [Gerasimos Chourdakis](https://github.com/MakisH)
+- Mentors: [Frédéric Simonis](https://github.com/fsimonis) - Fallback: [Benjamin Uekermann](https://github.com/uekerman)
 
 ### Project: Clean multi-step configuration
 
@@ -119,7 +119,7 @@ To figure out if this is for you, try the same as in the [project idea above](#p
 - Skills required: C++
 - Project size: Medium (175h)
 - Difficulty: Intermediate/Hard - Requires refactoring or modifying large parts of the C++ codebase, but with limited impact to/from other work.
-- Mentors: [Frédéric Simonis](https://github.com/fsimonis) - Fallback: [Gerasimos Chourdakis](https://github.com/MakisH)
+- Mentors: [Frédéric Simonis](https://github.com/fsimonis) - Fallback: [Benjamin Uekermann](https://github.com/uekerman)
 
 ## General guidelines
 

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -55,7 +55,7 @@ when we look at the documentation of other community projects, such as [GitLab](
 We also required some hacky jekyll plugins to integrate multiple repositories into one jekyll website, which are a bit error-prone.
 Our technology stack is also a bit outdated:
 For example, the front-end is using [Bootstrap](https://getbootstrap.com/docs/) 3.3.7, with some custom CSS on top.
-We have done some [preliminary work](https://github.com/orgs/precice/projects/22/views/1),
+We have done some [preliminary work](https://github.com/orgs/precice/projects/22/views/1) porting to hugo,
 but web development is not what we are good at.
 As a first step, we would like to [upgrade to a newer Bootstrap version](https://github.com/precice/precice.github.io/issues/691).
 After that, we would like to switch to the [Hugo static site generator](https://gohugo.io/),

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -26,7 +26,7 @@ In the university context, we also closely mentor students,
 we encourage participation in team events such as our coding days,
 and several students have so far participated in workshops, conferences, and publications.
 
-If you want to contribute with a student project (typically a thesis), see the [university groups behind preCICE](https://precice.org/about.html).
+If you want to contribute with a student project (typically a thesis), see the [university groups behind preCICE](about.html).
 This page highlights a few specific projects that are not directly suitable for a thesis ([thesis-suitable issues in the core library](https://github.com/precice/precice/issues?q=is%3Aissue%20state%3Aopen%20label%3Athesis)), but are also a bit more than a [good first issue](https://github.com/precice/precice/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
 Some of these projects we advertise publicly, in programs such as the Google Summer of Code.
 
@@ -47,7 +47,7 @@ Introduce yourself in the [forum](https://precice.discourse.group/c/jobs/gsoc/15
 This website is built with [Jekyll](https://jekyllrb.com/),
 a straight-forward static site generator that has served us well,
 but now starts to feel a bit restrictive
-([GitHub repository](https://github.com/precice/precice.github.io), [documentation](https://precice.org/docs-meta-overview.html)).
+([GitHub repository](https://github.com/precice/precice.github.io), [documentation]docs-meta-overview.html)).
 We envy the dark theme, the nice footer that showcases contributions, and the nice search engine support
 when we look at the documentation of other community projects, such as [GitLab](https://docs.gitlab.com/user/) or [Docker](https://docs.docker.com/get-started/).
 Our technology stack is also a bit outdated:
@@ -86,8 +86,8 @@ while they might sometimes miss important context for the user.
 In this project, we want to refactor the code to provide context directly from the configuration file:
 see the [related issue](https://github.com/precice/precice/issues/751).
 
-To figure out if this is for you, try [building preCICE from source](https://precice.org/installation-source-preparation.html),
-running the [elastic tube 1D tutorial](https://precice.org/tutorials-elastic-tube-1d.html),
+To figure out if this is for you, try [building preCICE from source](installation-source-preparation.html),
+running the [elastic tube 1D tutorial](tutorials-elastic-tube-1d.html),
 and modifying the [configuration file](https://github.com/precice/tutorials/blob/master/elastic-tube-1d/precice-config.xml)
 to trigger an error (e.g., remove one of the `<data>` tags).
 Then, locate and modify the error message in the source code, to provide more information.

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -27,7 +27,7 @@ we encourage participation in team events such as our coding days,
 and several students have so far participated in workshops, conferences, and publications.
 
 If you want to contribute with a student project (typically a thesis), see the [university groups behind preCICE](https://precice.org/about.html).
-This page highlights specific projects that we have in mind, but there is certainly much more than that.
+This page highlights a few specific projects that are not directly suitable for a thesis.
 Some of these projects we advertise publicly, in programs such as the Google Summer of Code.
 
 {% tip %}

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -6,6 +6,17 @@ permalink: community-contribute-open-projects.html
 toc: true
 ---
 
+## Context
+
+In case you skipped the [home page](index.html),
+preCICE is a _coupling library_ for **numerical simulations** (think meshes, iterative solution, FEM, CFD)
+and an _ecosystem_ of related components.
+Scientists take two independent numerical simulation codes and make them work together on a more complex simulation,
+which none of the individual codes could do alone.
+For this, they use one of the many _adapters_ (think plugins for various simulation codes), or directly the core library.
+While the latter is written in **C++**, many other languages are relevant as well: **Python, Julia, Matlab, C, Fortran, and Rust**,
+while it is primarily used on **Linux** systems (with macOS and Windows possible as well).
+
 Most of the preCICE development has been happening in a university context,
 and student projects have played a vital role: Just look at the [list of contributors](community-contributors.html).
 We are working on [GitHub](https://github.com/precice/), and we accept contributions by everyone.

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -94,7 +94,7 @@ The core library needs a [preCICE configuration file](configuration-overview.htm
 which currently needs to be written manually (we are working on higher-level configuration tools as well).
 When one configures something wrong, preCICE throws an error message with details and recommendations (think git).
 Writing these error messages is, however, rather cumbersome at the moment,
-while they might sometimes miss important context for the user.
+as they don't mention where the error occurs in the configuration file.
 In this project, we want to refactor the code to provide context directly from the configuration file:
 see the [related issue](https://github.com/precice/precice/issues/751).
 

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -29,6 +29,7 @@ The [Google Summer of Code](https://summerofcode.withgoogle.com/) is _"a global,
 
 For 2026 (our first year), we have prepared the following topics.
 Contact us on [Matrix](https://matrix.to/#/#precice_lobby:gitter.im?web-instance[element.io]=app.gitter.im) for any questions.
+Introduce yourself and let us know more about your background and motivation, so that we can find out together if these topics are a good fit.
 
 ### Project: Website modernization
 

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -93,9 +93,9 @@ To figure out if this is for you, [run the system tests locally](dev-docs-system
 The core library needs a [preCICE configuration file](configuration-overview.html),
 which currently needs to be written manually (we are working on higher-level configuration tools as well).
 When one configures something wrong, preCICE throws an error message with details and recommendations (think git).
-Writing these error messages is, however, rather cumbersome at the moment,
-as they don't mention where the error occurs in the configuration file.
-In this project, we want to refactor the code to provide context directly from the configuration file:
+In this project, we want to attach context to these error messages,
+referring to specific lines in the configuration file
+(similarly to how a compiler would refer to code lines with errors):
 see the [related issue](https://github.com/precice/precice/issues/751).
 
 To figure out if this is for you, try [building preCICE from source](installation-source-preparation.html),

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -16,8 +16,8 @@ and an _ecosystem_ of related components.
 Scientists take independent numerical simulation codes and make them work together on a more complex simulation,
 which none of the individual codes could do alone.
 For this, they use one of the many _adapters_ (think plugins for various simulation codes), or directly the core library.
-While the latter is written in **C++**, more languages are relevant (**Python, Julia, Matlab, C, Fortran, and Rust**),
-while it is primarily used on **Linux** systems (with macOS and Windows possible as well).
+While the latter is written in **C++**, more languages are relevant (**Python, Julia, Matlab, C, Fortran, and Rust**).
+preCICE is primarily used on **Linux** systems, with a growing user-base on macOS and Windows.
 
 Most of the preCICE development has been happening in a university context,
 and student projects have played a vital role: Just look at the [list of contributors](community-contributors.html).

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -42,7 +42,7 @@ The [Google Summer of Code](https://summerofcode.withgoogle.com/) is _"a global,
 
 For 2026, we have prepared the following topics, for different sets of skills.
 Since this is our first year, and since we are a rather small project, we might not be able to accommodate applicants to all of these projects.
-Introduce yourself in the [forum](https://precice.discourse.group/c/jobs/gsoc/15) and let us know more about your background and motivation, so that we can find out together if these topics are a good fit.
+Introduce yourself in the [forum](https://precice.discourse.group/c/jobs/gsoc/15) and let us know more about your background and motivation, so that we can find out together if these topics are a good fit. Show us what you have tried already (see "entry test" in each project and feel free to go beyond that), to support your application. We will contact you via replies and/or private messages there.
 
 ### Project: Website modernization
 
@@ -61,7 +61,7 @@ As a first step, we would like to [upgrade to a newer Bootstrap version](https:/
 After that, we would like to switch to the [Hugo static site generator](https://gohugo.io/),
 aiming to have a framework that we can upgrade and maintain with minimal effort.
 
-To figure out if this is for you, try [building the website locally](https://github.com/precice/precice.github.io/blob/master/README.md)
+**Entry test:** To figure out if this is for you, try [building the website locally](https://github.com/precice/precice.github.io/blob/master/README.md)
 and adding and styling some new element in the [landing page](https://github.com/precice/precice.github.io/blob/master/content/index.html).
 Be creative!
 
@@ -81,7 +81,7 @@ These tests are integrated into the [GitHub Actions](https://docs.github.com/en/
 While the system tests are already running every night and on many pull requests, several improvements are possible ([related issues](https://github.com/precice/tutorials/issues?q=is%3Aissue%20state%3Aopen%20label%3Asystemtests)):
 running (much) faster test cases, running multiple test cases in parallel, better communicating what went wrong, integrating more repositories, and the list of possibilities goes on.
 
-To figure out if this is for you, [run the system tests locally](dev-docs-system-tests.html#running-specific-test-suites) and [add one more tutorial to the tests](dev-docs-system-tests.html#adding-tutorials).
+**Entry test:** To figure out if this is for you, [run the system tests locally](dev-docs-system-tests.html#running-specific-test-suites) and [add one more tutorial to the tests](dev-docs-system-tests.html#adding-tutorials).
 
 - Skills required: Python, Docker, GitHub Actions
 - Project size: Medium (175h) - Depending on the availability, small or large are also possible
@@ -98,7 +98,7 @@ referring to specific lines in the configuration file
 (similarly to how a compiler would refer to code lines with errors):
 see the [related issue](https://github.com/precice/precice/issues/751).
 
-To figure out if this is for you, try [building preCICE from source](installation-source-preparation.html),
+**Entry test:** To figure out if this is for you, try [building preCICE from source](installation-source-preparation.html),
 running the [elastic tube 1D tutorial](tutorials-elastic-tube-1d.html),
 and modifying the [configuration file](https://github.com/precice/tutorials/blob/master/elastic-tube-1d/precice-config.xml)
 to trigger an error (e.g., remove one of the `<data>` tags).
@@ -118,7 +118,7 @@ or to parse the configuration in a predefined order.
 In this project, we want to refactor the configuration code to introduce a confguration AST (structured types), generated from the XML AST (nested tags and their attributes) built with libxml2.
 See the [related issue](https://github.com/precice/precice/issues/982).
 
-To figure out if this is for you, try the same as in the [project idea above](#project-error-messages-with-configuration-context).
+**Entry test:** To figure out if this is for you, try the same as in the [project idea above](#project-error-messages-with-configuration-context).
 
 - Skills required: C++
 - Project size: Medium (175h)

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -11,10 +11,10 @@ toc: true
 In case you skipped the [home page](index.html),
 preCICE is a _coupling library_ for **numerical simulations** (think meshes, iterative solution, FEM, CFD)
 and an _ecosystem_ of related components.
-Scientists take two independent numerical simulation codes and make them work together on a more complex simulation,
+Scientists take independent numerical simulation codes and make them work together on a more complex simulation,
 which none of the individual codes could do alone.
 For this, they use one of the many _adapters_ (think plugins for various simulation codes), or directly the core library.
-While the latter is written in **C++**, many other languages are relevant as well: **Python, Julia, Matlab, C, Fortran, and Rust**,
+While the latter is written in **C++**, more languages are relevant (**Python, Julia, Matlab, C, Fortran, and Rust**),
 while it is primarily used on **Linux** systems (with macOS and Windows possible as well).
 
 Most of the preCICE development has been happening in a university context,

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -59,3 +59,7 @@ Be creative!
 ## General guidelines
 
 Be creative, be proactive, make your project your own, and write like appealing to colleagues with the same questions as you when you started.
+
+We welcome all kinds of modern tools for assisting with code development, but we do value the human factor:
+we want to see your work, in your own words, and we trust that you understand what you contribute.
+No need to impress, we are happy to help understand every concept together!

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -1,0 +1,60 @@
+---
+title: Contribute to preCICE - Open projects
+keywords: contribute, GSoC, google summer of code, student
+summary: Open opportunities for contributing to preCICE
+permalink: community-contribute-open-projects.html
+toc: true
+---
+
+Most of the preCICE development has been happening in a university context,
+and student projects have played a vital role: Just look at the [list of contributors](community-contributors.html).
+We are working on [GitHub](https://github.com/precice/), and we accept contributions by everyone.
+We review pull requests trying to improve their quality together and bring them in line with the current project needs,
+which can sometimes be a long but rewarding experience.
+In the university context, we also closely mentor students,
+we encourage participation in team events such as our coding days,
+and several students have so far participated in workshops, conferences, and publications.
+
+If you want to contribute with a student project (typically a thesis), see the [university groups behind preCICE](https://precice.org/about.html).
+This page highlights specific projects that we have in mind, but there is certainly much more than that.
+Some of these projects we advertise publicly, in programs such as the Google Summer of Code.
+
+{% tip %}
+Are you looking for or offering a thesis / PhD / other related job? Have a look also at [our forum](https://precice.discourse.group/c/jobs/13).
+{% endtip %}
+
+## Google Summer of Code
+
+The [Google Summer of Code](https://summerofcode.withgoogle.com/) is _"a global, online program focused on bringing new contributors into open source software development. GSoC Contributors work with an open source organization on a 12+ week programming project under the guidance of mentors."_.
+
+For 2026 (our first year), we have prepared the following topics.
+Contact us on [Matrix](https://matrix.to/#/#precice_lobby:gitter.im?web-instance[element.io]=app.gitter.im) for any questions.
+
+### Project: Website modernization
+
+This website is built with [Jekyll](https://jekyllrb.com/),
+a straight-forward static site generator that has served us well,
+but now starts to feel a bit restrictive
+([GitHub repository](https://github.com/precice/precice.github.io), [documentation](https://precice.org/docs-meta-overview.html)).
+We envy the dark theme, the nice footer that showcases contributions, and the nice search engine support
+when we look at the documentation of other community projects, such as [GitLab](https://docs.gitlab.com/user/) or [Docker](https://docs.docker.com/get-started/).
+Our technology stack is also a bit outdated:
+For example, the front-end is using [Bootstrap](https://getbootstrap.com/docs/) 3.3.7, with some custom CSS on top.
+We have done some [preliminary work](https://github.com/orgs/precice/projects/22/views/1),
+but web development is not what we are good at.
+As a first step, we would like to [upgrade to a newer Bootstrap version](https://github.com/precice/precice.github.io/issues/691).
+After that, we would like to switch to the [Hugo static site generator](https://gohugo.io/),
+aiming to have a framework that we can upgrade and maintain with minimal effort.
+
+To figure out if this is for you, try [building the website locally](https://github.com/precice/precice.github.io/blob/master/README.md)
+and adding and styling some new element in the [landing page](https://github.com/precice/precice.github.io/blob/master/content/index.html).
+Be creative!
+
+- Skills required: Web development (Jekyll/Hugo + CSS, JS)
+- Project size: Medium (175h)
+- Difficulty: Intermediate
+- Mentors: [Frédéric Simonis](https://github.com/fsimonis) and [Gerasimos Chourdakis](https://github.com/MakisH)
+
+## General guidelines
+
+Be creative, be proactive, make your project your own, and write like appealing to colleagues with the same questions as you when you started.

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -28,8 +28,7 @@ Are you looking for or offering a thesis / PhD / other related job? Have a look 
 The [Google Summer of Code](https://summerofcode.withgoogle.com/) is _"a global, online program focused on bringing new contributors into open source software development. GSoC Contributors work with an open source organization on a 12+ week programming project under the guidance of mentors."_.
 
 For 2026 (our first year), we have prepared the following topics.
-Contact us on [Matrix](https://matrix.to/#/#precice_lobby:gitter.im?web-instance[element.io]=app.gitter.im) for any questions.
-Introduce yourself and let us know more about your background and motivation, so that we can find out together if these topics are a good fit.
+Introduce yourself in the [forum](https://precice.discourse.group/c/jobs/gsoc/15) and let us know more about your background and motivation, so that we can find out together if these topics are a good fit.
 
 ### Project: Website modernization
 


### PR DESCRIPTION
Adds a page `Contribute to preCICE - Open projects` under `Contribute`. The impulse for this is the need for a [Google Summer of Code ideas list](https://google.github.io/gsocguides/mentor/defining-a-project-ideas-list). The name is more general because:

- there are further programs like this
- we could one day advertise concrete thesis or PhD topics here

The introduction is meant to convince student candidates that:

- we are experienced in supervising
- their contribution will have an impact
- we work as a team
- we value student work

I am a bit intimidated by the amount of applications we might need to handle. I created a dedicated forum category for that. Some projects provide entry tests (e.g., [MBDyn](https://public.gitlab.polimi.it/DAER/mbdyn/-/wikis/GSoC-Entry-Test), [SU2](https://su2code.github.io/gsoc/Assignments/)), and the [notes for first year organizations](https://google.github.io/gsocguides/mentor/notes-for-first-year-organizations) encourage communication and (I understand) such a test. I have tried to formulate one as a self-test, we could make it more concrete.

I already added a first project proposal for the website (@fsimonis what do you think?), I will add 1-2 more topics as well.