### PR TITLE
fix: restore focus outline on navbar links for accessibility

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -344,8 +344,8 @@ a.accordion-toggle, a.accordion-collapsed {
     /*color: #333;*/
     color: rgb(38,38,38);
     display: block;
-    outline: none;
-    /*-webkit-border-radius: 4px;
+   /* outline: none;
+    -webkit-border-radius: 4px;
     -moz-border-radius: 4px;
     border-radius: 4px;*/
     text-decoration: none;


### PR DESCRIPTION
Problem : Keyboard users navigating the site with the Tab key had no visible focus indicator on navbar links. Users cannot see which element is currently focused .
Root Cause : In "css/customstyles.css", the ".nav" had "outline: none" which suppressed the browser's default focus ring on all navigation links .
Fix : Commented "outline: none" from the ".nav"  in "css/customstyles.css"
Testing : Open the site and press Tab to navigate through navbar links . A visible focus ring now appears on each focused element . Links elsewhere on the site are unaffected .
<img width="1366" height="641" alt="fix-nav" src="https://github.com/user-attachments/assets/b6401124-5b9d-4af6-80e2-ff874e8fb3d6" />