### PR TITLE
Automate tutorial sidebar generation

### DIFF
--- a/_data/tutorial_sidebar_config.yml
+++ b/_data/tutorial_sidebar_config.yml
@@ -1,0 +1,103 @@
+# _data/tutorial_sidebar_config.yml
+# ===================================
+# Single source of truth for tutorial sidebar navigation decisions.
+# Lives in the MAIN SITE REPO (_data/), never in the tutorials submodule.
+#
+# HUGO MIGRATION:
+#   Read via $.Site.Data.tutorial_sidebar_config — identical structure.
+#   Only the template syntax changes, not this file.
+#
+# TITLE OVERRIDES:
+#   Both `featured` entries and group `permalinks` support an optional `title`
+#   field. If present it overrides the verbose README title with a short display
+#   name matching the original tutorial_sidebar.yml. If absent, the template
+#   falls back to the page's own `title` front matter.
+#
+# ADDING A NEW TUTORIAL:
+#   - Appears in "All tutorials" automatically with no changes here.
+#   - To feature it in Basic cases: add an entry under `featured`.
+#   - To put it in a named group: add an entry under the group's `permalinks`.
+#   - To create a new group: add a new block under `groups`.
+
+# ------------------------------------------------------------------------------
+# Basic cases
+# Rendered in ascending `order`. Title overrides the README title if present.
+# ------------------------------------------------------------------------------
+featured:
+  - permalink: quickstart.html
+    order: 1
+    title: Quickstart
+  - permalink: tutorials-flow-over-heated-plate.html
+    order: 2
+    title: Flow over a heated plate
+  - permalink: tutorials-partitioned-heat-conduction.html
+    order: 3
+    title: Partitioned heat conduction
+  - permalink: tutorials-perpendicular-flap.html
+    order: 4
+    title: Perpendicular flap
+
+# ------------------------------------------------------------------------------
+# Subgroups
+# Each group becomes a collapsible sub-folder in "All tutorials".
+# Groups and flat pages are interleaved alphabetically by display name —
+# the `name` field is used as the sort key alongside flat page titles.
+# `order` is NOT used for positioning within All tutorials (alphabetical
+# interleaving handles that). `order` is kept for potential future use
+# and documents editorial intent.
+# Pages within each group are sorted alphabetically by their display title.
+# ------------------------------------------------------------------------------
+groups:
+  - name: Channel transport
+    order: 1
+    permalinks:
+      - url: tutorials-channel-transport.html
+        title: Basic variant
+      - url: tutorials-channel-transport-reaction.html
+        title: Reaction
+      - url: tutorials-channel-transport-particles.html
+        title: Particles
+
+  - name: Flow over a heated plate
+    order: 2
+    permalinks:
+      - url: tutorials-flow-over-heated-plate.html
+        title: Basic variant
+      - url: tutorials-flow-over-heated-plate-nearest-projection.html
+        title: Nearest-projection mapping
+      - url: tutorials-flow-over-heated-plate-steady-state.html
+        title: Steady state
+      - url: tutorials-flow-over-heated-plate-two-meshes.html
+        title: Two meshes
+
+  - name: Partitioned flow
+    order: 3
+    permalinks:
+      - url: tutorials-partitioned-backwards-facing-step.html
+        title: Partitioned flow over a b.f. step
+      - url: tutorials-flow-over-heated-plate-partitioned-flow.html
+        title: Partitioned flow over heated plate
+      - url: tutorials-partitioned-pipe.html
+        title: Partitioned pipe
+      - url: tutorials-partitioned-pipe-two-phase.html
+        title: Partitioned pipe two-phase
+
+  - name: Partitioned heat conduction
+    order: 4
+    permalinks:
+      - url: tutorials-partitioned-heat-conduction.html
+        title: Basic variant
+      - url: tutorials-partitioned-heat-conduction-complex.html
+        title: Complex variant
+      - url: tutorials-partitioned-heat-conduction-direct.html
+        title: Direct mesh access
+      - url: tutorials-partitioned-heat-conduction-overlap.html
+        title: Overlapping Schwarz
+
+  - name: Perpendicular flap
+    order: 5
+    permalinks:
+      - url: tutorials-perpendicular-flap.html
+        title: Basic variant
+      - url: tutorials-perpendicular-flap-stress.html
+        title: Stress variant

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,74 +1,119 @@
-{% assign sidebar = site.data.sidebars[page.sidebar].entries %}
+{% if page.sidebar == 'tutorial_sidebar' %}
+  {% include tutorial_sidebar.html %}
+{% else %}
+  {% assign sidebar = site.data.sidebars[page.sidebar].entries %}
 
-<nav aria-label="{{sidebar[0].product}}">
-<ul id="mysidebar" class="nav">
-  <li class="sidebarTitle">{{sidebar[0].product}} {{sidebar[0].version}}</li>
-  {% for entry in sidebar %}
-  {% for folder in entry.folders %}
-  {% if folder.output contains "web" %}
-  {% if folder.url %}
-  <!-- Parent menu item has url and no folderitems -->
-  {% if page.url == folder.url %}
-  <li class="active">
-    <a title="{{folder.title}}" href="{{folder.url | remove: "/"}}">{{folder.title}}</a>
-  </li>
-  {% else %}
-  <li>
-    <a title="{{folder.title}}" href="{{folder.url | remove: "/"}}">{{folder.title}}</a>
-  </li>
-  {% endif %}
-  {% else %}
-  <!-- Parent menu item has folderitems -->
-  <li>
-    <a title="{{folder.title}}" href="#">{{folder.title}}</a>
-    <ul>
-      {% for folderitem in folder.folderitems %}
-      {% if folderitem.output contains "web" %}
-      {% if folderitem.external_url %}
-      <li><a title="{{folderitem.title}}" href="{{folderitem.external_url}}" target="_blank" rel="noopener">{{folderitem.title}}</a></li>
-      {% elsif page.url == folderitem.url %}
-      <li {% if folderitem.link-only == nil or folderitem.link-only == false %} class="active" {% endif %} ><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
-      {% elsif folderitem.type == "empty" %}
-      <li><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
-
-      {% else %}
-      <li><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
-      {% endif %}
-      {% for subfolders in folderitem.subfolders %}
-      {% if subfolders.output contains "web" %}
-      <li class="subfolders">
-        <a title="{{subfolders.title}}" href="#">{{ subfolders.title }}</a>
-        <ul>
-          {% for subfolderitem in subfolders.subfolderitems %}
-          {% if subfolderitem.output contains "web" %}
-          {% if subfolderitem.external_url %}
-          <li><a title="{{subfolderitem.title}}" href="{{subfolderitem.external_url}}" target="_blank" rel="noopener">{{subfolderitem.title}}</a></li>
-          {% elsif page.url == subfolderitem.url %}
-          <li class="active"><a title="{{subfolderitem.title}}" href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
-          {% else %}
-          <li><a title="{{subfolderitem.title}}" href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
-          {% endif %}
-          {% endif %}
-          {% endfor %}
-        </ul>
+  <nav aria-label="{{sidebar[0].product}}">
+    <ul id="mysidebar" class="nav">
+      <li class="sidebarTitle">
+        {{ sidebar[0].product }}
+        {{ sidebar[0].version }}
       </li>
-      {% endif %}
-      {% endfor %}
-      {% endif %}
+      {% for entry in sidebar %}
+        {% for folder in entry.folders %}
+          {% if folder.output contains 'web' %}
+            {% if folder.url %}
+              <!-- Parent menu item has url and no folderitems -->
+              {% if page.url == folder.url %}
+                <li class="active">
+                  <a title="{{folder.title}}" href="{{folder.url | remove: "/"}}">{{ folder.title }}</a>
+                </li>
+              {% else %}
+                <li>
+                  <a title="{{folder.title}}" href="{{folder.url | remove: "/"}}">{{ folder.title }}</a>
+                </li>
+              {% endif %}
+            {% else %}
+              <!-- Parent menu item has folderitems -->
+              <li>
+                <a title="{{folder.title}}" href="#">{{ folder.title }}</a>
+                <ul>
+                  {% for folderitem in folder.folderitems %}
+                    {% if folderitem.output contains 'web' %}
+                      {% if folderitem.external_url %}
+                        <li>
+                          <a
+                            title="{{folderitem.title}}"
+                            href="{{folderitem.external_url}}"
+                            target="_blank"
+                            rel="noopener"
+                          >
+                            {{- folderitem.title -}}
+                          </a>
+                        </li>
+                      {% elsif page.url == folderitem.url %}
+                        <li
+                          {% if folderitem['link-only'] == null or folderitem['link-only'] == false %}
+                            class="active"
+                          {% endif %}
+                        >
+                          <a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">
+                            {{- folderitem.title -}}
+                          </a>
+                        </li>
+                      {% elsif folderitem.type == 'empty' %}
+                        <li>
+                          <a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">
+                            {{- folderitem.title -}}
+                          </a>
+                        </li>
+
+                      {% else %}
+                        <li>
+                          <a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">
+                            {{- folderitem.title -}}
+                          </a>
+                        </li>
+                      {% endif %}
+                      {% for subfolders in folderitem.subfolders %}
+                        {% if subfolders.output contains 'web' %}
+                          <li class="subfolders">
+                            <a title="{{subfolders.title}}" href="#">{{ subfolders.title }}</a>
+                            <ul>
+                              {% for subfolderitem in subfolders.subfolderitems %}
+                                {% if subfolderitem.output contains 'web' %}
+                                  {% if subfolderitem.external_url %}
+                                    <li>
+                                      <a
+                                        title="{{subfolderitem.title}}"
+                                        href="{{subfolderitem.external_url}}"
+                                        target="_blank"
+                                        rel="noopener"
+                                      >
+                                        {{- subfolderitem.title -}}
+                                      </a>
+                                    </li>
+                                  {% elsif page.url == subfolderitem.url %}
+                                    <li class="active">
+                                      <a title="{{subfolderitem.title}}" href="{{subfolderitem.url | remove: "/"}}">
+                                        {{- subfolderitem.title -}}
+                                      </a>
+                                    </li>
+                                  {% else %}
+                                    <li>
+                                      <a title="{{subfolderitem.title}}" href="{{subfolderitem.url | remove: "/"}}">
+                                        {{- subfolderitem.title -}}
+                                      </a>
+                                    </li>
+                                  {% endif %}
+                                {% endif %}
+                              {% endfor %}
+                            </ul>
+                          </li>
+                        {% endif %}
+                      {% endfor %}
+                    {% endif %}
+                  {% endfor %}
+                </ul>
+              </li>
+            {% endif %}
+          {% endif %}
+        {% endfor %}
       {% endfor %}
     </ul>
-  </li>
-  {% endif %}
-  {% endif %}
-  {% endfor %}
-  {% endfor %}
-  <!-- if you aren't using the accordion, uncomment this block:
-  <p class="external">
-  <a href="#" id="collapseAll">Collapse All</a> | <a href="#" id="expandAll">Expand All</a>
-  </p>
-  -->
-</ul>
-</nav>
+  </nav>
 
-<!-- this highlights the active parent class in the navgoco sidebar. this is critical so that the parent expands when you're viewing a page. This must appear below the sidebar code above. Otherwise, if placed inside customscripts.js, the script runs before the sidebar code runs and the class never gets inserted.-->
-<script>$("li.active").parents('li').toggleClass("active");</script>
+  <script>
+    $('li.active').parents('li').toggleClass('active');
+  </script>
+{% endif %}

--- a/_includes/tutorial_sidebar.html
+++ b/_includes/tutorial_sidebar.html
@@ -1,0 +1,213 @@
+{% comment %}
+  tutorial_sidebar.html
+  =====================
+  Renders the tutorials sidebar automatically from site.pages at build time.
+  All navigation decisions live in _data/tutorial_sidebar_config.yml for
+  exclusive links like "Basic cases" or named groups in "All tutorials".
+  Tutorial READMEs need no special front matter beyond `title` and `permalink`.
+
+  STRUCTURE:
+    1. Introduction  — hardcoded (not in submodule)
+    2. Basic cases   — from tutorial_sidebar_config.yml `featured` list
+    3. All tutorials — auto-discovered flat pages + named groups, interleaved
+                       alphabetically by display name
+{% endcomment %}
+
+{% comment %}
+  ============================================================
+  STEP 1 — Collect tutorial pages into parallel lookup arrays
+  ============================================================
+{% endcomment %}
+{% assign tutorial_pages = '' | split: '' %}
+{% assign tutorial_permalinks = '' | split: '' %}
+{% for p in site.pages %}
+  {% if p.path contains 'imported/tutorials/' %}
+    {% assign tutorial_pages = tutorial_pages | push: p %}
+    {% assign tutorial_permalinks = tutorial_permalinks | push: p.permalink %}
+  {% endif %}
+{% endfor %}
+
+{% comment %}
+  ============================================================
+  STEP 2 — Build lookup sets from the data file
+  ============================================================
+  featured_urls: used to suppress active class in Basic cases only.
+                 Featured pages ARE rendered in All tutorials with normal
+                 active class — that is their canonical active location.
+  grouped_urls:  used to exclude pages from the flat list in All tutorials
+                 (they appear inside their named group instead).
+{% endcomment %}
+{% assign featured_urls = '' | split: '' %}
+{% for f in site.data.tutorial_sidebar_config.featured %}
+  {% assign featured_urls = featured_urls | push: f.permalink %}
+{% endfor %}
+
+{% assign grouped_urls = '' | split: '' %}
+{% for group in site.data.tutorial_sidebar_config.groups %}
+  {% for gentry in group.permalinks %}
+    {% assign grouped_urls = grouped_urls | push: gentry.url %}
+  {% endfor %}
+{% endfor %}
+
+{% comment %}
+  ============================================================
+  STEP 3 — Build the unified All tutorials entry list
+  ============================================================
+  Flat pages: all tutorial pages NOT in any group.
+              Featured pages ARE included here as flat entries if they
+              are not also in a group (e.g. Quickstart).
+              Featured pages that ARE in a group (e.g. Flow over a heated
+              plate) will appear inside their group, not as flat entries.
+  Group entries: one per group, sorted by group name alongside flat pages.
+{% endcomment %}
+{% assign all_entries = '' | split: '' %}
+
+{% for p in tutorial_pages %}
+  {% unless grouped_urls contains p.permalink %}
+    {% assign raw_idx = forloop.index0 %}
+    {% assign padded_idx = raw_idx | prepend: '000' | slice: -4, 4 %}
+    {% assign entry = p.title | append: '^flat^' | append: padded_idx %}
+    {% assign all_entries = all_entries | push: entry %}
+  {% endunless %}
+{% endfor %}
+
+{% for group in site.data.tutorial_sidebar_config.groups %}
+  {% assign entry = group.name | append: '^group^' | append: group.name %}
+  {% assign all_entries = all_entries | push: entry %}
+{% endfor %}
+
+{% assign all_entries = all_entries | sort %}
+
+{% comment %}
+  ============================================================
+  STEP 4 — Sort featured list by order field
+  ============================================================
+{% endcomment %}
+{% assign sorted_featured = site.data.tutorial_sidebar_config.featured | sort: 'order' %}
+
+{% comment %}
+  ============================================================
+  RENDER
+  ============================================================
+{% endcomment %}
+<nav aria-label="Tutorials">
+  <ul id="mysidebar" class="nav">
+    <li class="sidebarTitle">Tutorials</li>
+
+    {% comment %}
+      ----------------------------------------------------------
+      SECTION 1: Introduction
+      ----------------------------------------------------------
+    {% endcomment %}
+    <li>
+      <a title="Introduction" href="#">Introduction</a>
+      <ul>
+        <li
+          {% if page.url == '/tutorials.html' %}
+            class="active"
+          {% endif %}
+        >
+          <a title="Overview" href="tutorials.html">Overview</a>
+        </li>
+        <li
+          {% if page.url == '/tutorials-visualization.html' %}
+            class="active"
+          {% endif %}
+        >
+          <a title="Visualization" href="tutorials-visualization.html">Visualization</a>
+        </li>
+      </ul>
+    </li>
+
+    {% comment %}
+      ----------------------------------------------------------
+      SECTION 2: Basic cases
+      ----------------------------------------------------------
+    {% endcomment %}
+    {% if sorted_featured.size > 0 %}
+      <li>
+        <a title="Basic cases" href="#">Basic cases</a>
+        <ul>
+          {% for f in sorted_featured %}
+            {% assign f_page = null %}
+            {% for pl in tutorial_permalinks %}
+              {% if pl == f.permalink %}
+                {% assign f_idx = forloop.index0 %}
+                {% assign f_page = tutorial_pages[f_idx] %}
+              {% endif %}
+            {% endfor %}
+            {% if f_page %}
+              {% assign display_title = f.title | default: f_page.title %}
+              <li>
+                <a title="{{ display_title }}" href="{{ f_page.permalink | remove: '/' }}">{{ display_title }}</a>
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </li>
+    {% endif %}
+
+    {% comment %}
+      ----------------------------------------------------------
+      SECTION 3: All tutorials
+      ----------------------------------------------------------
+    {% endcomment %}
+    <li>
+      <a title="All tutorials" href="#">All tutorials</a>
+      <ul>
+        {% for entry in all_entries %}
+          {% if entry contains '^flat^' %}
+            {% assign flat_parts = entry | split: '^flat^' %}
+            {% assign flat_idx = flat_parts[1] | plus: 0 %}
+            {% assign p = tutorial_pages[flat_idx] %}
+            {% if p %}
+              <li
+                {% if page.url == p.url %}
+                  class="active"
+                {% endif %}
+              >
+                <a title="{{ p.title }}" href="{{ p.permalink | remove: '/' }}">{{ p.title }}</a>
+              </li>
+            {% endif %}
+
+          {% elsif entry contains '^group^' %}
+            {% assign group_parts = entry | split: '^group^' %}
+            {% assign group_name = group_parts[1] %}
+            {% for group in site.data.tutorial_sidebar_config.groups %}
+              {% if group.name == group_name %}
+                <li class="subfolders">
+                  <a title="{{ group.name }}" href="#">{{ group.name }}</a>
+                  <ul>
+                    {% for gentry in group.permalinks %}
+                      {% assign gp = null %}
+                      {% for pl in tutorial_permalinks %}
+                        {% if pl == gentry.url %}
+                          {% assign gp_idx = forloop.index0 %}
+                          {% assign gp = tutorial_pages[gp_idx] %}
+                        {% endif %}
+                      {% endfor %}
+                      {% if gp %}
+                        {% assign g_display = gentry.title | default: gp.title %}
+                        <li
+                          {% if page.url == gp.url %}
+                            class="active"
+                          {% endif %}
+                        >
+                          <a title="{{ g_display }}" href="{{ gentry.url | remove: '/' }}">{{ g_display }}</a>
+                        </li>
+                      {% endif %}
+                    {% endfor %}
+                  </ul>
+                </li>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </li>
+  </ul>
+</nav>
+
+<script>
+  $('#mysidebar li.active').parents('li').toggleClass('active');
+</script>


### PR DESCRIPTION
## Automate tutorial sidebar generation

Replaces the manually maintained `tutorial_sidebar.yml` with a Liquid-based auto-discovery system (related to #586 - partial fix).

### Problem

Adding a tutorial required manually updating `tutorial_sidebar.yml`, creating duplication and cross-repo dependency between the main site and the tutorials submodule.

### Solution

- **_includes/sidebar.html**  
  Dispatches to a dedicated tutorial sidebar include when `tutorial_sidebar` is requested. Other sidebars remain unaffected.

- **_includes/tutorial_sidebar.html**  
  Auto-builds the sidebar using `site.pages` filtered to `imported/tutorials/`.  
  Renders:
  - **Introduction** (hardcoded — lives in main repo)
  - **Basic cases** (configured via data file, link-only behavior preserved)
  - **All tutorials** (auto-discovered, alphabetically interleaved flat pages and groups)

- **_data/tutorial_sidebar_config.yml**  
  Centralizes editorial decisions: featured tutorials, subgroup definitions, display order, short title overrides.  
  Only this file requires manual updates.

- **_data/sidebars/tutorial_sidebar.yml**  
  Preserved for reference but no longer used.

### Result

- New tutorial added → appears automatically in **All tutorials**
- Featuring/grouping changes → edit `_data/tutorial_sidebar_config.yml` only
- No additional front matter required in tutorial READMEs
- All other sidebars remain unchanged

### Hugo Migration

The configuration file structure is directly portable.  
Template logic maps cleanly to Hugo (`range where`, `GroupByParam`).  
No changes required to tutorial front matter.

### Testing

- Renamed and deleted `tutorial_sidebar.yml` → sidebar still renders
- Verified layout matches hosted site

### Note

- The sidebar for other repos can be automated similarly while being completely Hugo migration safe and will close the issue completely. This refers to issue #586.
- Short names present in tutorial_sidebar.yml couldn't be replicated, its only possible if all the README.md of subfolders in imported/tutorials has those short names in its front matter.

### Comparison

**Hosted site**

![Hosted site sidebar](https://github.com/user-attachments/assets/cd6f8f62-d73a-4952-8e1e-b660ef47743c)

**Local site**

![Local site sidebar](https://github.com/user-attachments/assets/8f98e046-101a-463a-a00c-c19cdbbcea60)
