### PR TITLE
Style: restore focus outline on navbar links globally for accessibility

### DIFF
--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -279,10 +279,10 @@ ul.devlist>li {
 .workshop-event p:first-of-type {
   margin-top: 10px;
 }
-*:focus
+/**:focus
 {
   outline: none;
-}
+}*/
 @media screen and (max-width: 767px) {
   .table-responsive > .table > thead > tr > th,
   .table-responsive > .table > tbody > tr > th,


### PR DESCRIPTION
Fix missing focus outline in Firefox and Chromium by suppressing the global

```
*:focus {
  outline: none;
}
```

rule in customstyles-precice.css.

This restores visible keyboard focus when navigating with Tab.

**Result**

Focus box now appears correctly in Firefox and Chromium browsers.

<img width="1919" height="1016" alt="image" src="https://github.com/user-attachments/assets/81653377-6894-425e-bf27-68c3dd070125" />
