### PR TITLE
Fix broken markdown link in open projects page

### DIFF
--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -66,7 +66,7 @@ We expect to work with the accepted GSoC participants in the summer. Our capacit
 This website is built with [Jekyll](https://jekyllrb.com/),
 a straight-forward static site generator that has served us well,
 but now starts to feel a bit restrictive
-([GitHub repository](https://github.com/precice/precice.github.io), [documentation]docs-meta-overview.html)).
+([GitHub repository](https://github.com/precice/precice.github.io), [documentation](docs-meta-overview.html)).
 We envy the dark theme, the nice footer that showcases contributions, and the nice search engine support
 when we look at the documentation of other community projects, such as [GitLab](https://docs.gitlab.com/user/) or [Docker](https://docs.docker.com/get-started/).
 We also required some hacky jekyll plugins to integrate multiple repositories into one jekyll website, which are a bit error-prone.


### PR DESCRIPTION
The [documentation] link was missing parentheses around the URL, rendering it as plain text instead of a clickable link. 

<img width="602" height="36" alt="image" src="https://github.com/user-attachments/assets/a676b5f3-8585-4045-a19a-55ad4e8bf9f5" />
