### PR TITLE
Fix: remove extra closing div in community section

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -382,7 +382,7 @@ layout: landing_page
           {% include newsletter.html %}
         </div>
       </div>
-      </div><!-- main -->
+      <!-- </div>main -->
     </div> <!-- section -->
   </div> <!-- container -->
 </div> <!-- light background -->


### PR DESCRIPTION
## Fix: Remove extra tag in community section
### I noticed an extra </div> tag at the end of the "Join the community" section that didn't need to be there. I've removed it to keep the HTML clean and make sure the page structure stays solid.