### PR TITLE
Fix width in release-strategy images

### DIFF
--- a/content/docs/dev-docs/release-strategy.md
+++ b/content/docs/dev-docs/release-strategy.md
@@ -12,7 +12,7 @@ permalink: dev-docs-release-strategy.html
 
 ## Dependency tree
 
-![Release dependencies](images/docs/dev-docs-release-dependencies.svg)
+<img class="img-responsive center-block" src="images/docs/dev-docs-release-dependencies.svg" alt="Release dependencies" style="width: 100%; margin: auto;">
 
 ## Release procedure
 
@@ -67,7 +67,7 @@ Goal: Release pyprecice version `1.2.3`.
 Root repository: `precice/pyprecice`
 Name of release branch: `pyprecice-v1.2.3`
 
-![Release example](images/docs/dev-docs-release-example.svg)
+<img class="img-responsive center-block" src="images/docs/dev-docs-release-example.svg" alt="Release example" style="width: 100%; margin: auto;">
 
 1. Create branch `pyprecice-v1.2.3` from `precice/pyprecice:develop`
 2. Prepare the release (bump version etc)


### PR DESCRIPTION
For the two images in https://precice.org/dev-docs-release-strategy.html, this PR replaces the Markdown image codes with HTML `<img>` tags with style, similarly to other instances (e.g., in https://precice.org/community.html).

Since the images are anyway quite detailed, I set them to always 100% width.

closes #877 (in a different way as discussed there)