### PR TITLE
ci: automate gsoc label assignment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Main Changes of this PR
+
+
+## Motivation and additional information
+
+<!--
+Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
+-->
+
+## Steps to Test
+
+
+## Screenshots (if applicable)
+
+
+## Author's checklist
+
+* [ ] I ran the website locally and verified the changes.
+* [ ] I ensured links and formatting render correctly.
+* [ ] I added screenshots if UI/visual changes are introduced.
+* [ ] I linked the related issue (if applicable).
+* [ ] I squashed commits that belong together.
+* [ ] This PR is a part of Google Summer of Code (GSoC)
+
+## Reviewers' checklist
+
+<!-- Tag people next to each point and add points for specific questions -->
+
+* [ ] Does the changelog entry make sense? Is it formatted correctly?
+* [ ] Do you understand the code changes?
+
+<!-- add more questions/tasks if necessary -->

--- a/.github/workflows/auto-label-gsoc.yml
+++ b/.github/workflows/auto-label-gsoc.yml
@@ -1,0 +1,26 @@
+name: Automatic labelling of GSoC related PRs
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  label-gsoc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add GSoC label if checkbox is checked
+        uses: actions/github-script@v7
+        with:
+          script: | 
+            const body = context.payload.pull_request.body || "";
+            const gsocChecked = body.includes("[x] This PR is a part of Google Summer of Code (GSoC)") ||
+                body.includes("[X] This PR is a part of Google Summer of Code (GSoC)");
+            if(gsocChecked) {
+              await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  labels: ["GSoC"]
+              });
+            }


### PR DESCRIPTION
## Summary
- Added a PR template by referring existing templates in preCICE repos.
- Added workflow to automatically assign GSoC labels via PR template checkbox.

## Motivation
There is no standard PR template in this repositiory that new contributors can follow.
GSoC labels are currently assigned manually. Considering the number of PRs created each day, this task can become overwhelming. Automating this process can reduce the workload for maintainers.