### PR TITLE
API docs: Predefined section anchor for C++

### DIFF
--- a/content/docs/couple-your-code/couple-your-code-api.md
+++ b/content/docs/couple-your-code/couple-your-code-api.md
@@ -14,7 +14,7 @@ Next to the native C++ API, bindings for further languages are also available. I
 
 The reference implementations are the so called _solver dummies_, which can be a great source to copy from. The community also maintains [MPI-parallel versions of some of these solver dummies](https://github.com/ajaust/precice-parallel-solverdummies).
 
-## C++
+## C++ {#cpp}
 
 This is the native API of preCICE.
 


### PR DESCRIPTION
In the updated [API documentation page](https://precice.org/couple-your-code-api.html), the anchors are currently ugly:

- C++: https://precice.org/couple-your-code-api.html#c
- C: https://precice.org/couple-your-code-api.html#c-1

This PR adds a predefined anchor for the C++ section, leading to:

- C++: https://precice.org/couple-your-code-api.html#cpp
- C: https://precice.org/couple-your-code-api.html#c

as expected. I am using the `## Heading {#anchor}` syntax, which seems to work on the rendered page:

<img width="548" height="383" alt="Screenshot from 2026-03-24 13-00-02" src="https://github.com/user-attachments/assets/a20f7fe8-7267-4766-ad95-293ed745aeed" />
