### PR TITLE
Enable scrolling in search results dropdown

### DIFF
--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -148,7 +148,7 @@ div.col-flex {
   border-left: 1px solid #dedede;
   box-shadow: 2px 3px 2px #dedede;
   max-height: 800px;
-  overflow: hidden;
+  overflow: auto;
 }
 .result-item {
   /*margin-bottom: 30px;*/


### PR DESCRIPTION
Changed overflow from hidden to auto on the search results container so users can scroll through all results instead of being cut off.

Fixes #403