### PR TITLE
perf: lazy-load logo wall images (#751)

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -515,7 +515,7 @@ layout: landing_page
         <div class="col-md-3 col-sm-3 col-xs-3 text-center"> <!--  vertical-align -->
           <a href="{{logo.link}}" class="logo no-icon">
             <div class="logo-holder vertical-align "> <!-- center-block -->
-              <img class="img-responsive center-block" src="images/logo/{{logo.logo}}" alt="{{logo.name}}, {{logo.country}}">
+              <img class="img-responsive center-block" src="images/logo/{{logo.logo}}" alt="{{logo.name}}, {{logo.country}}" loading="lazy">
             </div>
             <p class="institution">{{logo.name}}</p>
             <p class="country">{{logo.country}}</p>


### PR DESCRIPTION
Closes #751

## What

Adds `loading="lazy"` to the ~67 logo wall `<img>` tags on the homepage.

## Why

All logo images fire HTTP requests immediately on page load, even though the logo wall is near the bottom of a long page. This competes with above-the-fold resources (hero, CSS, JS) and hurts initial load performance — especially on mobile.

## How

Single attribute addition in [content/index.html](cci:7://file:///d:/top/gsoc/precice.github.io/content/index.html:0:0-0:0):

```diff
- <img class="img-responsive center-block" src="images/logo/{{logo.logo}}" alt="{{logo.name}}, {{logo.country}}">
+ <img class="img-responsive center-block" src="images/logo/{{logo.logo}}" alt="{{logo.name}}, {{logo.country}}" loading="lazy">
