### PR TITLE
Bump actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
          python-version: '3.x'
       - name: Run pre-commit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     name: pre-commit checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup python
         uses: actions/setup-python@v5
         with:
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           lfs: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           JEKYLL_ENV: production
         run: bundle exec jekyll build
       - name: Upload site
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: site
           path: website/_site

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
          python-version: '3.x'
       - name: Run pre-commit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     name: pre-commit checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup python
         uses: actions/setup-python@v5
         with:
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout website
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           lfs: false
@@ -36,14 +36,14 @@ jobs:
           fetch-depth: 0 # full history required to determine last edit
 
       - name: Fetch - precice develop
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: precice/precice
           ref: develop
           path: develop
 
       - name: Fetch - precice main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: precice/precice
           ref: main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,7 @@ jobs:
         run: find public
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.JEKYLL_PAT }}
           publish_dir: ./public

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,21 +10,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout website
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           lfs: false
           path: website
 
       - name: Fetch - precice develop
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: precice/precice
           ref: develop
           path: develop
 
       - name: Fetch - precice main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: precice/precice
           ref: main

--- a/.github/workflows/update-algolia.yml
+++ b/.github/workflows/update-algolia.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           lfs: false

--- a/.github/workflows/update-discourse-data.yml
+++ b/.github/workflows/update-discourse-data.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.WEBSITE_UPDATER_APPID }}

--- a/.github/workflows/update-discourse-data.yml
+++ b/.github/workflows/update-discourse-data.yml
@@ -19,7 +19,7 @@ jobs:
           private-key: ${{ secrets.WEBSITE_UPDATER_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       success: ${{ steps.commit.outputs.outcome  == 'success' }}
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.WEBSITE_UPDATER_APPID }}

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -18,7 +18,7 @@ jobs:
           app-id: ${{ vars.WEBSITE_UPDATER_APPID }}
           private-key: ${{ secrets.WEBSITE_UPDATER_KEY }}
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
           lfs: true


### PR DESCRIPTION
In this repository, Dependabot is disabled (not sure why, probably historical reasons that might not be relevant anymore - we should reconsider).

This PR bumps the versions of all GitHub Actions used in all workflows. All workflows are still relevant.

Triggered by #832 but for all actions.