### PR TITLE
Fix latest news card title truncation at intermediate breakpoints

### DIFF
--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -266,13 +266,8 @@ div.logo-holder > img {
 }
 
 .news-card h4 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2; 
-  -webkit-box-orient: vertical;
-  height: 2.8em; 
+  overflow-wrap: anywhere;
+  hyphens: auto;
 }
 
 .news-card p:first-of-type {
@@ -297,9 +292,9 @@ div.logo-holder > img {
 
 @media (max-width: 768px) {
   #news-container {
-    flex-wrap: wrap;         
+    flex-wrap: wrap;
   }
   #news-container .col-md-4 {
-    flex: 1 1 100%;         
+    flex: 1 1 100%;
   }
 }


### PR DESCRIPTION
## Summary
This fixes issue #699 where the "Latest news" card titles were getting cut off (ellipsis/clipping) on certain viewport widths.

## What changed
- Updated `/css/landing-page.css` for `.news-card h4`:
  - removed the fixed 2-line clamp/truncation styles
  - enabled natural wrapping with `overflow-wrap: anywhere;` and `hyphens: auto;`

## Why
The previous title clamp (`-webkit-line-clamp` + fixed height) caused aggressive truncation at intermediate breakpoints.  
This change keeps the existing card layout and only adjusts title text behavior.

## Validation
- Built locally with `bundle exec jekyll build`
- Verified the "Latest news" section no longer cuts off titles at the affected widths (mobile and desktop behavior preserved)

Closes #699

## Demo
https://github.com/user-attachments/assets/62fabfef-55c4-49d7-8f93-84ee460f0750