### PR TITLE
Fix Windows encoding bug in check-old-precice script

### DIFF
--- a/tools/check-old-precice.py
+++ b/tools/check-old-precice.py
@@ -7,7 +7,7 @@ from sys import exit, stderr
 
 def oldAPI():
     return [entry
-            for entry in (pathlib.Path(__file__).parent / "old-precice.txt").read_text().splitlines()
+            for entry in (pathlib.Path(__file__).parent / "old-precice.txt").read_text(encoding="utf-8").splitlines()
             if entry and not entry.startswith("#")]
 
 
@@ -22,7 +22,7 @@ def checkFiles(files: list[pathlib.Path], root:pathlib.Path):
     old = oldAPI()
     success = True
     for file in filter(fileFilter, files):
-        content = file.read_text().splitlines()
+        content = file.read_text(encoding="utf-8").splitlines()
         for n, line in enumerate(content):
             for ex in old:
                 if ex in line:


### PR DESCRIPTION
## Description
Fixes a Windows-specific encoding bug in `tools/check-old-precice.py`.
On Windows Python uses a locale-dependent encoding (e.g. `cp1252`) when opening files by default. This causes a `UnicodeDecodeError` when trying to read files that contain special characters or emojis. 

This PR adds `encoding="utf-8"` to the `read_text()` calls in the script to ensure the files are always read correctly, regardless of the operating system's default encoding. 

Fixes # (issue) <!-- If there's an issue this resolves, add the number here -->

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or content (non-breaking change which adds functionality/content)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code/content follows the style guidelines of this project
- [x] I have performed a self-review of my own code/content
- [x] I have commented my code/content, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have read the [contributing to preCICE](https://precice.org/community-contribute-to-precice.html) page.
