### PR TITLE
fix: update Font Awesome icon classes to FA6 format

### DIFF
--- a/_data/alerts.yml
+++ b/_data/alerts.yml
@@ -1,9 +1,9 @@
-tip: '<div class="alert alert-success" role="alert"><i class="fa fa-check-square"></i> <b>Tip: </b>'
-note: '<div class="alert alert-info" role="alert"><i class="fa fa-info-circle"></i> <b>Note: </b>'
-important: '<div class="alert alert-warning" role="alert"><i class="fa fa-warning"></i> <b>Important: </b>'
-warning: '<div class="alert alert-danger" role="alert"><i class="fa fa-exclamation-circle"></i> <b>Warning: </b>'
-disclaimer: '<div class="alert alert-info" role="alert"><i class="fa fa-fa-hands-wash"></i> <b>Disclaimer: </b>'
-end: '</div>'
+tip: '<div class="alert alert-success" role="alert"><i class="fas fa-check-square"></i> <b>Tip: </b>'
+note: '<div class="alert alert-info" role="alert"><i class="fas fa-info-circle"></i> <b>Note: </b>'
+important: '<div class="alert alert-warning" role="alert"><i class="fas fa-exclamation-triangle"></i> <b>Important: </b>'
+warning: '<div class="alert alert-danger" role="alert"><i class="fas fa-exclamation-circle"></i> <b>Warning: </b>'
+disclaimer: '<div class="alert alert-info" role="alert"><i class="fas fa-hands-wash"></i> <b>Disclaimer: </b>'
+end: "</div>"
 
 callout_danger: '<div class="bs-callout bs-callout-danger">'
 callout_default: '<div class="bs-callout bs-callout-default">'

--- a/_plugins/customblocks.rb
+++ b/_plugins/customblocks.rb
@@ -2,14 +2,14 @@ module Jekyll
   class TipBlock < Liquid::Block
     def render(context)
       text = super
-      '<div markdown="span" class="alert alert-success" role="alert"><i class="fa fa-check-square"></i> <b>Tip:</b> ' + text + '</div>'
+      '<div markdown="span" class="alert alert-success" role="alert"><i class="fas fa-check-square"></i> <b>Tip:</b> ' + text + '</div>'
     end
   end
 
   class NoteBlock < Liquid::Block
     def render(context)
       text = super
-      '<div markdown="span" class="alert alert-info" role="alert"><i class="fa fa-info-circle"></i> <b>Note:</b> ' + text + '</div>'
+      '<div markdown="span" class="alert alert-info" role="alert"><i class="fas fa-info-circle"></i> <b>Note:</b> ' + text + '</div>'
     end
   end
 
@@ -30,7 +30,7 @@ module Jekyll
   class DisclaimerBlock < Liquid::Block
     def render(context)
       text = super
-      '<div markdown="span" class="alert alert-info" role="alert"><i class="fa fa-hands-wash"></i> <b>Disclaimer:</b> ' + text + '</div>'
+      '<div markdown="span" class="alert alert-info" role="alert"><i class="fas fa-hands-wash"></i> <b>Disclaimer:</b> ' + text + '</div>'
     end
   end
 


### PR DESCRIPTION
### Update icon class prefix from deprecated FA4 'fa' to FA6 'fas' in alert blocks and custom Liquid blocks. Additionally, corrects a typo 'fa-fa-hands-wash' (double prefix) that was preventing the Disclaimer icon from displaying properly 

## Description
This Pull Request will update the Font Awesome icon prefixes throughout the site's alert data and custom Liquid blocks to reflect the new FA6 style. Additionally, this PR will correct a specific typo that was causing the Disclaimer icon to not display properly on the site. 

## Changes Made
- **Fixed Icon Prefix:** Updated the deprecated Font Awesome 4 `fa` prefix to the new Font Awesome 6 `fas` (solid) prefix in [_data/alerts.yml]and [_plugins/customblocks.rb]
- **Fixed Redundant Prefix Typo:** Fixed the `fa-fa-hands-wash` typo in [_data/alerts.yml](line 5). The double prefix was preventing the icon from rendering properly on the live site.
- **Updated Deprecated Aliases:** Updated `fa-warning` to `fa-exclamation-triangle` to reflect the new Font Awesome naming conventions. ## Why this is important
Using the new `fas` prefixes in the latest Font Awesome 6 library will provide better performance and consistency across modern browsers. More importantly, this PR will fix the broken Disclaimer icon due to a high-impact typo.