### PR TITLE
Add scroll to top button

### DIFF
--- a/_includes/scroll_to_top.html
+++ b/_includes/scroll_to_top.html
@@ -1,0 +1,75 @@
+<button id="scroll-to-top" class="scroll-to-top" aria-label="Scroll to top">
+  <i class="fa fa-chevron-up"></i>
+</button>
+
+<style>
+.scroll-to-top {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  width: 45px;
+  height: 45px;
+  border-radius: 50%;
+  background-color: #0066cc;
+  color: white;
+  border: none;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease, background-color 0.3s ease;
+  z-index: 1000;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.scroll-to-top:hover {
+  background-color: #0052a3;
+}
+
+.scroll-to-top.visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+@media (max-width: 768px) {
+  .scroll-to-top {
+    bottom: 20px;
+    right: 20px;
+    width: 40px;
+    height: 40px;
+  }
+}
+
+@media (max-width: 480px) {
+  .scroll-to-top {
+    bottom: 15px;
+    right: 15px;
+    width: 35px;
+    height: 35px;
+    font-size: 14px;
+  }
+}
+</style>
+
+<script>
+(function() {
+  const scrollBtn = document.getElementById('scroll-to-top');
+  const scrollThreshold = 300; // Show button after scrolling 300px
+
+  // Show/hide button on scroll
+  window.addEventListener('scroll', function() {
+    if (window.pageYOffset > scrollThreshold) {
+      scrollBtn.classList.add('visible');
+    } else {
+      scrollBtn.classList.remove('visible');
+    }
+  });
+
+  // Scroll to top on click
+  scrollBtn.addEventListener('click', function() {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  });
+})();
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -102,6 +102,7 @@
         {% endunless %}
     </div>
     {% include footer.html %}
+    {% include scroll_to_top.html %}
 
 {% if site.google_analytics %}
 {% include google_analytics.html %}

--- a/_layouts/landing_page.html
+++ b/_layouts/landing_page.html
@@ -17,6 +17,7 @@
 	</main>
 
 	{% include footer.html %}
+	{% include scroll_to_top.html %}
 
 	<script src="{{ '/js/github-queries.js' | relative_url }}"></script>
 


### PR DESCRIPTION
Closes #876

Adds a scroll-to-top button for long pages.

- Smooth scroll-to-top behavior
- Reduces navigation time
- Self-contained and easy to maintain

Context and details are in the issue.