### PR TITLE
Add tutorial free-flow-over-porous-media

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -287,6 +287,7 @@ subprojects:
   - imported/tutorials/flow-over-heated-plate-partitioned-flow
   - imported/tutorials/flow-over-heated-plate-steady-state
   - imported/tutorials/flow-over-heated-plate-two-meshes
+  - imported/tutorials/free-flow-over-porous-media
   - imported/tutorials/heat-exchanger
   - imported/tutorials/heat-exchanger-simplified
   - imported/tutorials/multiple-perpendicular-flaps

--- a/_config.yml
+++ b/_config.yml
@@ -267,48 +267,48 @@ plugins:
   - jekyll-last-modified-at
 
 subprojects:
-  - imported/tutorials/quickstart
+  - imported/aste/docs
+  - imported/dumux-adapter/docs
+  - imported/dune-adapter/docs
+  - imported/fmi-runner/docs
+  - imported/micro-manager/docs
+  - imported/openfoam-adapter/docs
+  - imported/preeco-orga/guidelines
+  - imported/su2-adapter/docs
+  - imported/tutorials/aste-turbine
   - imported/tutorials/breaking-dam-2d
+  - imported/tutorials/channel-transport
+  - imported/tutorials/channel-transport-reaction
   - imported/tutorials/elastic-tube-1d
   - imported/tutorials/elastic-tube-3d
   - imported/tutorials/flow-around-controlled-moving-cylinder
   - imported/tutorials/flow-over-heated-plate
-  - imported/tutorials/flow-over-heated-plate-steady-state
   - imported/tutorials/flow-over-heated-plate-nearest-projection
+  - imported/tutorials/flow-over-heated-plate-partitioned-flow
+  - imported/tutorials/flow-over-heated-plate-steady-state
   - imported/tutorials/flow-over-heated-plate-two-meshes
   - imported/tutorials/heat-exchanger
   - imported/tutorials/heat-exchanger-simplified
   - imported/tutorials/multiple-perpendicular-flaps
+  - imported/tutorials/oscillator
+  - imported/tutorials/oscillator-overlap
+  - imported/tutorials/partitioned-backwards-facing-step
   - imported/tutorials/partitioned-elastic-beam
   - imported/tutorials/partitioned-heat-conduction
   - imported/tutorials/partitioned-heat-conduction-complex
   - imported/tutorials/partitioned-heat-conduction-direct
   - imported/tutorials/partitioned-heat-conduction-overlap
-  - imported/tutorials/oscillator
-  - imported/tutorials/oscillator-overlap
-  - imported/tutorials/perpendicular-flap
-  - imported/tutorials/perpendicular-flap-stress
-  - imported/tutorials/turek-hron-fsi3
   - imported/tutorials/partitioned-pipe
   - imported/tutorials/partitioned-pipe-two-phase
-  - imported/tutorials/partitioned-backwards-facing-step
-  - imported/tutorials/flow-over-heated-plate-partitioned-flow
+  - imported/tutorials/perpendicular-flap
+  - imported/tutorials/perpendicular-flap-stress
+  - imported/tutorials/quickstart
+  - imported/tutorials/resonant-circuit
+  - imported/tutorials/tools/tests
+  - imported/tutorials/turek-hron-fsi3
+  - imported/tutorials/two-scale-heat-conduction
   - imported/tutorials/volume-coupled-diffusion
   - imported/tutorials/volume-coupled-flow
-  - imported/tutorials/channel-transport
-  - imported/tutorials/channel-transport-reaction
-  - imported/tutorials/aste-turbine
-  - imported/tutorials/two-scale-heat-conduction
-  - imported/tutorials/tools/tests
-  - imported/tutorials/resonant-circuit
-  - imported/openfoam-adapter/docs
-  - imported/micro-manager/docs
-  - imported/fmi-runner/docs
-  - imported/aste/docs
-  - imported/su2-adapter/docs
-  - imported/dune-adapter/docs
-  - imported/dumux-adapter/docs
-  - imported/preeco-orga/guidelines
 
 # We use these versions to centrally update links
 # and other version-specific information.

--- a/_data/sidebars/tutorial_sidebar.yml
+++ b/_data/sidebars/tutorial_sidebar.yml
@@ -95,10 +95,14 @@ entries:
           url: /tutorials-flow-over-heated-plate-two-meshes.html
           output: web
 
+    - title: Free flow over porous media
+      url: /tutorials-free-flow-over-porous-media-2d.html
+      output: web
+
     - title: Heat exchanger
       url: /tutorials-heat-exchanger.html
       output: web
-    
+
     - title: Heat exchanger simplified
       url: /tutorials-heat-exchanger-simplified.html
       output: web


### PR DESCRIPTION
Pending follow-up of https://github.com/precice/tutorials/pull/678

Also sorts the list of subprojects in `_config.yml`, to be able to identify such missing tutorials easier.

The only other tutorial currently missing is the growing-mesh, which is not yet ready to be on the website (no `README.md`).

@uekerman @Fujikawas FYI