### PR TITLE
Fix news card title truncation

### DIFF
--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -270,16 +270,16 @@ div.logo-holder > img {
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-line-clamp: 2;
-  line-clamp: 2; 
+  line-clamp: 2;
   -webkit-box-orient: vertical;
-  height: 2.8em; 
+  color: #000;
 }
 
 .news-card p:first-of-type {
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 5; 
+  -webkit-line-clamp: 5;
   line-clamp: 5;
   -webkit-box-orient: vertical;
 }
@@ -301,5 +301,20 @@ div.logo-holder > img {
   }
   #news-container .col-md-4 {
     flex: 1 1 100%;         
+  }
+}
+
+/* Responsive title line-clamp for news cards */
+@media (max-width: 992px) {
+  .news-card h4 {
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+  }
+}
+
+@media (max-width: 576px) {
+  .news-card h4 {
+    -webkit-line-clamp: 4;
+    line-clamp: 4;
   }
 }

--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -312,7 +312,7 @@ div.logo-holder > img {
   }
 }
 
-@media (max-width: 576px) {
+@media (max-width: 768px) {
   .news-card h4 {
     -webkit-line-clamp: 4;
     line-clamp: 4;


### PR DESCRIPTION
## Fix responsive truncation of news card titles

Closes #699

---

This PR addresses #699 by improving how news card titles are truncated across different viewport sizes.

Previously, titles were limited to **two lines regardless of screen width**, which caused overly aggressive truncation on tablet and mobile devices. On narrower viewports, this reduced readability and cut off titles prematurely.

---

### **Approach**

Introduced responsive `-webkit-line-clamp` values using media queries to allow more vertical space for titles on smaller screens:

- **Desktop (> 992px):** 2 lines  
- **Tablet (768px – 992px):** 3 lines  
- **Mobile (< 576px):** 4 lines  

This preserves a compact layout on larger screens while improving readability on smaller devices.

Additionally, the title color was explicitly set to `#000` so the ellipsis (`...`) visually matches the title text.

---

### **Why This Approach?**

- Improves readability on smaller viewports  
- Maintains consistent layout density on desktop  
- Uses a CSS-only solution (no JavaScript required)  
- Aligns with the existing responsive breakpoint structure  

---

### **Changes**

- Updated `css/landing-page.css`
- Added media queries for `.news-card h4`
- Adjusted responsive `-webkit-line-clamp` values
- Explicitly set title color to black

---

### **Testing**

Tested locally by:

- Resizing the browser viewport  
- Using DevTools device emulation  
- Verifying title rendering at different breakpoints  

The truncation now behaves consistently and improves title visibility across devices.

---

### **Screenshots**

<img width="888" height="741" alt="image" src="https://github.com/user-attachments/assets/919dc73f-ff2c-4d44-984b-cbbbce17bee2" />
<img width="1578" height="792" alt="image" src="https://github.com/user-attachments/assets/9952bbca-0ef9-4bac-8af1-7b8b1ab46fe5" />
<img width="1578" height="792" alt="image" src="https://github.com/user-attachments/assets/cbbed3ff-5176-42d5-b63f-8d8e0d3189b7" />
