### PR TITLE
Fix broken HTML tags in landing page and topnav

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -1,4 +1,4 @@
-<a!-- Navigation -->
+<!-- Navigation -->
 <nav class="navbar navbar-inverse navbar-fixed-top" aria-label="Main">
     <div class="container topnavlinks">
         <div class="navbar-header">

--- a/content/index.html
+++ b/content/index.html
@@ -36,10 +36,10 @@ layout: landing_page
         </p>
         <p>
           Partitioned means that <strong>preCICE couples existing programs/solvers</strong> capable of simulating a subpart of the complete physics involved in a simulation. This allows for the high flexibility that is needed to keep a decent time-to-solution for complex coupled problems.
-          <p>
+        </p>
         <p class="no-margin">
           The software offers convenient methods for transient equation coupling, communication, time interpolation, and data mapping.
-        <p>
+        </p>
       </div>
       <div class="col-md-6">
         <img class="img-responsive col-xs-12" src="images/lead-image-precice.svg" alt="visualisation of how preCICE couples different solvers">


### PR DESCRIPTION
Found a few minor HTML issues while working on the codebase:
1. Unclosed <p> tags in content/index.html (lines 39, 42)
            <p>       <!-- should be </p> -->
          ...
          <p>         <!-- should be </p> -->
Browsers auto-correct this, but it's invalid HTML.

2. Broken comment tag in _includes/topnav.html (line 1)
  <a!-- Navigation -->   should be <!-- Navigation -->
  <a!-- is parsed as an invalid element, not a comment.