### PR TITLE
Fix sticky footer layout issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,5 @@ gem "open-uri"
 
 # For current Ruby installations (3+?)
 gem "webrick"
+
+gem "ostruct", "~> 0.6.3"

--- a/Gemfile
+++ b/Gemfile
@@ -33,4 +33,3 @@ gem "open-uri"
 # For current Ruby installations (3+?)
 gem "webrick"
 
-gem "ostruct", "~> 0.6.3"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -85,7 +85,7 @@
           <!-- News banner -->
           {% include news_banner.html onlanding=false %}
     </header>
-    <div class="container" style="margin-bottom:50px">
+    <div class="container page-content" style="margin-bottom:50px">
         {% unless page.hide_sidebar %}
         <div class="row">
           <div class="col-md-3" id="tg-sb-sidebar">

--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -8,7 +8,8 @@ body {
     display: flex;
     flex-direction: column;
 }
-.page-content {
+.page-content,
+main {
     flex: 1;
 }
 

--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -4,6 +4,12 @@ body {
     font-size: 16px;
     font-family: Roboto,"Helvetica Neue",Helvetica,Arial,sans-serif;
     padding-top: 70px;      /* https://getbootstrap.com/docs/3.4/components/#navbar-fixed-top */
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+.page-content {
+    flex: 1;
 }
 
 .banner-container {
@@ -411,13 +417,4 @@ div.highlighter-rouge:hover .copy-code-btn {
     background-color: #28a745;
     color: white;
     border-color: #28a745;
-}
-body {
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-}
-
-.page-content {
-    flex: 1;
 }

--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -412,3 +412,12 @@ div.highlighter-rouge:hover .copy-code-btn {
     color: white;
     border-color: #28a745;
 }
+body {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.page-content {
+    flex: 1;
+}


### PR DESCRIPTION
This PR fixes the sticky footer layout issue reported in #879.

Problem:
When the browser was zoomed out or viewed on large viewport sizes, the footer appeared above the bottom of the page, leaving unwanted empty space below it.

Solution:
- Added a flexible page-content layout structure to keep the footer pushed to the bottom.
- Updated the default layout structure in `_layouts/default.html`.
- Added the required flex behavior in `customstyles-precice.css`.

Result:
The footer now stays correctly at the bottom of the page across zoomed-out and large-screen layouts.

Screenshots:
Before Fix:
The footer shifted upward and left large empty space below the page.

After Fix:
The footer now remains properly aligned at the bottom of the page even at zoomed-out viewport sizes.