### PR TITLE
Fix irrelevant search results for short queries like GSoC

### DIFF
--- a/_includes/algolia.html
+++ b/_includes/algolia.html
@@ -9,6 +9,13 @@ const algoliaSearch = instantsearch({
       searchResults.hide();
       return;
     }
+
+    // Increase minimum word sizes for typo tolerance to prevent
+    // short queries like "gsoc" from matching unrelated code tokens
+    // (e.g., "gsoc" was matching "sockets" via prefix with 2 typos)
+    helper.setQueryParameter('minWordSizefor1Typo', 5);
+    helper.setQueryParameter('minWordSizefor2Typos', 9);
+
     helper.search();
     searchResults.show();
   }

--- a/js/algolia-search.js
+++ b/js/algolia-search.js
@@ -9,6 +9,13 @@ const algoliaSearch = instantsearch({
       searchResults.hide();
       return;
     }
+
+    // Increase minimum word sizes for typo tolerance to prevent
+    // short queries like "gsoc" from matching unrelated code tokens
+    // (e.g., "gsoc" was matching "sockets" via prefix with 2 typos)
+    helper.setQueryParameter('minWordSizefor1Typo', 5);
+    helper.setQueryParameter('minWordSizefor2Typos', 9);
+
     helper.search();
     searchResults.show();
   }


### PR DESCRIPTION
Fixes #733

### Problem

Short queries like `gsoc` were returning irrelevant XML reference results due to Algolia's default typo tolerance. For example, `gsoc` was fuzzy-matching `sockets` in XML code content.

### Fix

Added stricter typo tolerance parameters at query time in includes/algolia.html and js/algolia-search.js, so words with 4 or fewer characters require exact matches. This is a client-side-only change with no indexing, config, or content modifications.

> [!NOTE]
> Making "GSoC" fully discoverable would additionally require adding `keywords` to `searchableAttributes` in config.yml and re-indexing.

### Screenshots

**Before**

<img width="1901" height="912" alt="image" src="https://github.com/user-attachments/assets/aeea9593-b9ea-413f-84ed-591a878325b1" />

**After**

<img width="1918" height="962" alt="image" src="https://github.com/user-attachments/assets/d9379ffd-b95e-451a-a645-59eaeffbea15" />
