### PR TITLE
Add hints to check the installation with precice-version

### DIFF
--- a/content/community/community-training.md
+++ b/content/community/community-training.md
@@ -125,7 +125,7 @@ Do not remove the USB during a live session.
 
 In case you prefer to install everything on your system, you will need the following:
 
-- [preCICE](installation-overview.html)
+- [preCICE](installation-overview.html) (check with running `precice-version` in a terminal)
 - [preCICE Python bindings](installation-bindings-python.html):
   - Create a virtual environment: `python3 -m venv .venv && source .venv/bin/activate`. As long as the environment is active, you will see `(venv)` before your command prompt. You need to activate the venv in new terminal windows.
   - Install the bindings: `pip3 install pyprecice` (check with running `import precice` in a Python interpreter)

--- a/content/docs/installation/building-from-source/installation-source-installation.md
+++ b/content/docs/installation/building-from-source/installation-source-installation.md
@@ -17,6 +17,8 @@ To test your installation please run `make test_install`.
 This will attempt to build our C++ example program against the **installed version** of the library.
 This is commonly known as _the smoke test_.
 
+Alternatively, run `precice-version` in a terminal (see [built-in tooling](tooling-builtin.html#precice-version)), to see which version is being picked up at runtime.
+
 ## Next steps
 
 If you chose a system directory as installation prefix, then this concludes the preCICE installation and you should have a working installation of preCICE on your system.

--- a/content/docs/installation/installation-overview.md
+++ b/content/docs/installation/installation-overview.md
@@ -21,6 +21,8 @@ To find the right method for you, follow this decision graph, or read on!
     <area target="" alt="Demo Virtual Machine" title="Demo Virtual Machine" href="installation-vm.html" coords="439,340,562,401" shape="rect">
 </map>
 
+You can always check your preCICE installation by running `precice-version` in a terminal (see [built-in tooling](tooling-builtin.html#precice-version)).
+
 Note that preCICE is much more than the core library. To find out which library, bindings, adapters, and tutorials versions work together,
 have a look at the [preCICE distribution](installation-distribution.html).
 


### PR DESCRIPTION
Adds hints in:

- Installation overview, below the graph: https://precice.org/installation-overview.html
- Building from source - installation: https://precice.org/installation-source-installation.html
- Training preparation: https://precice.org/community-training.html#individual-dependencies

Anywhere else to add it?