### PR TITLE
Improve short-query precision in Algolia search

### DIFF
--- a/_includes/algolia.html
+++ b/_includes/algolia.html
@@ -9,6 +9,8 @@ const algoliaSearch = instantsearch({
       searchResults.hide();
       return;
     }
+    helper.setQueryParameter('minWordSizefor1Typo', 5);
+    helper.setQueryParameter('minWordSizefor2Typos', 9);
     helper.search();
     searchResults.show();
   }

--- a/_includes/algolia.html
+++ b/_includes/algolia.html
@@ -9,6 +9,8 @@ const algoliaSearch = instantsearch({
       searchResults.hide();
       return;
     }
+    // Raise typo thresholds so short words (<=4 chars) like "gsoc" require
+    // exact matches, preventing fuzzy hits against unrelated XML tokens.
     helper.setQueryParameter('minWordSizefor1Typo', 5);
     helper.setQueryParameter('minWordSizefor2Typos', 9);
     helper.search();

--- a/js/algolia-search.js
+++ b/js/algolia-search.js
@@ -9,6 +9,8 @@ const algoliaSearch = instantsearch({
       searchResults.hide();
       return;
     }
+    helper.setQueryParameter('minWordSizefor1Typo', 5);
+    helper.setQueryParameter('minWordSizefor2Typos', 9);
     helper.search();
     searchResults.show();
   }

--- a/js/algolia-search.js
+++ b/js/algolia-search.js
@@ -9,6 +9,8 @@ const algoliaSearch = instantsearch({
       searchResults.hide();
       return;
     }
+    // Raise typo thresholds so short words (<=4 chars) like "gsoc" require
+    // exact matches, preventing fuzzy hits against unrelated XML tokens.
     helper.setQueryParameter('minWordSizefor1Typo', 5);
     helper.setQueryParameter('minWordSizefor2Typos', 9);
     helper.search();


### PR DESCRIPTION
Summary
Improve short-query precision in Algolia by applying a minimal query-time typo-threshold tweak in both Algolia entry points.

What changed
- `_includes/algolia.html`
- `js/algolia-search.js`

Both now set:
- `minWordSizefor1Typo = 5`
- `minWordSizefor2Typos = 9`

This is intentionally unconditional and minimal. Algolia applies these as per-word thresholds, so the behavior is naturally scoped to short words without extra helper logic.

Why
This reduces false positives for short queries (for example `gsoc` matching unrelated XML tokens) while avoiding broader search/index configuration changes.

Context
- The indexing/root-cause workflow typo has already been fixed separately in `#813`.
- This PR focuses only on query-time typo-tolerance behavior in the frontend search code.

Validation
- `pre-commit run --files _includes/algolia.html js/algolia-search.js` (passed)
- Attempted Docker build:
  - `docker run --rm -v "${PWD}:/srv/jekyll" -w /srv/jekyll jekyll/jekyll:4 bash -lc "bundle exec jekyll build"`
  - Could not run in this environment because Docker daemon is not available (`dockerDesktopLinuxEngine` pipe missing).

Related: #733
