### PR TITLE
Fix: increase max_record_size to 20000 for open-source plan

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -260,6 +260,7 @@ algolia:
   index_name:     jekyll
   search_only_api_key: 760ed6be3e165d08b4a798ac4aa82fe4
   nodes_to_index: 'p,code,table' # html tags to include in search index
+  max_record_size: 20000
 
 mermaid:
   src: 'https://cdn.jsdelivr.net/npm/mermaid@11.12.3/dist/mermaid.min.js'


### PR DESCRIPTION
The project has been on the Algolia open-source plan since Sep 2024, which supports 20Kb records. The default max_record_size (10Kb) was causing indexing to fail on adapters-overview.html (10.22Kb). 

References :

https://github.com/algolia/jekyll-algolia/blob/master/lib/jekyll/algolia/configurator.rb#L17

After merging, please manually trigger the workflow once to verify that the changes have been successfully applied.

Closes #388 