### PR TITLE
Security: add rel=noopener noreferrer to social links

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -79,20 +79,20 @@
                     <!--end search-->
                 </li>
                 <li>
-                    <a class="no-icon nav-external" href="https://precice.discourse.group" target="_blank" data-show-count="false" aria-label="Join the discourse community"><i class="fab fa-discourse"></i></a>
+                    <a class="no-icon nav-external" href="https://precice.discourse.group" target="_blank" rel="noopener noreferrer" data-show-count="false" aria-label="Join the discourse community"><i class="fab fa-discourse"></i></a>
                 </li>
                 <li>
-                    <a class="no-icon nav-external" href="https://github.com/precice" target="_blank" data-show-count="false" aria-label="Star precice/precice on GitHub"><i class="fab fa-github"></i></a>
+                    <a class="no-icon nav-external" href="https://github.com/precice" target="_blank" rel="noopener noreferrer" data-show-count="false" aria-label="Star precice/precice on GitHub"><i class="fab fa-github"></i></a>
                 </li>
                 <li>
-                    <a class="no-icon nav-external" href="https://www.linkedin.com/company/precice" target="_blank" data-show-count="false" aria-label="Follow us on LinkedIn"><i class="fab fa-linkedin"></i></a>
+                    <a class="no-icon nav-external" href="https://www.linkedin.com/company/precice" target="_blank" rel="noopener noreferrer" data-show-count="false" aria-label="Follow us on LinkedIn"><i class="fab fa-linkedin"></i></a>
                 </li>
                 <li>
                     <!-- rel="me" required by Mastodon for verification -->
-                    <a rel="me" class="no-icon nav-external" href="https://fosstodon.org/@precice" target="_blank" data-show-count="false" aria-label="Follow us on Mastodon"><i class="fab fa-mastodon"></i></a>
+                    <a rel="me noopener noreferrer" class="no-icon nav-external" href="https://fosstodon.org/@precice" target="_blank" data-show-count="false" aria-label="Follow us on Mastodon"><i class="fab fa-mastodon"></i></a>
                 </li>
                 <li>
-                    <a class="no-icon nav-external" href="https://www.youtube.com/c/preCICECoupling/" target="_blank" data-show-count="false" aria-label="Subscribe on Youtube"><i class="fab fa-youtube"></i></a>
+                    <a class="no-icon nav-external" href="https://www.youtube.com/c/preCICECoupling/" target="_blank" rel="noopener noreferrer" data-show-count="false" aria-label="Subscribe on Youtube"><i class="fab fa-youtube"></i></a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Closes #760

## What

Adds `rel="noopener noreferrer"` to 5 external social media links in the top navigation.

## Why

Using `target="_blank"` without `rel="noopener noreferrer"` is a known security vulnerability (Reverse Tabnabbing). It allows the newly opened tab to potentially manipulate the `window.opener` object of the original page. Additionally, `noopener` yields a minor performance benefit because the new page runs in a dedicated renderer process.

## How

- Added `rel="noopener noreferrer"` to Discourse, GitHub, LinkedIn, and YouTube layout links in [_includes/topnav.html](cci:7://file:///d:/top/gsoc/precice.github.io/_includes/topnav.html:0:0-0:0).
- Appended `noopener noreferrer` to the existing `rel="me"` on the Mastodon link.
