### PR TITLE
Add copy button.

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -40,6 +40,16 @@ layout: landing_page
         <p class="no-margin">
           The software offers convenient methods for transient equation coupling, communication, time interpolation, and data mapping.
         </p>
+        <div class="code-container position-relative bg-light p-3 rounded">
+          <pre id="intro-text">
+preCICE is an open-source coupling library and ecosystem for general partitioned multi-physics and multi-scale simulations, including surface and volume coupling.
+
+Partitioned means that preCICE couples existing programs/solvers capable of simulating a subpart of the complete physics involved in a simulation. This allows for the high flexibility that is needed to keep a decent time-to-solution for complex coupled problems.
+
+The software offers convenient methods for transient equation coupling, communication, time interpolation, and data mapping.
+          </pre>
+          <button class="btn btn-primary position-absolute top-0 end-0 m-2" onclick="copyText()">Copy</button>
+        </div>
       </div>
       <div class="col-md-6">
         <img class="img-responsive col-xs-12" src="images/lead-image-precice.svg" alt="visualisation of how preCICE couples different solvers">

--- a/content/index.html
+++ b/content/index.html
@@ -40,16 +40,6 @@ layout: landing_page
         <p class="no-margin">
           The software offers convenient methods for transient equation coupling, communication, time interpolation, and data mapping.
         </p>
-        <div class="code-container position-relative bg-light p-3 rounded">
-          <pre id="intro-text">
-preCICE is an open-source coupling library and ecosystem for general partitioned multi-physics and multi-scale simulations, including surface and volume coupling.
-
-Partitioned means that preCICE couples existing programs/solvers capable of simulating a subpart of the complete physics involved in a simulation. This allows for the high flexibility that is needed to keep a decent time-to-solution for complex coupled problems.
-
-The software offers convenient methods for transient equation coupling, communication, time interpolation, and data mapping.
-          </pre>
-          <button class="btn btn-primary position-absolute top-0 end-0 m-2" onclick="copyText()">Copy</button>
-        </div>
       </div>
       <div class="col-md-6">
         <img class="img-responsive col-xs-12" src="images/lead-image-precice.svg" alt="visualisation of how preCICE couples different solvers">

--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -129,6 +129,75 @@ pre > code {
   word-wrap: normal;
   white-space: pre;
 }
+
+/* global code block container with left copy button */
+.code-container {
+  position: relative;
+  margin: 1.25em 0;
+}
+
+.code-container pre {
+  margin-bottom: 0;
+  padding-top: 2.2em; /* space for copy button */
+}
+
+.copy-btn {
+  position: absolute;
+  right: 10px;
+  top: 8px;
+  background: rgba(32, 33, 35, 0.9);
+  color: #fff;
+  border: none;
+  padding: 4px 6px;
+  cursor: pointer;
+  border-radius: 999px;
+  font-size: 11px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 22px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  transition: background 0.15s ease, box-shadow 0.15s ease, transform 0.1s ease;
+}
+
+.copy-btn i {
+  font-size: 12px;
+}
+
+.copy-btn::after {
+  content: 'Copy';
+  position: absolute;
+  right: 110%;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(32, 33, 35, 0.95);
+  color: #fff;
+  padding: 3px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+  transition: opacity 0.15s ease;
+}
+
+.copy-btn--copied::after {
+  content: 'Copied!';
+  opacity: 1;
+}
+
+.copy-btn:hover {
+  background: #085e92;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.18);
+  transform: translateY(-1px);
+}
+
+.copy-btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(34, 34, 34, 0.3);
+}
 div.col-flex {
   display: flex;
   flex-flow: column;

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -20,21 +20,24 @@ $( document ).ready(function() {
      */
     anchors.add('main h2:not(.no-anchor),main h3:not(.no-anchor),main h4:not(.no-anchor),main h5:not(.no-anchor)');
 
-    // Add copy buttons only to explicit code boxes
-    $('.code-container').each(function () {
-        var $container = $(this);
+    // Add copy buttons and wrappers to all code blocks inside main content
+    $('main pre, main div.highlight, main figure.highlight, main .highlighter-rouge').each(function () {
+        var $block = $(this);
 
+        // Find or create a code-container wrapper
+        var $container = $block.closest('.code-container');
+        if ($container.length === 0) {
+            $container = $('<div class="code-container"></div>');
+            $block.before($container);
+            $container.append($block);
+        }
+
+        // Avoid adding multiple buttons
         if ($container.data('has-copy-button')) {
             return;
         }
 
-        var $block = $container.find('pre, div.highlight, figure.highlight, .highlighter-rouge').first();
-        if (!$block.length) {
-            return;
-        }
-
         var $button = $('<button type="button" class="copy-btn" aria-label="Copy code"><i class="fa-regular fa-copy" aria-hidden="true"></i></button>');
-
         $container.prepend($button);
 
         $button.on('click', function () {

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -20,21 +20,22 @@ $( document ).ready(function() {
      */
     anchors.add('main h2:not(.no-anchor),main h3:not(.no-anchor),main h4:not(.no-anchor),main h5:not(.no-anchor)');
 
-    // Add copy buttons and wrappers to all code blocks inside main content
-    $('main pre, main div.highlight, main figure.highlight, main .highlighter-rouge').each(function () {
-        var $block = $(this);
+    // Add copy buttons only to explicit code boxes
+    $('.code-container').each(function () {
+        var $container = $(this);
 
-        // Avoid wrapping twice
-        if ($block.closest('.code-container').length) {
+        if ($container.data('has-copy-button')) {
             return;
         }
 
-        var $container = $('<div class="code-container"></div>');
+        var $block = $container.find('pre, div.highlight, figure.highlight, .highlighter-rouge').first();
+        if (!$block.length) {
+            return;
+        }
+
         var $button = $('<button type="button" class="copy-btn" aria-label="Copy code"><i class="fa-regular fa-copy" aria-hidden="true"></i></button>');
 
-        $block.before($container);
-        $container.append($button);
-        $container.append($block);
+        $container.prepend($button);
 
         $button.on('click', function () {
             var codeElement = $container.find('code').get(0) || $block.get(0);
@@ -44,6 +45,8 @@ $( document ).ready(function() {
             var text = codeElement.innerText || codeElement.textContent || '';
             copyToClipboard(text, $button);
         });
+
+        $container.data('has-copy-button', true);
     });
 
 });

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -24,6 +24,11 @@ $( document ).ready(function() {
     $('main pre, main div.highlight, main figure.highlight, main .highlighter-rouge').each(function () {
         var $block = $(this);
 
+        // Skip inline code (e.g. single words like Glyph, paths, etc.)
+        if ($block.is('code') && !$block.closest('pre').length) {
+            return;
+        }
+
         // Find or create a code-container wrapper
         var $container = $block.closest('.code-container');
         if ($container.length === 0) {

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -52,3 +52,35 @@ $(function() {
         }
     });
 });
+
+function copyText() {
+    var introElement = document.getElementById("intro-text");
+    if (!introElement) {
+        return;
+    }
+    var text = introElement.innerText || introElement.textContent;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text)
+            .then(function () {
+                alert("Copied!");
+            })
+            .catch(function (err) {
+                console.error("Copy failed", err);
+            });
+    } else {
+        var textArea = document.createElement("textarea");
+        textArea.value = text;
+        textArea.style.position = "fixed";
+        textArea.style.top = "-1000px";
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        try {
+            document.execCommand("copy");
+            alert("Copied!");
+        } catch (err) {
+            console.error("Copy failed", err);
+        }
+        document.body.removeChild(textArea);
+    }
+}

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -20,8 +20,9 @@ $( document ).ready(function() {
      */
     anchors.add('main h2:not(.no-anchor),main h3:not(.no-anchor),main h4:not(.no-anchor),main h5:not(.no-anchor)');
 
-    // Add copy buttons and wrappers to all code blocks inside main content
-    $('main pre, main div.highlight, main figure.highlight, main .highlighter-rouge').each(function () {
+    // Add copy buttons and wrappers to block-level code inside main content
+    // (command/code boxes only, not inline red filenames or short code words)
+    $('main pre, main div.highlight, main figure.highlight').each(function () {
         var $block = $(this);
 
         // Skip inline code (e.g. single words like Glyph, paths, etc.)

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -20,6 +20,32 @@ $( document ).ready(function() {
      */
     anchors.add('main h2:not(.no-anchor),main h3:not(.no-anchor),main h4:not(.no-anchor),main h5:not(.no-anchor)');
 
+    // Add copy buttons and wrappers to all code blocks inside main content
+    $('main pre, main div.highlight, main figure.highlight, main .highlighter-rouge').each(function () {
+        var $block = $(this);
+
+        // Avoid wrapping twice
+        if ($block.closest('.code-container').length) {
+            return;
+        }
+
+        var $container = $('<div class="code-container"></div>');
+        var $button = $('<button type="button" class="copy-btn" aria-label="Copy code"><i class="fa-regular fa-copy" aria-hidden="true"></i></button>');
+
+        $block.before($container);
+        $container.append($button);
+        $container.append($block);
+
+        $button.on('click', function () {
+            var codeElement = $container.find('code').get(0) || $block.get(0);
+            if (!codeElement) {
+                return;
+            }
+            var text = codeElement.innerText || codeElement.textContent || '';
+            copyToClipboard(text, $button);
+        });
+    });
+
 });
 
 // needed for nav tabs on pages. See Formatting > Nav tabs for more details.
@@ -53,16 +79,25 @@ $(function() {
     });
 });
 
-function copyText() {
-    var introElement = document.getElementById("intro-text");
-    if (!introElement) {
+function copyToClipboard(text, $button) {
+    if (!text) {
         return;
     }
-    var text = introElement.innerText || introElement.textContent;
+
+    function indicateCopied() {
+        if (!$button) {
+            return;
+        }
+        $button.addClass('copy-btn--copied');
+        setTimeout(function () {
+            $button.removeClass('copy-btn--copied');
+        }, 2000);
+    }
+
     if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText(text)
             .then(function () {
-                alert("Copied!");
+                indicateCopied();
             })
             .catch(function (err) {
                 console.error("Copy failed", err);
@@ -77,10 +112,19 @@ function copyText() {
         textArea.select();
         try {
             document.execCommand("copy");
-            alert("Copied!");
+            indicateCopied();
         } catch (err) {
             console.error("Copy failed", err);
         }
         document.body.removeChild(textArea);
     }
+}
+
+function copyText() {
+    var introElement = document.getElementById("intro-text");
+    if (!introElement) {
+        return;
+    }
+    var text = introElement.innerText || introElement.textContent;
+    copyToClipboard(text);
 }


### PR DESCRIPTION
### Summary

This PR adds a small copy-to-clipboard button to all code blocks across the documentation site.

### Motivation

Many tutorials contain long commands and code examples.  
Currently users must manually select the text to copy it.

Adding a copy button makes it easier to copy commands and reduces copy-paste errors.

### Implementation

- Adds a copy button to each code block
- Implemented using global JavaScript + CSS
- Works for:
  - Markdown code blocks
  - Rouge highlighted blocks
  - `<pre><code>` HTML blocks
- Uses `navigator.clipboard.writeText()` with a fallback method for compatibility

### UI

- Small unobtrusive icon button
- Appears in the top-right corner of the code block
- Shows **"Copied!"** feedback after clicking

### Notes

This implementation works globally and does not require modifying existing documentation files.

This contribution is part of my preparation for Google Summer of Code.

### UI Comparison

| Before | After |
|------|------|
| <img width="1369" height="340" alt="image" src="https://github.com/user-attachments/assets/fa0f3ecf-dd19-46a4-8ccf-9eee9f77cb5f" /> |<img width="1338" height="316" alt="Screenshot 2026-03-11 021811" src="https://github.com/user-attachments/assets/c8a48090-995a-4b14-bbf6-83a3b51adcfc" />
 |
