### PR TITLE
Porting guide v2-v3: Fix getMaxTimeStepSize() typo

### DIFF
--- a/content/docs/couple-your-code/porting/couple-your-code-porting-v2-3.md
+++ b/content/docs/couple-your-code/porting/couple-your-code-porting-v2-3.md
@@ -197,7 +197,7 @@ The API function `initializeData()` has been removed in [#1350](https://github.c
   // Move initialize to the place where you called initializeData() previously.
 - couplingInterface.initializeData();
 + participant.initialize();
-+ double dt = participant.getMaxTimeWindowSize();
++ double dt = participant.getMaxTimeStepSize();
 ```
 
 Typical error message that should lead you here:


### PR DESCRIPTION
`participant::getMaxTimeWindowSize(`) is not a method in preCICE. I believe this was meant to be `participant::getMaxTimeStepSize() `as in the example above.