### PR TITLE
Fix list of sidebars in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -235,7 +235,7 @@ defaults:
 sidebars:
 - home_sidebar
 - docs_sidebar
-- tutorials_sidebar
+- tutorial_sidebar
 - community_sidebar
 
 description: "preCICE is an open-source coupling library and ecosystem for general partitioned multi-physics and multi-scale simulations, including surface and volume coupling."


### PR DESCRIPTION
This PR fixes the `tutorial_sidebar` entry in the list of sidebars in `_config.yml` (closes #873).

The `site.data.sidebars` is used in:

- `_includes/breadcrumb.html`
- `_includes/links.html`
- `_includes/sidebar.html`
- `pdfconfigs/prince-list.txt`
- `pdfconfigs/tocpage.html`

and might have side-effects in #734.