### PR TITLE
Add required _index.md files for mounted adapters (Hugo migration)

### DIFF
--- a/content/docs/adapters/dumux/_index.md
+++ b/content/docs/adapters/dumux/_index.md
@@ -1,0 +1,3 @@
+---
+title: "DuMuX Adapter"
+---

--- a/content/docs/adapters/dune/_index.md
+++ b/content/docs/adapters/dune/_index.md
@@ -1,0 +1,3 @@
+---
+title: "DUNE Adapter"
+---

--- a/content/docs/adapters/openfoam/_index.md
+++ b/content/docs/adapters/openfoam/_index.md
@@ -1,0 +1,3 @@
+---
+title: "OpenFOAM Adapter"
+---

--- a/content/docs/adapters/su2/_index.md
+++ b/content/docs/adapters/su2/_index.md
@@ -1,0 +1,3 @@
+---
+title: "SU2 Adapter"
+---


### PR DESCRIPTION
Resolves #590

### What this does
As requested in #590, preparing the content structure for the upcoming Hugo migration (#588). Hugo requires folder sections to contain an [_index.md](cci:7://file:///d:/top/gsoc/precice.github.io/content/docs/_index.md:0:0-0:0) file in order for imported materials/subprojects to mount correctly as top-level sections. 

I checked the [_config.yml](cci:7://file:///d:/top/gsoc/precice.github.io/_config.yml:0:0-0:0) subprojects and added the missing [_index.md](cci:7://file:///d:/top/gsoc/precice.github.io/content/docs/_index.md:0:0-0:0) files (with a basic title frontmatter) to the currently mounted adapter locations:
- [content/docs/adapters/dumux/_index.md](cci:7://file:///d:/top/gsoc/precice.github.io/content/docs/adapters/dumux/_index.md:0:0-0:0)
- [content/docs/adapters/dune/_index.md](cci:7://file:///d:/top/gsoc/precice.github.io/content/docs/adapters/dune/_index.md:0:0-0:0)
- [content/docs/adapters/openfoam/_index.md](cci:7://file:///d:/top/gsoc/precice.github.io/content/docs/adapters/openfoam/_index.md:0:0-0:0)
- [content/docs/adapters/su2/_index.md](cci:7://file:///d:/top/gsoc/precice.github.io/content/docs/adapters/su2/_index.md:0:0-0:0)

(Note: Let me know if you would also like me to add [_index.md](cci:7://file:///d:/top/gsoc/precice.github.io/content/docs/_index.md:0:0-0:0) files for the other non-adapter mounted subprojects like `aste` or `fmi-runner`, or if you prefer keeping this PR scoped strictly to the adapters!)