### PR TITLE
Update the C++ API location / URLs

### DIFF
--- a/content/docs/couple-your-code/couple-your-code-api.md
+++ b/content/docs/couple-your-code/couple-your-code-api.md
@@ -13,7 +13,7 @@ The definite documentation of the C++ API is available on [the preCICE API doxyg
 
 | Language       | Location                                                                                    | Installation                                                                  |
 |----------------|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| C++            | [`precice/precice/tree/main/src/precice/Participant.hpp`](https://github.com/precice/precice/tree/main/src/precice/Participant.hpp)       | Automatically included                                          |
+| C++            | [`precice/precice/tree/main/src/precice/precice.hpp`](https://github.com/precice/precice/blob/main/src/precice/precice.hpp)       | Automatically included                                          |
 
 ## Bindings
 

--- a/content/docs/couple-your-code/couple-your-code-api.md
+++ b/content/docs/couple-your-code/couple-your-code-api.md
@@ -13,7 +13,7 @@ The definite documentation of the C++ API is available on [the preCICE API doxyg
 
 | Language       | Location                                                                                    | Installation                                                                  |
 |----------------|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| C++            | [`precice/precice/tree/main/src/precice/precice.hpp`](https://github.com/precice/precice/blob/main/src/precice/precice.hpp)       | Automatically included                                          |
+| C++            | [`precice/precice/src`](https://github.com/precice/precice/blob/main/src): [header](https://github.com/precice/precice/tree/main/src/precice/precice.hpp), [API](https://github.com/precice/precice/tree/main/src/precice/Participant.hpp)       | Automatically included                                          |
 
 ## Bindings
 
@@ -21,8 +21,8 @@ Besides the C++ API, there are also bindings to other languages available:
 
 | Language       | Location                                                                                    | Installation                                                                  |
 |----------------|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| C              | [`precice/precice/tree/main/extras/bindings/c`](https://github.com/precice/precice/tree/main/extras/bindings/c)       | [native bindings](installation-source-advanced.html#disabling-native-bindings)|
-| Fortran        | [`precice/precice/tree/main/extras/bindings/fortran`](https://github.com/precice/precice/tree/main/extras/bindings/fortran) | [native bindings](installation-source-advanced.html#disabling-native-bindings)|
+| C              | [`precice/precice/extras/bindings/c`](https://github.com/precice/precice/tree/main/extras/bindings/c)       | [native bindings](installation-source-advanced.html#disabling-native-bindings)|
+| Fortran        | [`precice/precice/extras/bindings/fortran`](https://github.com/precice/precice/tree/main/extras/bindings/fortran) | [native bindings](installation-source-advanced.html#disabling-native-bindings)|
 | Fortran Module | [`precice/fortran-module`](https://github.com/precice/fortran-module)                       | [`make`](installation-bindings-fortran.html)                                  |
 | Python         | [`precice/python-bindings`](https://github.com/precice/python-bindings)                     | [`pip3 install pyprecice`](installation-bindings-python.html)                 |
 | Matlab         | [`precice/matlab-bindings`](https://github.com/precice/matlab-bindings)                     | [installation script](installation-bindings-matlab.html)                      |


### PR DESCRIPTION
The "Location" of the C++ API currently links to `Participant.hpp`. This is the direct link to the API (so, easy for quick access), but it is not the header that we want people to include. This is a bit confusing.

This PR:

- As "location", links to the directory https://github.com/precice/precice/tree/main/src/precice, similarly to the C/Fortran bindings
- Adds a link to "header" (`precice.hpp`)
- Keeps the link to "API" (`Participant.hpp`)
- Fixes the locations of the C/Fortran bindings to remove the GitHub URL parts from the locations

From a discussion with @dabele.

@fsimonis what do you think?