### PR TITLE
Add bug report and documentation improvement issue templates (#746)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug Report
+description: Create a report to help us improve the documentation
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below.
+  - type: input
+    id: url
+    attributes:
+      label: Page URL
+      description: On which page did you encounter the issue?
+      placeholder: "https://precice.org/..."
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type of issue
+      description: What kind of issue are you experiencing?
+      options:
+        - Broken link
+        - Layout or rendering issue
+        - Content error (e.g. typos, outdated info)
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please describe the bug clearly and concisely.
+      placeholder: "When I click on the link to X, I get a 404 error."
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual behavior (optional)
+      description: What did you expect to happen, and what actually happened?
+      placeholder: "I expected the page to show Y, but it showed Z instead."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Ask a question on Discourse
+    url: https://precice.discourse.group/
+    about: For general questions about using preCICE, please use the Discourse forum instead of opening an issue.
+  - name: 📖 preCICE Documentation
+    url: https://precice.org/docs.html
+    about: Check the documentation before opening an issue — your question might already be answered there.
+  - name: 🐛 Report a bug in preCICE (the library)
+    url: https://github.com/precice/precice/issues/new/choose
+    about: For bugs in the preCICE library itself (not the website), please open an issue in the main repository.

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.yml
@@ -1,0 +1,25 @@
+name: Documentation Improvement
+description: Suggest an improvement, clarification, or addition to the docs
+title: "[Docs]: "
+labels: ["content"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve our documentation! Please describe what is missing or unclear and how we can fix it.
+  - type: textarea
+    id: unclear
+    attributes:
+      label: What is unclear or missing?
+      description: Which part of the documentation did you find confusing, incomplete, or entirely missing?
+      placeholder: "The section on X doesn't explain how to configure Y."
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: Do you have a suggestion on how to improve this? (e.g. proposed wording, new examples)
+      placeholder: "It would be helpful to add a code snippet showing..."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature Request
+description: Suggest an enhancement or new feature for the preCICE website
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please describe what you'd like to see on the preCICE website.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: Is your feature request related to a problem? What is the use case?
+      placeholder: "I find it difficult to navigate to X because..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you'd like to see.
+      placeholder: "It would be great to have a sidebar link to... / a search filter for..."
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+      description: Have you considered any alternative solutions or workarounds?
+      placeholder: "I currently work around this by..."
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area of the website
+      description: Which part of the website does this relate to?
+      options:
+        - Documentation (docs pages)
+        - Landing page / homepage
+        - Navigation / search
+        - Community pages (workshops, stories)
+        - Infrastructure (build, CI, deployment)
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/technical_issue.yml
+++ b/.github/ISSUE_TEMPLATE/technical_issue.yml
@@ -1,0 +1,60 @@
+name: Technical Issue
+description: Report a technical problem with the website infrastructure (build, performance, accessibility, SEO)
+title: "[Technical]: "
+labels: ["technical"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for issues related to the website's technical infrastructure, such as build failures, performance problems, accessibility gaps, or SEO issues.
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: What kind of technical issue is this?
+      options:
+        - Build / Jekyll issue
+        - Performance (loading speed, asset size)
+        - Accessibility (a11y)
+        - SEO / metadata
+        - CSS / styling
+        - JavaScript / interactivity
+        - CI / GitHub Actions
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please describe the technical issue clearly and concisely. Include error messages, screenshots, or links where relevant.
+      placeholder: "The site takes 8+ seconds to load on mobile because..."
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce (if applicable)
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Run `bundle exec jekyll serve`
+        2. Navigate to ...
+        3. See error in console
+    validations:
+      required: false
+  - type: textarea
+    id: proposed-fix
+    attributes:
+      label: Proposed fix (optional)
+      description: If you have investigated the root cause, describe your proposed solution.
+      placeholder: "The issue is in `_includes/head.html` line 42. We should..."
+    validations:
+      required: false
+  - type: input
+    id: browser
+    attributes:
+      label: Browser / environment (if relevant)
+      description: Which browser or environment did you test in?
+      placeholder: "Chrome 120 on Windows 11 / Firefox 121 on Ubuntu 22.04"
+    validations:
+      required: false


### PR DESCRIPTION
Resolves #746

### What this does
Added structured YAML issue forms for:
1. **Bug reports** (capturing Page URL, issue type, description, and expected behavior)
2. **Documentation improvements** (capturing unclear aspects and suggested improvements)

This provides exactly the fields requested in #746, while automatically applying the `bug` and `content` labels respectively to make triage easier.

(Note: Tested the YAML structure locally; the form generates cleanly matching the existing `user-story.yml` schema limitations).
