### PR TITLE
fix(ui): use exact https protocol for DataTables CDN

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -60,8 +60,8 @@
     </script>
     {% if page.datatable == true %}
     <!-- Include the standard DataTables bits -->
-    <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.13/css/jquery.dataTables.css">
-    <script type="text/javascript" charset="utf8" src="//cdn.datatables.net/1.10.13/js/jquery.dataTables.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.13/css/jquery.dataTables.css">
+    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.13/js/jquery.dataTables.js"></script>
     <!-- First, this walks through the tables that occur between ...-begin
          and ...-end and add the "datatable" class to them.
          Then it invokes DataTable's standard initializer


### PR DESCRIPTION
### Description
This PR replaces the deprecated protocol-relative URLs (`//cdn.datatables.net/...`) with explicit `https://` URLs in [_layouts/default.html](cci:7://file:///d:/top/gsoc/precice.github.io/_layouts/default.html:0:0-0:0). 

Protocol-relative URLs are no longer recommended as best practice. Using explicit `https://` improves security, aligns with modern standards, and prevents issues when running the site locally.

This is a minimal 2-line change.

Fixes #769 
