### PR TITLE
fix(ui): correct malformed HTML comment in topnav.html

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -1,4 +1,4 @@
-<a!-- Navigation -->
+<!-- Navigation -->
 <nav class="navbar navbar-inverse navbar-fixed-top" aria-label="Main">
     <div class="container topnavlinks">
         <div class="navbar-header">


### PR DESCRIPTION
### Description
This PR fixes a minor typo in the very first line of [_includes/topnav.html](cci:7://file:///d:/top/gsoc/precice.github.io/_includes/topnav.html:0:0-0:0). 



The file started with `<a!-- Navigation -->` instead of the standard `<!-- Navigation -->`. Since `<a!--` is not a valid HTML comment syntax, browsers might interpret it as an unclosed or broken `<a>` element. 

This is a single-line cleanup to ensure correct HTML syntax.

Fixes #766 
