### PR TITLE
Mitigate Jekyll local build issues with Docker-first workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,9 @@ group :dev do
   gem 'jekyll-watch'
 end
 
-# For googlescholar.rb
+# For googlescholar.rb.
+# Keep open-uri from Ruby stdlib to avoid extra native dependencies.
 gem "nokogiri"
-gem "open-uri"
 
 # Maybe in the future
 # https://rubygems.org/gems/jekyll-scholar

--- a/README.md
+++ b/README.md
@@ -4,20 +4,32 @@
 
 First install [`pre-commit`](https://repology.org/project/python:pre-commit/versions) to keep your commits clean.
 
-The website is using [Jekyll](https://jekyllrb.com/) static website generator and [Github pages](https://pages.github.com/).
-To run and develop it locally you need to install [`rbenv`](rbenv.org) using `apt install rbenv ruby-build`.
-Then use `rbenv init` and follow the instructions to set it up.
-With `rbenv` installed and activated in your shell:
+The website uses [Jekyll](https://jekyllrb.com/) and [GitHub Pages](https://pages.github.com/). For most contributors, the most reliable setup is to run Jekyll in Docker.
+
+### Recommended: run Jekyll in Docker
 
 ```bash
 git clone --recurse-submodules https://github.com/precice/precice.github.io && cd precice.github.io
 pre-commit install
-rbenv install
-bundle install
-bundle exec jekyll serve -l
+docker run --rm --volume="${PWD}:/srv/jekyll" --workdir /srv/jekyll --publish 127.0.0.1:4000:4000 -it jekyll/jekyll:4 bash -lc "bundle install && bundle exec jekyll serve -H 0.0.0.0"
 ```
 
-You can now view website locally in your browser at `localhost:4000`.
+You can now view the website locally at `http://localhost:4000/`.
+
+### Optional: native Ruby setup
+
+If you prefer a native setup, install [`rbenv`](https://rbenv.org/) and `ruby-build` (for example via `apt install rbenv ruby-build`), then run `rbenv init` and follow its shell setup instructions.
+
+```bash
+git clone --recurse-submodules https://github.com/precice/precice.github.io && cd precice.github.io
+pre-commit install
+rbenv init
+rbenv install
+bundle install
+bundle exec jekyll serve
+```
+
+With `rbenv` installed and activated in your shell, you can now view the website locally at `http://localhost:4000/`.
 
 ## Update submodules
 
@@ -42,21 +54,20 @@ git pull --recurse-submodules
 
 ## Build inside a Docker container
 
-Instead of building on your system (which requires some setup the first time), you can directly serve the website from a Docker container (using the community image [`jekyll/jekyll`](https://hub.docker.com/r/jekyll/jekyll)). In this directory, after you initialize and update the git submodules, run the following:
+To run a one-off production build inside Docker:
 
-```shell
-docker run --rm --volume="$PWD:/srv/jekyll:Z" --publish 127.0.0.1:4000:4000 -it jekyll/jekyll jekyll serve
+```bash
+docker run --rm --volume="${PWD}:/srv/jekyll" --workdir /srv/jekyll -it jekyll/jekyll:4 bash -lc "bundle install && bundle exec jekyll build"
 ```
 
 Arguments:
 
 * `docker run`: The Docker command to run a container from an existing image
 * `--rm`: Automatically remove (or not) the container when it exists
-* `--volume`: Mount the current directory (`$PWD`) to a directory in the container (`/srv/jekyll`), so that only the current container can see the content (`:Z`)
-* `--publish`: Publish the container's port 4000 (where Jekyll serves the website) to the host port 4000. Note that `127.0.0.1` is the localhost in IPv4. For IPv6, you can replace that with `[::1]`.
+* `--volume`: Mount the current directory (`$PWD`) to `/srv/jekyll` in the container. If your host uses SELinux, append `:Z`.
 * `-it`: Interactive container, capturing signals (such as `Ctrl-C`).
-* `jekyll/jekyll`: The image
-* `jekyll serve`: The command to run. Somehow, the current default `make` target does not work in this context.
+* `jekyll/jekyll:4`: The image
+* `bundle exec jekyll build`: The command to run
 
 ## Further information
 

--- a/content/docs/docs-meta/docs-meta-common-issues.md
+++ b/content/docs/docs-meta/docs-meta-common-issues.md
@@ -21,6 +21,22 @@ In order to retrieve the current number of citations on Google Scholar, we use t
 
 Either visit [http://scholar.google.com](http://scholar.google.com) in your browser and solve the Captcha or deactivate the `googlescholar.rb` plugin temporarily, e.g. by renaming it to `googlescholar.rb_`, or commenting out its contents.
 
+## Native gem extension build fails
+
+You may see errors such as `Gem::Ext::BuildError` while installing dependencies, often mentioning gems like `sassc`, `google-protobuf`, `ffi`, or `stringio`.
+
+### Why this happens
+
+Some Jekyll-related dependencies include native extensions. Depending on your host toolchain and distro defaults, these builds can fail.
+
+### Workaround
+
+Use the Docker-based workflow from the [README](https://github.com/precice/precice.github.io/blob/master/README.md#local-development), which avoids host-specific compilation issues:
+
+```bash
+docker run --rm --volume="${PWD}:/srv/jekyll" --workdir /srv/jekyll --publish 127.0.0.1:4000:4000 -it jekyll/jekyll:4 bash -lc "bundle install && bundle exec jekyll serve -H 0.0.0.0"
+```
+
 ## Jekyll crashes on Windows
 
 Some of the flags (arguments) for running `jekyll build` or `jekyll serve` are known to crash on Windows, e.g. `--safe -l` or `--detach`. In most cases there is no workaround, because the features are simply not implemented or available in Windows, so run the command without the flag.

--- a/content/docs/docs-meta/docs-meta-overview.md
+++ b/content/docs/docs-meta/docs-meta-overview.md
@@ -17,20 +17,24 @@ In addition Tom did a great job documenting the theme (using the theme) and you 
 
 ## Getting started
 
-To develop the website locally it is recommended to install jekyll and run
+The most reliable way to develop the website locally is to run Jekyll in Docker:
 
 ```bash
-bundle exec jekyll serve
+docker run --rm --volume="${PWD}:/srv/jekyll" --workdir /srv/jekyll --publish 127.0.0.1:4000:4000 -it jekyll/jekyll:4 bash -lc "bundle install && bundle exec jekyll serve -H 0.0.0.0"
 ```
 
-The [theme's documentation page](https://idratherbewriting.com/documentation-theme-jekyll/index.html#2-install-jekyll) has a step-by-step guide to install jekyll and the plugin ("gem") manager `bundler`. When running jekyll for the first time you might have to install and/or update the gems first:
+This avoids host-specific native gem build problems and should run consistently across distributions.
+
+If you prefer a native Ruby setup, the [theme's documentation page](https://idratherbewriting.com/documentation-theme-jekyll/index.html#2-install-jekyll) has a step-by-step guide to install Jekyll and the plugin ("gem") manager `bundler`.
+
+When running Jekyll natively for the first time you might have to install and/or update the gems first:
 
 ```bash
 bundle install
 bundle update
 ```
 
-Now try again `bundle exec jekyll serve` and the site should be running at `http://localhost:4000/`. Jekyll will refresh and rebuild when you change files.
+Then run `bundle exec jekyll serve` and open `http://localhost:4000/`. Jekyll refreshes and rebuilds when you change files.
 
 ## How documentation-theme-jekyll works in a nutshell
 


### PR DESCRIPTION
Summary
Reduce day-to-day Jekyll setup friction by documenting and prioritizing a reproducible Docker workflow, plus remove an unnecessary gem dependency that can trigger native build failures.

What this changes
- Make Docker the recommended local development path in README.
- Keep native Ruby setup as an optional path.
- Update docs-meta overview accordingly.
- Add troubleshooting guidance for native gem extension failures (sassc/google-protobuf/ffi/stringio).
- Remove explicit `open-uri` Gemfile dependency and rely on Ruby stdlib `open-uri` for the citation plugin.

Why
This addresses part of #471 with a low-risk mitigation while migration exploration in #472 continues.

Validation
- pre-commit run --files Gemfile README.md content/docs/docs-meta/docs-meta-overview.md content/docs/docs-meta/docs-meta-common-issues.md
- dockerized Jekyll build via jekyll/jekyll:4 completed successfully

Relates to #471
Context: #472