### PR TITLE
Add profiling merge example without arguments

### DIFF
--- a/content/docs/tooling/tooling-performance-analysis.md
+++ b/content/docs/tooling/tooling-performance-analysis.md
@@ -222,17 +222,18 @@ where the naming pattern is `participant-rank-file_number`. To find and merge th
 $ ls
 A
 B
-$ precice-cli profiling merge A B
-Searching A : found 1 files in A/precice-profiling
-Searching B : found 1 files in B/precice-profiling
-Found 2 unique event files
+$ precice-cli profiling merge
+Found 2 files in .
 Found a single run for participant B
 Found a single run for participant A
-Loading event files
-Globalizing event names
-Grouping events
-Aligning B (-179us) with A
-Writing to profiling.db
+Loading 2 event files
+Loading precice-profiling/B-0-1.txt
+Processing precice-profiling/B-0-1.txt
+Loading precice-profiling/A-0-1.txt
+Processing precice-profiling/A-0-1.txt
+Align participant ranks
+Align participants
+Aligning B with A shift latter by 5
 $ ls
 A
 B
@@ -241,6 +242,24 @@ profiling.db
 
 The merge command searches passed directories for the event files.
 You can also pass individual files if you are not interested in all ranks.
+To tell the merge to search only folders A and B run:
+
+```console
+precice-cli profiling merge A B 
+Found 1 files in A
+Found 1 files in B
+Found 2 profiling files in total
+Found a single run for participant A
+Found a single run for participant B
+Loading 2 event files
+Loading A/precice-profiling/A-0-1.txt
+Processing A/precice-profiling/A-0-1.txt
+Loading B/precice-profiling/B-0-1.txt
+Processing B/precice-profiling/B-0-1.txt
+Align participant ranks
+Align participants
+Aligning B with A shift latter by 5
+```
 
 The merge command is written in pure Python, without external dependencies, to make it easy to use on clusters.
 After you run `precice-cli profiling merge`, you end up with a single file, which can be additionally compressed and transferred to another machine.

--- a/content/docs/tooling/tooling-performance-analysis.md
+++ b/content/docs/tooling/tooling-performance-analysis.md
@@ -240,7 +240,8 @@ B
 profiling.db
 ```
 
-The merge command searches passed directories for the event files.
+The merge command searches the current directory recursively for event files.
+You can also pass individual directories to be searched, or individual event files to use.
 You can also pass individual files if you are not interested in all ranks.
 To tell the merge to search only folders A and B run:
 


### PR DESCRIPTION
The first example used merge with arguments, which can be misunderstood to be the Participants to merge.

We now
- first show the non-argument version that should be enough in most cases.
- then explain what arguments mean
- and finally show the example with arguments
