### PR TITLE
Add jekyll-mermaid to conditionally render Mermaid graphs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :jekyll_plugins do
   gem 'jekyll-sitemap'
   gem 'jekyll-redirect-from'
   gem "jekyll-last-modified-at"
+  gem 'jekyll-mermaid'
 end
 
 gem 'jemoji'

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,5 @@
 repository: precice/precice.github.io_future
 
-mermaid:
-  src: 'https://cdn.jsdelivr.net/npm/mermaid@11.12.3/dist/mermaid.min.js'
-
 output: web
 # this property is useful for conditional filtering of content that is separate from the PDF.
 
@@ -263,6 +260,9 @@ algolia:
   index_name:     jekyll
   search_only_api_key: 760ed6be3e165d08b4a798ac4aa82fe4
   nodes_to_index: 'p,code,table' # html tags to include in search index
+
+mermaid:
+  src: 'https://cdn.jsdelivr.net/npm/mermaid@11.12.3/dist/mermaid.min.js'
 
 plugins:
   - jekyll-redirect-from

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,8 @@
 repository: precice/precice.github.io_future
 
+mermaid:
+  src: 'https://cdn.jsdelivr.net/npm/mermaid@11.12.3/dist/mermaid.min.js'
+
 output: web
 # this property is useful for conditional filtering of content that is separate from the PDF.
 

--- a/content/docs/configuration/advanced/configuration-coupling-multi.md
+++ b/content/docs/configuration/advanced/configuration-coupling-multi.md
@@ -48,11 +48,12 @@ Still, even with only explicit schemes, you can do very strange combinations. So
 
 The mesh over which the data is communicated plays no role. We get a circular dependency:
 
-```txt
-A -- first to second --> B;
-B -- first to second --> C;
-C -- first to second --> A;
-```
+{% mermaid %}
+graph LR
+  A -->|first to second| B
+  B -->|first to second| C
+  C -->|first to second| A
+{% endmermaid %}
 
 All three participants are a second participant in a serial coupling scheme, in which they receive data. Thus, they all wait for data in `initialize`, which is, however, only sent in the `advance` call of another participant, as explained on the [coupling flow pages](couple-your-code-coupling-flow.html).
 


### PR DESCRIPTION
Fixes https://github.com/precice/precice.github.io/issues/552

# Feature:

Added mermaid.js support for the docs.

# Approach

Mermaid can only be loaded on the html layer. We conditionally load it only on the pages where required as it is quite heavy (approx. 800KB).

# Changes

## Before

<img width="907" height="329" alt="image" src="https://github.com/user-attachments/assets/00a9c3ba-1b77-4fcc-91ba-29cb0749f619" />

## After

<img width="898" height="336" alt="image" src="https://github.com/user-attachments/assets/6ff68fb5-cb2e-46f2-a92a-cca6caf3fde1" />
