### PR TITLE
Fix: typo in Algolia workflow and add GSoC to heading

### DIFF
--- a/.github/workflows/update-algolia.yml
+++ b/.github/workflows/update-algolia.yml
@@ -22,7 +22,7 @@ jobs:
         id: checkcommit
         working-directory: website
         run: |
-          LASTEST_COMMIT=$(git log -1 --format=%ct)
+          LATEST_COMMIT=$(git log -1 --format=%ct)
           CURRENT_TIME=$(date +%s)
           TIME_DIFF=$((CURRENT_TIME - LATEST_COMMIT))
           if [ $TIME_DIFF -gt 86400 ]; then

--- a/content/community/contribute/community-contribute-open-projects.md
+++ b/content/community/contribute/community-contribute-open-projects.md
@@ -36,7 +36,7 @@ Some of these projects we advertise publicly, in programs such as the Google Sum
 Are you looking for or offering a thesis / PhD / other related job? Have a look also at [our forum](https://precice.discourse.group/c/jobs/13).
 {% endtip %}
 
-## Google Summer of Code
+## Google Summer of Code (GSoC)
 
 The [Google Summer of Code](https://summerofcode.withgoogle.com/) is _"a global, online program focused on bringing new contributors into open source software development. GSoC Contributors work with an open source organization on a 12+ week programming project under the guidance of mentors."_.
 


### PR DESCRIPTION
Fixes #733

Fixed typo in update-algolia.yml (LASTEST_COMMIT → LATEST_COMMIT) which could prevent scheduled Algolia indexing from running properly.

Updated heading to Google Summer of Code (GSoC) to improve search indexing and discoverability.

After merge, manually triggering the workflow once to reindex immediately and verify the fix.

