### PR TITLE
Document precice-cli

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -238,6 +238,10 @@ entries:
       url: /tooling-aste.html
       output: web, pdf
 
+    - title: The preCICE CLI
+      url: /tooling-cli.html
+      output: web, pdf
+
     - title: Built-in tooling
       url: /tooling-builtin.html
       output: web, pdf

--- a/content/docs/tooling/tooling-builtin.md
+++ b/content/docs/tooling/tooling-builtin.md
@@ -10,7 +10,11 @@ With the `precice-cli`, you can get the installed preCICE version, generate a re
 
 ## XML reference
 
-For generating the XML reference, we can use `precice-config-doc` (or the deprecated `precice-tools`, with the same options):
+{% version 3.3.0 %}
+`precice-tools md|xml|dt` was deprecated in version 3.3.0 in favour of `precice-config-doc`.
+{% endversion %}
+
+For generating the XML reference, we can use `precice-config-doc`:
 
 ```bash
 precice-config-doc md
@@ -43,11 +47,11 @@ This prints the DTD information, which can be used to validate the XML configura
 ## preCICE version
 
 {% version 2.4.0 %}
-This feature is available since version 2.4.0.
+`precice-tools version` was introduced in version 2.4.0 and deprecated in version 3.3.0 in favour of `precice-version`.
 {% endversion %}
 
 ```bash
-precice-tools version
+precice-version
 ```
 
 This prints the version information of preCICE, which consists of multiple semicolon-separated parts.
@@ -62,11 +66,12 @@ This prints the version information of preCICE, which consists of multiple semic
 ## Configuration check
 
 {% version 2.4.0 %}
-This feature is available since version 2.4.0.
+`precice-tools check` was introduced in version 2.4.0 and deprecated in version 3.3.0 in favour of `precice-config-validate`.
+Prefer to use `precice-cli config check` for the extra logic checks instead.
 {% endversion %}
 
 ```bash
-precice-tools check FILE [ PARTICIPANT [ COMMSIZE ] ]
+precice-config-validate FILE [ PARTICIPANT [ COMMSIZE ] ]
 ```
 
 The `check` runs the preCICE configuration parsing and checking logic on the given configuration file.
@@ -78,7 +83,7 @@ For more logical checks, see the [preCICE config checker](https://github.com/pre
 The basic usage is to check a configuration file:
 
 ```bash
-precice-tools check precice-config.xml
+precice-config-validate precice-config.xml
 ```
 
 Some example errors handled by the checker:
@@ -113,6 +118,6 @@ You may additionally pass the communicator size of the participant.
 This enables some checks regarding user-defined intra-participant communication, which should not be necessary in the vast majority of cases.
 
 ```bash
-precice-tools check precice-config.xml Fluid
-precice-tools check precice-config.xml Fluid 2
+precice-config-validate precice-config.xml Fluid
+precice-config-validate precice-config.xml Fluid 2
 ```

--- a/content/docs/tooling/tooling-cli.md
+++ b/content/docs/tooling/tooling-cli.md
@@ -1,0 +1,71 @@
+---
+title: The preCICE CLI
+permalink: tooling-cli.html
+keywords: tooling, xml, configuration, version, cli, pypi
+summary: "The preCICE CLI provides a unified interface to the main preCICE tools."
+---
+
+The [`precice-cli`](https://github.com/precice/cli) package provides an easy-to-use interface for the [builtin tools](tooling-builtin) of preCICE and a range of python-based tooling.
+
+## Installation
+
+To install the cli locally as a runnable program, we recommend using either [pipx](https://pipx.pypa.io/latest/installation/) by the Python Packaging Authority or [uv](https://docs.astral.sh/uv/) by the [Astal](https://astral.sh) project.
+
+### pipx
+
+```bash
+$ pipx install precice-cli  
+  installed package precice-cli 1.0.0, installed using Python 3.13.7
+  These apps are now globally available
+    - precice-cli
+done! 
+```
+
+### uv
+
+```bash
+$ uv tool install precice-cli
+Resolved 39 packages in 11ms
+Installed 39 packages in 15ms
+Installed 1 executable: precice-cli
+```
+
+## Usage
+
+`precice-cli` offers some basic sub commands and categories:
+
+### version
+
+```bash
+precice-cli version
+```
+
+This subcommand displays the version of installed subcomponents of the cli and the version of the installed precice library.
+
+### profiling
+
+```bash
+precice-cli profiling merge
+precice-cli profiling trace
+```
+
+This subcommand group exposes all commands from the [precice profiling tools](tooling-performance-analysis).
+
+### config
+
+```bash
+precice-cli config check
+precice-cli config visualize
+precice-cli config format
+```
+
+This subcommand group includes configuration related commands such as checking, [visualization](tooling-config-visualization), and formatting.
+
+### init
+
+```bash
+precice-cli init
+```
+
+This experimental command initializes a preCICE case using a topology file.
+Have a look at the [repository](https://github.com/precice/case-generate) for up2date information on the development.

--- a/content/docs/tooling/tooling-cli.md
+++ b/content/docs/tooling/tooling-cli.md
@@ -40,7 +40,8 @@ Installed 1 executable: precice-cli
 precice-cli version
 ```
 
-This subcommand displays the version of installed subcomponents of the cli and the version of the installed precice library.
+This subcommand displays the version of the precice-cli and all preCICE-related dependencies.
+If the preCICE library is installed, it also shows its version and configuration.
 
 ### profiling
 
@@ -59,7 +60,8 @@ precice-cli config visualize
 precice-cli config format
 ```
 
-This subcommand group includes configuration related commands such as checking, [visualization](tooling-config-visualization), and formatting.
+This subcommand group includes configuration related commands such as checking, [visualization](tooling-config-visualization), and [formatting](https://github.com/precice/config-format).
+The check command first validates the given configuration using the [builtin tool](tooling-builtin) and then runs the [config checker](https://github.com/precice/config-check) on it.
 
 ### init
 
@@ -68,4 +70,4 @@ precice-cli init
 ```
 
 This experimental command initializes a preCICE case using a topology file.
-Have a look at the [repository](https://github.com/precice/case-generate) for up2date information on the development.
+Have a look at the [case generation repository](https://github.com/precice/case-generate) for up-to-date information on the development.

--- a/content/docs/tooling/tooling-overview.md
+++ b/content/docs/tooling/tooling-overview.md
@@ -9,6 +9,7 @@ There are probably a few common tasks that could use some automation for.
 
 Here you will find a few tools to:
 
+- [Install and use preCICE tools](tooling-cli.html) as a single integrated preCICE CLI.
 - [Simulate and replay coupled simulations in an artificial environment](tooling-aste.html) without actual solvers and adapters.
 - [Check your configuration file](tooling-builtin.html) without starting a whole simulation.
 - [Visualize the preCICE configuration file](tooling-config-visualization.html) to understand if you are really asking preCICE to do what you meant to.


### PR DESCRIPTION
This PR 

- Adds a page for the tooling-cli, linking to relevant repositories and subpages
- Updates the builtin tooling docs
- Adds the precice-cli to the tooling overview

Closes #581
