### PR TITLE
Refactor FAQ inline styles into reusable CSS classes

### DIFF
--- a/content/docs/fundamentals/fundamentals-faq.md
+++ b/content/docs/fundamentals/fundamentals-faq.md
@@ -10,9 +10,9 @@ redirect_from:
 
 Search and filter frequently asked questions on the [preCICE Discourse forum](https://precice.discourse.group/tag/faq).
 
-<div style="display:flex;flex-wrap:wrap;gap:8px;margin:12px 0;">
-  <input id="q" placeholder="Search questions..." style="padding:8px;border:1px solid #ddd;border-radius:8px;min-width:240px;">
-  <select id="sort" style="padding:8px;border:1px solid #ddd;border-radius:8px;">
+<div class="faq-search-wrapper">
+  <input id="q" placeholder="Search questions..."  class="faq-search-input">
+  <select id="sort" class="faq-search-select">
     <option value="last_posted_at">Sort by last activity</option>
     <option value="created_at">Sort by creation date</option>
     <option value="posts_count">Sort by replies</option>
@@ -21,10 +21,10 @@ Search and filter frequently asked questions on the [preCICE Discourse forum](ht
   </select>
 </div>
 
-<p id="meta" style="margin:0 0 8px 0;color:#666;"></p>
-<p id="stats" style="margin:0 0 16px 0;color:#666;"></p>
+<p id="meta" class="faq-meta-text"></p>
+<p id="stats" class="faq-stats-text"></p>
 
-<div id="list" style="display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));"></div>
-<div id="empty" style="display:none;color:#666;padding:16px 0;text-align:center;">No results found.</div>
+<div id="list" class="faq-results-grid"></div>
+<div id="empty" class="faq-empty-state">No results found.</div>
 
 <script src="/js/forum-fetch.js"></script>

--- a/content/docs/fundamentals/fundamentals-faq.md
+++ b/content/docs/fundamentals/fundamentals-faq.md
@@ -11,7 +11,7 @@ redirect_from:
 Search and filter frequently asked questions on the [preCICE Discourse forum](https://precice.discourse.group/tag/faq).
 
 <div class="faq-search-wrapper">
-  <input id="q" placeholder="Search questions..."  class="faq-search-input">
+  <input id="q" placeholder="Search questions..." class="faq-search-input">
   <select id="sort" class="faq-search-select">
     <option value="last_posted_at">Sort by last activity</option>
     <option value="created_at">Sort by creation date</option>

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1214,3 +1214,46 @@ h4.panel-title {
 .banner {
   padding: 15px 0;
 }
+
+
+/* --- FAQ Page Custom Component --- */
+.faq-search-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.faq-search-input, 
+.faq-search-select {
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+.faq-search-input {
+  min-width: 240px;
+}
+
+.faq-meta-text {
+  margin: 0 0 8px 0;
+  color: #666;
+}
+
+.faq-stats-text {
+  margin: 0 0 16px 0;
+  color: #666;
+}
+
+.faq-results-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.faq-empty-state {
+  display: none;
+  color: #666;
+  padding: 16px 0;
+  text-align: center;
+}


### PR DESCRIPTION
## Closes #731 

This PR extracts the inline layout styles from `pages/fundamentals-faq.md` into reusable classes in `css/customstyles.css`.

No visual changes are intended, the goal is to improve maintainability and centralize styling in preparation for future theming and modernization work.

I chose to extend `customstyles.css` instead of introducing a new CSS file to keep the current structure unchanged and avoid adding additional assets while the website modernization effort is ongoing.

This change only affects the FAQ page.