### PR TITLE
Fix: use native Jekyll plugin to get correct git dates for submodules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,10 @@ jobs:
           bundler-cache: true
           working-directory: website
 
+      - name: Fetch full history for submodules
+        working-directory: website
+        run: git submodule foreach --recursive "git fetch --unshallow --all 2>/dev/null || git fetch --all"
+
       - name: Build website
         working-directory: website
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ group :jekyll_plugins do
   gem 'jekyll-seo-tag'
   gem 'jekyll-sitemap'
   gem 'jekyll-redirect-from'
-  gem "jekyll-last-modified-at"
   gem 'jekyll-mermaid'
 end
 

--- a/_config.yml
+++ b/_config.yml
@@ -262,7 +262,6 @@ mermaid:
 plugins:
   - jekyll-redirect-from
   - jekyll-sitemap
-  - jekyll-last-modified-at
 
 subprojects:
   - imported/aste/docs

--- a/_plugins/last_modified_at.rb
+++ b/_plugins/last_modified_at.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module Jekyll
   class LastModifiedAtGenerator < Generator
     safe true
@@ -25,7 +27,8 @@ module Jekyll
 
       # Get the timestamp from git log specifically from the file's directory.
       # This naturally works for submodules because we run it inside the submodule dir.
-      timestamp = `git -C "#{dir}" log -1 --format="%ct" -- "#{base}" 2>/dev/null`.strip
+      stdout_str, status = Open3.capture2e("git", "-C", dir, "log", "-1", "--format=%ct", "--", base)
+      timestamp = status.success? ? stdout_str.strip : ""
 
       if timestamp.empty?
         # Fallback to filesystem mtime if git history is not available

--- a/_plugins/last_modified_at.rb
+++ b/_plugins/last_modified_at.rb
@@ -1,0 +1,40 @@
+module Jekyll
+  class LastModifiedAtGenerator < Generator
+    safe true
+    priority :lowest
+
+    def generate(site)
+      site.pages.each { |page| set_last_modified_at(page) }
+      if site.respond_to?(:docs_to_write)
+        site.docs_to_write.each { |doc| set_last_modified_at(doc) }
+      end
+    end
+
+    private
+
+    def set_last_modified_at(item)
+      # Skip if already specified in frontmatter
+      return if item.data['last_modified_at']
+
+      # Skip if there's no actual file path
+      file_path = item.path
+      return unless file_path && File.exist?(file_path)
+
+      dir = File.dirname(file_path)
+      base = File.basename(file_path)
+
+      # Get the timestamp from git log specifically from the file's directory.
+      # This naturally works for submodules because we run it inside the submodule dir.
+      timestamp = `git -C "#{dir}" log -1 --format="%ct" -- "#{base}" 2>/dev/null`.strip
+
+      if timestamp.empty?
+        # Fallback to filesystem mtime if git history is not available
+        parsed_date = File.mtime(file_path)
+      else
+        parsed_date = Time.at(timestamp.to_i)
+      end
+
+      item.data['last_modified_at'] = parsed_date
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR fixes the issue where imported pages from submodules display the incorrect "Updated on" date (all showing the same date of the latest site build).

After reviewing the discussion in #783, I agreed that patching vendor directories using `sed` and `bash` scripts is fragile. Instead, this PR solves the problem using a completely native Jekyll approach:

1. **Removed `jekyll-last-modified-at`:** This gem is officially abandoned and has an architectural flaw where it only searches the parent repository's top-level git directory (meaning it can never see submodule file histories).
2. **Created a Custom Generator Plugin :** Added a lightweight, 30-line Ruby plugin. It hooks into the Jekyll build and executes `git log` specifically from the file's own directory (`git -C <directory> log`). This means Git naturally resolves the correct commit history for submodule files out-of-the-box.
3. **Updated CI :** Added a single step to `git fetch --unshallow` the submodules prior to the build. This ensures the full commit history is actually downloaded by GitHub Actions so the plugin can read it.

This completely eliminates the need for any bash script workarounds or frontmatter text manipulation while keeping the deploy configuration clean.

Closes #404

Screenshots:

Before :

<img width="1915" height="843" alt="image" src="https://github.com/user-attachments/assets/03b1425b-5097-4b2f-b001-e0d81962f47d" />


After :

<img width="1918" height="612" alt="image" src="https://github.com/user-attachments/assets/e1889da3-f9eb-48df-9c5a-be8ff483ae7a" />


Verification :

I also tested things locally and `pre-commit` passes successfully (tested on my local fork also just to be sure )
