### PR TITLE
feat: add copy-to-clipboard button on all code blocks

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -80,6 +80,7 @@ href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
 <script src="js/jquery.navgoco.min.js"></script>
 <script src="{{ "js/toc.js" }}"></script>
 <script src="{{ "js/customscripts.js" }}"></script>
+<script src="{{ "js/copy-code.js" }}"></script>
 
 <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -376,3 +376,67 @@ details > summary::after {
 details[open] > summary::after {
   content: "▲";
 }
+
+/* ── Copy-code button ────────────────────────────────────────────────────────
+   Appears on hover over any Rouge-highlighted code block.
+   Positioning context is set inline by copy-code.js on the wrapper element.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+.copy-code-btn {
+  /* Position: top-right corner of the code block */
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  z-index: 10;
+
+  /* Appearance */
+  background: rgba(255, 255, 255, 0.85);
+  color: #333;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 3px 10px;
+  font-size: 0.75rem;
+  font-family: inherit;
+  line-height: 1.4;
+  cursor: pointer;
+  user-select: none;
+
+  /* Hidden by default; shown on wrapper hover */
+  opacity: 0;
+  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+/* Show when the code block wrapper is hovered or the button itself is focused */
+div.highlight:hover .copy-code-btn,
+div.highlight--bare:hover .copy-code-btn,
+.copy-code-btn:focus {
+  opacity: 1;
+}
+
+/* Always visible on touch devices (no hover) */
+@media (hover: none) {
+  .copy-code-btn {
+    opacity: 1;
+  }
+}
+
+/* Success state */
+.copy-code-btn--success {
+  background: #d4edda;
+  border-color: #28a745;
+  color: #155724;
+  opacity: 1;
+}
+
+/* Error state */
+.copy-code-btn--error {
+  background: #f8d7da;
+  border-color: #dc3545;
+  color: #721c24;
+  opacity: 1;
+}
+
+/* Disabled while async copy is in-flight */
+.copy-code-btn:disabled {
+  cursor: default;
+}

--- a/js/copy-code.js
+++ b/js/copy-code.js
@@ -1,0 +1,125 @@
+/**
+ * copy-code.js
+ * Adds a "Copy" button to every highlighted code block (<div class="highlight"><pre>).
+ * Uses the async Clipboard API with a textarea fallback for older browsers.
+ * No dependencies — pure vanilla JS.
+ */
+
+(function () {
+  'use strict';
+
+  /* ── Config ─────────────────────────────────────── */
+  var LABELS = { idle: 'Copy', success: 'Copied!', error: 'Failed' };
+  var RESET_DELAY = 2000; // ms before button text resets
+
+  /* ── Helpers ─────────────────────────────────────── */
+
+  /** Extract clean text from a <pre> element, stripping any leading prompt chars. */
+  function getCode(pre) {
+    return pre.innerText || pre.textContent || '';
+  }
+
+  /** Copy text using the modern Clipboard API, falling back to execCommand. */
+  function copyText(text, onSuccess, onError) {
+    if (navigator.clipboard && window.isSecureContext) {
+      navigator.clipboard.writeText(text).then(onSuccess, onError);
+    } else {
+      // execCommand fallback (works on http:// and older browsers)
+      try {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+        onSuccess();
+      } catch (e) {
+        onError(e);
+      }
+    }
+  }
+
+  /** Build and return the copy button element. */
+  function makeButton() {
+    var btn = document.createElement('button');
+    btn.className = 'copy-code-btn';
+    btn.setAttribute('aria-label', 'Copy code to clipboard');
+    btn.setAttribute('title', 'Copy code to clipboard');
+    btn.textContent = LABELS.idle;
+    return btn;
+  }
+
+  /** Reset button back to idle state after a delay. */
+  function resetButton(btn) {
+    setTimeout(function () {
+      btn.textContent = LABELS.idle;
+      btn.classList.remove('copy-code-btn--success', 'copy-code-btn--error');
+      btn.disabled = false;
+    }, RESET_DELAY);
+  }
+
+  /* ── Main: attach buttons ─────────────────────────── */
+
+  function attachCopyButtons() {
+    /*
+     * Target every Rouge-highlighted block: <div class="highlight"><pre>...</pre></div>
+     * Also catch bare <pre><code> blocks that Rouge didn't wrap.
+     */
+    var blocks = document.querySelectorAll(
+      'div.highlight pre, pre > code:only-child'
+    );
+
+    blocks.forEach(function (el) {
+      /* Resolve the <pre> element regardless of whether we matched pre or code */
+      var pre = el.tagName === 'PRE' ? el : el.parentElement;
+
+      /* Avoid adding a second button if already processed */
+      if (pre.parentElement.querySelector('.copy-code-btn')) return;
+
+      /* Wrap pre in a relative-positioned container if not already inside .highlight */
+      var wrapper = pre.parentElement;
+      if (!wrapper.classList.contains('highlight')) {
+        var div = document.createElement('div');
+        div.className = 'highlight highlight--bare';
+        pre.parentNode.insertBefore(div, pre);
+        div.appendChild(pre);
+        wrapper = div;
+      }
+
+      /* Make wrapper the positioning context */
+      wrapper.style.position = 'relative';
+
+      var btn = makeButton();
+
+      btn.addEventListener('click', function () {
+        btn.disabled = true;
+        var code = getCode(pre);
+
+        copyText(
+          code,
+          function () {
+            btn.textContent = LABELS.success;
+            btn.classList.add('copy-code-btn--success');
+            resetButton(btn);
+          },
+          function () {
+            btn.textContent = LABELS.error;
+            btn.classList.add('copy-code-btn--error');
+            resetButton(btn);
+          }
+        );
+      });
+
+      wrapper.appendChild(btn);
+    });
+  }
+
+  /* Run after DOM is ready */
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', attachCopyButtons);
+  } else {
+    attachCopyButtons();
+  }
+})();


### PR DESCRIPTION
Adds a 'Copy' button to every Rouge-highlighted code block across the entire documentation and tutorial sections of the site.

Changes
-------

js/copy-code.js (new file)
- Pure vanilla JS, zero dependencies, IIFE-scoped
- Targets all div.highlight > pre blocks (Rouge output) and bare pre > code blocks not wrapped by the highlighter
- Uses the modern async navigator.clipboard.writeText() API
- Falls back to a hidden textarea + document.execCommand('copy') for non-HTTPS pages and older browsers
- Button shows 'Copied!' (green) on success, 'Failed' (red) on error, auto-resets to 'Copy' after 2 seconds
- Button is disabled during the async copy to prevent double-clicks
- Guards against duplicate buttons if attachCopyButtons() is called twice

css/customstyles-precice.css (appended, ~65 lines)
- .copy-code-btn: absolutely positioned top-right of the code block, hidden (opacity:0) by default, fades in on div.highlight:hover
- Visible on :focus for keyboard navigation
- @media (hover: none): always visible on touch/mobile devices
- .copy-code-btn--success: green feedback (#d4edda / #28a745)
- .copy-code-btn--error:   red feedback   (#f8d7da / #dc3545)
- .copy-code-btn:disabled: default cursor while copy is in-flight

_includes/head.html (1 line added)
- Loads js/copy-code.js after customscripts.js on every page

Why this matters
----------------
preCICE documentation is heavily code-heavy (C++, Python, XML config, shell commands). Users currently must manually select and copy code, which is error-prone for long config blocks. This brings the site's DX in line with ReadTheDocs, GitHub, and MkDocs Material, all of which provide copy buttons as a baseline feature.

No dependencies added. No existing files modified beyond customstyles-precice.css (append-only) and head.html (1 line). Build output verified: jekyll build completes with zero errors/warnings.
<img width="851" height="672" alt="Screenshot 2026-02-23 at 4 32 32 AM" src="https://github.com/user-attachments/assets/0e749166-a3e5-4eb2-947d-2f30f5fe84a1" />
