### PR TITLE
Add: A light weight documentation footer above the site footer. (Issue: #405)

### DIFF
--- a/_data/discourse_map.yml
+++ b/_data/discourse_map.yml
@@ -1,0 +1,27 @@
+fundamentals:
+  name: "Is preCICE for me?"
+  url: "https://precice.org/docs.html"
+
+installation:
+  name: "Installing preCICE"
+  url: "https://precice.org/installation-overview.html"
+
+configuration:
+  name: "Using preCICE"
+  url: "https://precice.org/configuration-overview.html"
+
+tooling:
+  name: "Using preCICE"
+  url: "https://precice.org/tooling-overview.html"
+
+adapters:
+  name: "Official adapters and tutorials"
+  url: "https://precice.org/adapters-overview.html"
+
+couple-your-code:
+  name: "Using preCICE"
+  url: "https://precice.org/couple-your-code-overview.html"
+
+running:
+  name: "Using preCICE"
+  url: "https://precice.org/running-overview.html"

--- a/_includes/doc_footer.html
+++ b/_includes/doc_footer.html
@@ -1,0 +1,33 @@
+<div class="doc-footer">
+  <div class="doc-footer-inner">
+
+    <div class="doc-footer-col">
+      <p class="doc-footer-heading">Improve this page</p>
+      <a
+        class="doc-edit-btn"
+        href="https://github.com/precice/precice.github.io/edit/master/{{ page.path }}"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+        Edit on GitHub
+      </a>
+      {% if page.last_modified_at %}
+        <p class="doc-footer-meta">Last updated: {{ page.last_modified_at | date: "%b %d, %Y" }}</p>
+      {% endif %}
+    </div>
+
+    <div class="doc-footer-col">
+      <p class="doc-footer-heading">Need help?</p>
+      <ul class="doc-footer-links">
+        <li>
+          <a href="https://precice.discourse.group/tag/faq" target="_blank" rel="noopener noreferrer">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            Read the FAQ
+          </a>
+        </li>
+      </ul>
+    </div>
+
+  </div>
+</div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -1,0 +1,7 @@
+---
+layout: default
+---
+
+{{ content }}
+
+{% include doc_footer.html %}

--- a/content/docs/fundamentals/fundamentals-overview.md
+++ b/content/docs/fundamentals/fundamentals-overview.md
@@ -1,5 +1,6 @@
 ---
 title: The preCICE documentation
+layout: docs
 keywords: overview, features, docs
 summary: "This page gives an overview of the complete preCICE documentation, including building, configuration, literature, the API, and much more."
 permalink: docs.html

--- a/css/modern-business.css
+++ b/css/modern-business.css
@@ -69,6 +69,93 @@ footer {
     padding: 50px 0;
 }
 
+/* Doc Footer Styles */
+
+.doc-footer {
+    border-top: 1px solid #dde2e8;
+    padding: 40px 24px 48px;
+    margin-top: 72px;
+    font-size: 0.9rem;
+    color: #374151;
+}
+
+.doc-footer-inner {
+    display: flex;
+    gap: 48px;
+    max-width: 1100px;
+    margin: 0 auto;
+    flex-wrap: wrap;
+}
+
+.doc-footer-col {
+    flex: 1 1 200px;
+}
+
+.doc-footer-heading {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: #6b7280;
+    margin: 0 0 12px;
+}
+
+.doc-edit-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 7px 14px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    background: #fff;
+    color: #374151;
+    font-size: 0.875rem;
+    text-decoration: none;
+    transition: border-color 0.15s, color 0.15s, box-shadow 0.15s;
+}
+
+.doc-edit-btn:hover {
+    border-color: #0069b4;
+    color: #0069b4;
+    box-shadow: 0 1px 4px rgba(0, 105, 180, 0.1);
+    text-decoration: none;
+}
+
+.doc-footer-meta {
+    margin: 10px 0 0;
+    font-size: 0.8rem;
+    color: #9ca3af;
+}
+
+.doc-footer-links {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.doc-footer-links a {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    color: #374151;
+    font-size: 0.875rem;
+    text-decoration: none;
+    transition: color 0.15s;
+}
+
+.doc-footer-links a:hover {
+    color: #0069b4;
+    text-decoration: underline;
+}
+
+.doc-footer-links svg {
+    flex-shrink: 0;
+    opacity: 0.5;
+}
+
 /* Responsive Styles */
 
 @media(max-width:991px) {
@@ -85,5 +172,16 @@ footer {
 
     header.carousel .carousel {
         height: 70%;
+    }
+}
+
+@media (max-width: 480px) {
+    .doc-footer {
+        padding: 32px 16px 40px;
+        margin-top: 48px;
+    }
+
+    .doc-footer-inner {
+        gap: 28px;
     }
 }


### PR DESCRIPTION
## Documentation Footer

Adds a lightweight documentation footer above the site footer.

Addresses Issue #405 

Features:
- "Edit this page" GitHub edit link
- Last updated date
- Quick help links (only FAQ for now - Discourse links planned for later... perhaps after review)

### Design considerations

The implementation intentionally remains minimal and migration-safe since the documentation site will migrate from Jekyll to Hugo in the near future.

Features that require additional infrastructure (feedback forms, contributor lists, GitHub API usage) are intentionally not implemented here and can be reconsidered after migration.

### Future improvements

Once the documentation system migrates to Hugo, themes such as Docsy could provide additional functionality including:
- feedback widgets
- enhanced navigation
- richer page metadata

### Note:

This PR intentionally omits section-aware Discourse links (e.g. linking to "Installing preCICE" when browsing installation docs). This would require a `section:` front matter field to be added across doc pages. Happy to open a follow-up issue for this if the team think it's worth pursuing.

`_data/discourse_map.yml` is included as a reference for the planned section-aware Discourse links but is not actively used in this PR.

`content/docs/fundamentals/fundamentals-overview.md` is the only file where this appears for now. Will add it to other doc pages similarly.

### Screenshot:

<img width="770" height="313" alt="image" src="https://github.com/user-attachments/assets/5a8b3f8f-1e04-4d01-adbf-bab323296314" />
