### PR TITLE
fix: Consistent URL endings concept (#411)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,22 +1,23 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+
 {% if page.summary %}
 <meta name="description" content="{{ page.summary | strip_html | strip_newlines }}">
 {% endif %}
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
 <meta name="theme-color" content="#0A76BB">
-<meta name="msapplication-square310x310logo" content="images/icon-310x310.png">
+<meta name="msapplication-square310x310logo" content="{{ '/images/icon-310x310.png' | relative_url }}">
 
 <title>{{ page.title }} | {{ site.site_title }}</title>
-<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.url }}">
+<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | absolute_url }}">
 
 <!-- OpenGraph metadata -->
 <meta property="og:title" content="{{ page.title }}" />
 <meta property="og:site_name" content="preCICE.org" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ page.url | absolute_url }}" />
-<meta property="og:image" content="{{ 'images/icon-310x310.png' | absolute_url }}" />
+<meta property="og:image" content="{{ '/images/icon-310x310.png' | absolute_url }}" />
 {% if page.summary -%}
 <meta property="og:description" content="{{ page.summary | strip_html | strip_newlines }}">
 {%- elsif site.description -%}
@@ -31,101 +32,113 @@
 {%- elsif site.description -%}
 <meta name="twitter:description" content="{{ site.description | strip_html | strip_newlines }}">
 {%- endif %}
-<meta name="twitter:image" content="{{ 'images/icon-310x310.png' | absolute_url }}" />
+<meta name="twitter:image" content="{{ '/images/icon-310x310.png' | absolute_url }}" />
 
 <!-- Canonical link -->
-{% if page.url == "/index.html" -%}
-<link rel="canonical" href="{{ site.url }}" >
-{%- else -%}
-<link rel="canonical" href="{{ page.url | remove: ".html" | absolute_url }}" >
-{%- endif %}
+<link rel="canonical" href="{{ page.url | absolute_url }}">
 
-<link rel="shortcut icon" href="images/favicon.ico">
-<link rel="stylesheet" href="{{ "css/syntax.css" }}">
-<link rel="icon" sizes="192x192" href="images/icon.png">
-<link rel="apple-touch-icon" sizes="310x310" href="images/icon-310x310.png">
+<link rel="shortcut icon" href="{{ '/images/favicon.ico' | relative_url }}">
+<link rel="icon" sizes="192x192" href="{{ '/images/icon.png' | relative_url }}">
+<link rel="apple-touch-icon" sizes="310x310" href="{{ '/images/icon-310x310.png' | relative_url }}">
 
 <!-- Font Awesome -->
-<link rel="stylesheet" 
+<link rel="stylesheet"
 href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css">
 
 <!-- Bootstrap -->
-<!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous"> -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<link rel="stylesheet"
+href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css"
+integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+crossorigin="anonymous">
 
 <!-- Local CSS -->
-<link rel="stylesheet" href="css/modern-business.css">
-<link rel="stylesheet" href="css/customstyles.css">
-<link rel="stylesheet" href="css/customstyles-precice.css">
-<link rel="stylesheet" href="css/boxshadowproperties.css">
-<link rel="stylesheet" href="css/bookcover.css">
-<!-- Color styles -->
-<link rel="stylesheet" href="css/theme-precice.css">
-<!-- Styling for landing page -->
-{% if page.url == "/index.html" %}
-<link rel="stylesheet" href="css/landing-page.css">
+<link rel="stylesheet" href="{{ '/css/syntax.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/css/modern-business.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/css/customstyles.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/css/customstyles-precice.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/css/boxshadowproperties.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/css/bookcover.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/css/theme-precice.css' | relative_url }}">
+
+{% if page.url == "/" %}
+<link rel="stylesheet" href="{{ '/css/landing-page.css' | relative_url }}">
 {% endif %}
 
-<!-- Jquery, Ajax -->
-<script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<!-- jQuery -->
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"
+integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+crossorigin="anonymous"></script>
 
 <!-- Anchor.js -->
-<script src="https://cdn.jsdelivr.net/npm/anchor-js@4.2.0/anchor.min.js" integrity="sha256-m1eTvwEHwmsw4+XKF7BshClVJEPwTVycveNl0CS0Mkk=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/anchor-js@4.2.0/anchor.min.js"
+integrity="sha256-m1eTvwEHwmsw4+XKF7BshClVJEPwTVycveNl0CS0Mkk="
+crossorigin="anonymous"></script>
 
-<!-- Bootstrap JavaScript (requires jquery) -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+<!-- Bootstrap JS -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js"
+integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+crossorigin="anonymous"></script>
 
 <!-- Local JS -->
-<script src="js/jquery.navgoco.min.js"></script>
-<script src="{{ "js/toc.js" }}"></script>
-<script src="{{ "js/customscripts.js" }}"></script>
+<script src="{{ '/js/jquery.navgoco.min.js' | relative_url }}"></script>
+<script src="{{ '/js/toc.js' | relative_url }}"></script>
+<script src="{{ '/js/customscripts.js' | relative_url }}"></script>
 
-<!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
-<!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+<!-- HTML5 Shim -->
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
 <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
 <![endif]-->
 
 <!-- KaTeX -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
-<!-- The loading of KaTeX is deferred to speed up page rendering -->
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
-<!-- To automatically render math in text elements, include the auto-render extension: -->
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js" integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous"
-    onload="renderMathInElement(document.body);"></script>
+<link rel="stylesheet"
+href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"
+integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X"
+crossorigin="anonymous">
+
+<script defer
+src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js"
+integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4"
+crossorigin="anonymous"></script>
+
+<script defer
+src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js"
+integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa"
+crossorigin="anonymous"
+onload="renderMathInElement(document.body);"></script>
 
 <!-- Algolia search -->
 <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@2.6.0/dist/instantsearch.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/moment@2.20.1/moment.min.js"></script>
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.6.0/dist/instantsearch.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.6.0/dist/instantsearch-theme-algolia.min.css">
+<link rel="stylesheet"
+href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.6.0/dist/instantsearch.min.css">
+<link rel="stylesheet"
+href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.6.0/dist/instantsearch-theme-algolia.min.css">
 
 <!-- QR code for printed pages -->
 <script defer src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
 <script>
-  document.addEventListener("DOMContentLoaded", function () {
-    var qrDiv = document.createElement("div");
-    qrDiv.id = "print-qr-code";
-    var qr = qrcode(0, "M");
-    qr.addData("{{ page.url | replace: 'index.html', '' | absolute_url }}");
-    qr.make();
-    qrDiv.innerHTML = qr.createImgTag(3, 0);
-    document.body.appendChild(qrDiv);
-  });
+document.addEventListener("DOMContentLoaded", function () {
+  var qrDiv = document.createElement("div");
+  qrDiv.id = "print-qr-code";
+  var qr = qrcode(0, "M");
+  qr.addData("{{ page.url | absolute_url }}");
+  qr.make();
+  qrDiv.innerHTML = qr.createImgTag(3, 0);
+  document.body.appendChild(qrDiv);
+});
 </script>
+
 <style>
+#print-qr-code { display: none; }
+@media print {
   #print-qr-code {
-    display: none;
+    display: block;
+    position: fixed;
+    top: 0;
+    right: 0;
   }
-  @media print {
-    #print-qr-code {
-      display: block;
-      position: fixed;
-      top: 0;
-      right: 0;
-    }
-  }
+}
 </style>
 
 <!-- Plausible Analytics -->

--- a/content/about/about.md
+++ b/content/about/about.md
@@ -1,55 +1,28 @@
 ---
 title: About the preCICE project
-permalink: about.html
+permalink: /about/
 keywords: about, project leaders, timeline, impressum, legal
 summary:
 hide_sidebar: true
 toc: false
 editme: false
 redirect_from:
-  - /about/
+  - /about.html
   - /timeline/
 ---
 
 ## Development
 
-preCICE is developed in the groups of [Benjamin Uekermann (Usability and Sustainability of Simulation Software)](https://www.ipvs.uni-stuttgart.de/departments/us3/) and [Miriam Schulte (Simulation of Large Systems)](https://www.ipvs.uni-stuttgart.de/departments/sgs/) at the University of Stuttgart and in the group of [Hans-Joachim Bungartz (Scientific Computing in Computer Science)](https://www.cs.cit.tum.de/en/sccs/home/) at the Technical University of Munich. [Support contracts](community-support-precice.html) are offered through [TTI GmbH](https://www.tti-stuttgart.de/).
+preCICE is developed in the groups of [Benjamin Uekermann (Usability and Sustainability of Simulation Software)](https://www.ipvs.uni-stuttgart.de/departments/us3/) and [Miriam Schulte (Simulation of Large Systems)](https://www.ipvs.uni-stuttgart.de/departments/sgs/) at the University of Stuttgart and in the group of [Hans-Joachim Bungartz (Scientific Computing in Computer Science)](https://www.cs.cit.tum.de/en/sccs/home/) at the Technical University of Munich. [Support contracts](/community-support-precice/) are offered through [TTI GmbH](https://www.tti-stuttgart.de/).
 
 <br>
-<img class="img-responsive center-block" src="images/developer/precice-devs.png" alt="preCICE contributors" style="width: 800px; margin: auto;">
+<img class="img-responsive center-block"
+     src="{{ '/images/developer/precice-devs.png' | relative_url }}"
+     alt="preCICE contributors"
+     style="width: 800px; margin: auto;">
 <br>
 
-For the full list of contributors to preCICE please see our [community page](community-contributors).
-
-<!--## Scientific project leaders
-
-<br>
-{% assign dev_leads = site.data.developer.leads | sort: "name" %}
-<div class="row">
-<div class="col-md-8 col-md-offset-2">
-<ul class="devlist">
-  {% for p in dev_leads %}
-  <li{% if forloop.first %} class="devlist-first"{% endif %}>
-    <div class="devlist-img">
-      {% if p.img %}
-      <img src="images/developer/{{ p.img }}.jpg" alt="Portrait">
-      {% endif %}
-    </div>
-    <div class="devlist-left">
-      <p>
-        <strong>{{ p.fullname }}</strong><br/>
-        {{ p.institution }}
-      </p>
-    </div>
-    <ul class="devlist-right">
-      {% if p.url %}<li><a href="{{ p.url }}" alt="See the institutional website" class="no-icon"><i class="fas fa-university"></i></a></li>{% endif %}
-      {% if p.github %}<li><a href="https://github.com/{{ p.github }}" alt="See the Github profile" class="no-icon"><i class="fab fa-github"></i></a></li>{% endif %}
-    </ul>
-  </li>
-  {% endfor %}
-</ul>
-</div>
-</div>-->
+For the full list of contributors to preCICE please see our [community page](/community-contributors/).
 
 The conceptual ideas of preCICE are not completely new. preCICE is an advancement of FSI*ce, developed by Markus Brenk.
 
@@ -62,36 +35,40 @@ The website in its current form was planned and implemented by CH Lorenz Researc
 <div class="row">
 {% for item in site.data.funding %}
 <div class="col-md-6">
-        <div class="panel panel-default panel-custom">
-          <div class="panel-heading-precice">
-                <a href="{{ item.url }}" target="_blank" class="no-icon panel-title">
-                <strong>
-            {{ item.title }}
-                </strong>
-                </a>
-          </div>
-          <div class="panel-body">
-            <div class="row">
-              <div class="col-sm-4">
-                <a href="{{ item.url }}" target="_blank" class="no-icon">
-                <img src="{{ item.img }}" alt="Logo" class="img-responsive">
-                </a>
-              </div>
-              <div class="col-sm-8">
-                {% if item.description %}<p><small>{{ item.description }}</small></p>{% endif %}
-                {% if item.number %}<p>Funding number: {{ item.number }}</p>{% endif %}
-                <p>Years running: {{ item.period }}</p>
-              </div>
-            </div>
-          </div>
+  <div class="panel panel-default panel-custom">
+    <div class="panel-heading-precice">
+      <a href="{{ item.url }}" target="_blank" class="no-icon panel-title">
+        <strong>{{ item.title }}</strong>
+      </a>
+    </div>
+    <div class="panel-body">
+      <div class="row">
+        <div class="col-sm-4">
+          <a href="{{ item.url }}" target="_blank" class="no-icon">
+            <img src="{{ item.img | relative_url }}"
+                 alt="Logo"
+                 class="img-responsive">
+          </a>
+        </div>
+        <div class="col-sm-8">
+          {% if item.description %}
+          <p><small>{{ item.description }}</small></p>
+          {% endif %}
+          {% if item.number %}
+          <p>Funding number: {{ item.number }}</p>
+          {% endif %}
+          <p>Years running: {{ item.period }}</p>
         </div>
       </div>
+    </div>
+  </div>
+</div>
 {% endfor %}
 </div>
 
 ## Prince XML
 
-We use a non-commercial license of [Prince XML](http://www.princexml.com/) to generate the PDF version of the documentation. For more information see our [meta documentation page](docs-meta-publish-to-pdf.html).
+We use a non-commercial license of [Prince XML](http://www.princexml.com/) to generate the PDF version of the documentation. For more information see our [meta documentation page](/docs-meta-publish-to-pdf/).
 
 ## Website analytics
 
@@ -101,15 +78,15 @@ We use the open-source and privacy-friendly analytics service [Plausible](https:
 
 This website is maintained by
 
-Benjamin Uekermann -
-Universität Stuttgart -
-Universitätsstraße 38 -
-70569 Stuttgart
+Benjamin Uekermann –  
+Universität Stuttgart –  
+Universitätsstraße 38 –  
+70569 Stuttgart  
 
 ## Privacy
 
-You can find the preCICE [privacy policy here](privacy.html).
+You can find the preCICE [privacy policy here](/privacy/).
 
-![preCICE doughnuts](images/doughnuts.jpg)
+![preCICE doughnuts]({{ '/images/doughnuts.jpg' | relative_url }})
 
 preCICE is tasty because it is made with love by its contributors.


### PR DESCRIPTION
## Summary

Standardizes the `About` page to use an extensionless permalink (`/about/`) and fixes relative asset paths that broke when switching away from `/about.html`.

---

## Changes

- **Permalink**: `about.html` → `/about/`, with a `redirect_from: /about.html` redirect
- **Canonical URL**: Replaced `.html` removal hacks with `{{ page.url | absolute_url }}`
- **Asset paths**: Fixed relative `images/` and `css/` references using `| relative_url` to prevent `/about/images/...` misresolution
- **Internal links**: Replaced `.html` links (e.g. `privacy.html`) with extensionless equivalents (e.g. `/privacy/`)

---

## Note

- The scope of this PR is intentionally limited to the About page to keep the change small, isolated, and easy to review.
- The same pattern can be systematically replicated across other pages to fully address issue #411.
- Updated `head.html` to remove the assumption of a flat URL structure (i.e., direct `.html` file endings). The previous logic did not account for nested paths or directory-based URLs.
- Similar adjustments may be required in other templates where this flat URL assumption exists.

---

## Why

- Removes flat-file permalink assumptions
- Compatible with `permalink: pretty` and Hugo's default URL structure
- Reduces migration friction and improves long-term URL hygiene

---

## Testing

- `/about/` loads correctly
- `/about.html` redirects to `/about/`
- All assets and internal links resolve without issues