### PR TITLE
Fix/news section sorting 402

### DIFF
--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -89,7 +89,7 @@ div.image-holder.usp > img {
 }
 
 /* Adapter section */
-/* adapter class also used for news in the langing page */
+/* adapter class also used for news in the landing page */
 a.adapter {
   text-decoration: none;
 }
@@ -263,6 +263,10 @@ div.logo-holder > img {
   padding: 20px;
   margin-bottom: 20px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.news-card a.adapter {
+  display: block;
 }
 
 .news-card h4 {

--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -265,8 +265,15 @@ div.logo-holder > img {
   box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
-.news-card a.adapter {
+.news-card a.news-link {
   display: block;
+  text-decoration: none;
+  color: #040606;
+}
+
+.news-card a.news-link:hover {
+  text-decoration: none;
+  color: #040606;
 }
 
 .news-card h4 {

--- a/js/news-collect.js
+++ b/js/news-collect.js
@@ -10,7 +10,6 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     if (!topics.length) throw new Error("No topics found");
 
-    // Sort by publication date instead of last activity
     topics.sort((a, b) => new Date(b.created_at || b.last_posted_at) - new Date(a.created_at || a.last_posted_at));
     loadingText.style.display = "none";
 
@@ -23,7 +22,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
       const date = new Date(topic.created_at || topic.last_posted_at).toLocaleDateString("en-GB");
 
-      card.innerHTML = `<a href="${topic.url}" target="_blank" rel="noopener noreferrer" class="adapter no-external-marker">
+      card.innerHTML = `<a href="${topic.url}" target="_blank" rel="noopener noreferrer" class="news-link no-external-marker">
         <h4><strong>${topic.title}</strong></h4>
         <p>${topic.description}</p>
         <p class="text-muted"><small>${date}</small></p>

--- a/js/news-collect.js
+++ b/js/news-collect.js
@@ -1,5 +1,3 @@
-console.log(">>> USING JS FILE: news-collect.js LOADED <<<");
-
 document.addEventListener("DOMContentLoaded", async function () {
   const newsContainer = document.getElementById("news-container");
   const loadingText = document.getElementById("loading-news");
@@ -12,29 +10,28 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     if (!topics.length) throw new Error("No topics found");
 
-    topics.sort((a, b) => new Date(b.last_posted_at) - new Date(a.last_posted_at));
+    // Sort by publication date instead of last activity
+    topics.sort((a, b) => new Date(b.created_at || b.last_posted_at) - new Date(a.created_at || a.last_posted_at));
     loadingText.style.display = "none";
 
-for (const topic of topics.slice(0, 3)) {
-  const col = document.createElement("div");
-  col.className = "col-md-4 col-sm-6 col-xs-12";
+    for (const topic of topics.slice(0, 3)) {
+      const col = document.createElement("div");
+      col.className = "col-md-4 col-sm-6 col-xs-12";
 
-  const card = document.createElement("div");
-  card.className = "news-card";
+      const card = document.createElement("div");
+      card.className = "news-card";
 
-  // NOTE: The `adapter` class is used here as an already available card class, feel free to provide a new one.
-  card.innerHTML = `<a href="${topic.url}" target="_blank" rel="noopener noreferrer" class="adapter no-external-marker">
-    <h4><strong>${topic.title}</strong></h4>
-    <p>${topic.description}</p>
-    </a>
-    <p class="text-muted"><small>
-      Last activity: ${new Date(topic.last_posted_at).toLocaleDateString("en-GB")}
-    </small></p>
-  `;
+      const date = new Date(topic.created_at || topic.last_posted_at).toLocaleDateString("en-GB");
 
-  col.appendChild(card);
-  newsContainer.appendChild(col);
-}
+      card.innerHTML = `<a href="${topic.url}" target="_blank" rel="noopener noreferrer" class="adapter no-external-marker">
+        <h4><strong>${topic.title}</strong></h4>
+        <p>${topic.description}</p>
+        <p class="text-muted"><small>${date}</small></p>
+      </a>`;
+
+      col.appendChild(card);
+      newsContainer.appendChild(col);
+    }
 
   } catch (err) {
     console.error(err);

--- a/tools/fetch-news.py
+++ b/tools/fetch-news.py
@@ -34,6 +34,7 @@ def main():
                 "title": topic["title"],
                 "slug": topic["slug"],
                 "url": f"https://precice.discourse.group/t/{topic['slug']}/{topic['id']}",
+                "created_at": topic.get("created_at"),
                 "last_posted_at": topic.get("last_posted_at"),
                 "like_count": topic.get("like_count"),
                 "posts_count": topic.get("posts_count"),


### PR DESCRIPTION
Sort news by publication date and make full card clickable                                                                                                                      
- Sort by created_at instead of last_posted_at (remaining item from #628)                                                                                                                                 
- Move date inside <a> tag so entire card is clickable                                                                                                                                                    
- Add created_at field to fetch-news.py for sort support
- Remove debug console.log                                                                                                                                                                                 - Fix typo in CSS comment
Addresses #402