### PR TITLE
Fix/restore Doxygen pages deployment

### DIFF
--- a/content/docs/couple-your-code/couple-your-code-api.md
+++ b/content/docs/couple-your-code/couple-your-code-api.md
@@ -3,7 +3,9 @@ title: Application programming interface
 permalink: couple-your-code-api.html
 keywords: api, adapter, library, bindings, Participant
 summary: "This page gives an overview on available preCICE APIs and minimal reference implementations."
-redirect_from: dev-docs-sourcedocs.html
+redirect_from:
+  - dev-docs-sourcedocs.html
+  - /doxygen/ # Also creates the doxygen/ directory - Important for deploying the Doxygen pages (see .github/workflows/deploy.yml)
 ---
 
 preCICE is written in C++. Thus, the native API language of preCICE is C++ as well. If you are new to the preCICE API, we recommended that you first follow the [step-by-step guide](couple-your-code-preparing-your-solver.html). If you are using an older version, see the [porting guides](couple-your-code-porting-overview) to port an adapter between major version of preCICE.


### PR DESCRIPTION
In https://github.com/precice/precice.github.io/pull/718, I deleted the page `dev-docs-sourcedocs.html`, which included a `redirect_from: /doxygen/`. The latter seems to be important, since it also creates the destination directory used in the `deploy.yml`:

https://github.com/precice/precice.github.io/blob/c99ee16ea83881495ec82e548655142d843fede0/.github/workflows/deploy.yml#L97-L101

At the moment (and before #718 gets deployed), https://precice.org/doxygen redirects to the deleted page https://precice.org/dev-docs-sourcedocs.html, which #718 merged into https://precice.org/couple-your-code-api.html (as decided in the coding days - Feb 2026).

Following the [jekyll-redirect-from documentation](https://github.com/jekyll/jekyll-redirect-from), this PR adds a list that redirects both:

- https://precice.org/doxygen, and
- https://precice.org/dev-docs-sourcedocs.html

to https://precice.org/couple-your-code-api.html

This should also restore the deployment of the Doxygen pages. Since our `deploy.yml` is only triggered on push to master, I can only check if this worked out after merging. If not, I will follow-up.