### PR TITLE
Improvements to the PDF archive

### DIFF
--- a/content/docs/dev-docs/release-strategy.md
+++ b/content/docs/dev-docs/release-strategy.md
@@ -12,7 +12,7 @@ permalink: dev-docs-release-strategy.html
 
 ## Dependency tree
 
-<img class="img-responsive center-block" src="images/docs/dev-docs-release-dependencies.svg" alt="Release dependencies" style="width: 100%; margin: auto;">
+<img class="img-responsive center-block" src="images/docs/dev-docs-release-dependencies.svg" alt="Release dependencies" style="min-width: 100%; width:800px; margin: auto;">
 
 ## Release procedure
 
@@ -67,7 +67,7 @@ Goal: Release pyprecice version `1.2.3`.
 Root repository: `precice/pyprecice`
 Name of release branch: `pyprecice-v1.2.3`
 
-<img class="img-responsive center-block" src="images/docs/dev-docs-release-example.svg" alt="Release example" style="width: 100%; margin: auto;">
+<img class="img-responsive center-block" src="images/docs/dev-docs-release-example.svg" alt="Release example" style="min-width: 100%; width:800px; margin: auto;">
 
 1. Create branch `pyprecice-v1.2.3` from `precice/pyprecice:develop`
 2. Prepare the release (bump version etc)

--- a/content/docs/installation/installation-special-systems.md
+++ b/content/docs/installation/installation-special-systems.md
@@ -43,7 +43,11 @@ libxml2 is part of the `-devel` packages, which are loaded by default on the log
 (3) Build preCICE. For PETSc, the library path and include path need to be defined explicitly:
 
 ```bash
-cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX="my/install/prefix" -DPRECICE_FEATURE_PETSC_MAPPING=ON -DPETSc_INCLUDE_DIRS="$PETSC_DIR/include" -DPETSc_LIBRARIES="$PETSC_DIR/lib/libpetsc.so" -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF /path/to/precice/source
+cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX="my/install/prefix" \
+      -DPRECICE_FEATURE_PETSC_MAPPING=ON \
+      -DPETSc_INCLUDE_DIRS="$PETSC_DIR/include" -DPETSc_LIBRARIES="$PETSC_DIR/lib/libpetsc.so" \
+      -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF \
+      /path/to/precice/source
 
 make install -j 16
 ```
@@ -107,7 +111,8 @@ export EIGEN3_ROOT="$HOME/Software/eigen3"
 (2) [Download latest boost](https://www.boost.org/), copy it to SuperMUC and build yourself:
 
 ```bash
-./bootstrap.sh --with-libraries=log,thread,system,filesystem,program_options,test --prefix=$HOME/Software/boost-install
+./bootstrap.sh --with-libraries=log,thread,system,filesystem,program_options,test \
+               --prefix=$HOME/Software/boost-install
 ./b2 install
 ```
 
@@ -156,8 +161,8 @@ module load slurm_setup
 rm -rf tests
 mkdir tests
 cd tests
-mpiexec -np 4 ../../Software/precice-1.6.1/build/debug/testprecice --log_level=test_suite --run_test="\!@MPI_Ports"
-
+mpiexec -np 4 ../../Software/precice-1.6.1/build/debug/testprecice \
+        --log_level=test_suite --run_test="\!@MPI_Ports"
 ```
 
 #### Notes on OpenFOAM
@@ -319,7 +324,8 @@ This gives on `module list`:
 
 ```bash
 Currently Loaded Modulefiles:
- 1) admin/1.0   2) tempdir/1.0   3) lrz/1.0   4) spack/21.1.1   5) gcc/8.4.0   6) intel-mpi/2019-gcc   7) precice/2.2.0-gcc8-impi
+ 1) admin/1.0   2) tempdir/1.0   3) lrz/1.0   4) spack/21.1.1
+ 5) gcc/8.4.0   6) intel-mpi/2019-gcc   7) precice/2.2.0-gcc8-impi
 ```
 
 **Note:** If you want to use FEniCS (see below), please stick to GCC from the very beginning.
@@ -359,7 +365,9 @@ Before running the command `module load mpi.intel/2019.12_gcc` the user has to r
 
 ```bash
 mkdir build && cd build
-cmake -DBUILD_SHARED_LIBS=ON -DPRECICE_FEATURE_PETSC_MAPPING=OFF -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF -DPRECICE_FEATURE_MPI_COMMUNICATION=OFF -DCMAKE_INSTALL_PREFIX=/path/to/precice/installation -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cmake -DBUILD_SHARED_LIBS=ON -DPRECICE_FEATURE_PETSC_MAPPING=OFF -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF \
+      -DPRECICE_FEATURE_MPI_COMMUNICATION=OFF -DCMAKE_INSTALL_PREFIX=/path/to/precice/installation \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 make -j 12
 make install
 ```
@@ -379,7 +387,8 @@ If you want to install a solver/adapter which depends on **yaml-cpp** (e.g. Open
 ```bash
 tar -xzvf boost_1_65_1.tar.gz
 cd boost_1_65_1
-./bootstrap.sh --with-libraries=log,thread,system,filesystem,program_options,test --prefix=/path/to/installation/target
+./bootstrap.sh --with-libraries=log,thread,system,filesystem,program_options,test
+               --prefix=/path/to/installation/target
 ./b2 install
 ```
 
@@ -418,7 +427,8 @@ salloc --ntasks=12
 As mentioned above, we want to use `mpi.intel/2018_gcc`. You may get an error message if you run the configuration script without specifying the `mpi-dir`. If you use another version, you can look it up with `module show` under `I_MPI_ROOT`. Then, run the `configure` script and follow the instructions:
 
 ```bash
-./configure --with-mpi-dir=/lrz/sys/intel/studio2018_p4/impi/2018.4.274 --download-fblaslapack=1
+./configure --with-mpi-dir=/lrz/sys/intel/studio2018_p4/impi/2018.4.274
+            --download-fblaslapack=1
 ```
 
 You may additionally specify a `--prefix` for the target directory. Then, you just need to set `PETSC_DIR= prefix`.
@@ -435,7 +445,9 @@ Afterwards, you could follow the usual building instructions:
 
 ```bash
 mkdir build && cd build
-CC=mpicc CXX=mpicxx cmake -DPETSC=ON -DPYTHON=OFF -DCMAKE_INSTALL_PREFIX=/path/to/precice/installation -DCMAKE_BUILD_TYPE=Release ../..
+CC=mpicc CXX=mpicxx cmake -DPETSC=ON -DPYTHON=OFF \
+                          -DCMAKE_INSTALL_PREFIX=/path/to/precice/installation \
+                          -DCMAKE_BUILD_TYPE=Release ../..
 make -j 12
 make install
 ```
@@ -585,7 +597,9 @@ Type "help", "copyright", "credits" or "license" for more information.
 You might face this problem:
 
 ```bash
-/.../.conda/envs/precice/lib/python3.12/site-packages/dolfin/jit/jit.py:46: RuntimeWarning: mpi4py.MPI.Session size changed, may indicate binary incompatibility. Expected 32 from C header, got 40 from PyObject                                                                                                                                       
+/.../.conda/envs/precice/lib/python3.12/site-packages/dolfin/jit/jit.py:46:
+  RuntimeWarning: mpi4py.MPI.Session size changed, may indicate binary incompatibility.
+  Expected 32 from C header, got 40 from PyObject                                                                                                                                       
 ```
 
 Please check your `mpi4py` version via `python -c "import mpi4py; print(mpi4py.__version__)`. If you are using a version `>= 4.x`, downgrade to the `3.x` version by running
@@ -887,6 +901,7 @@ module list
 
 rm -rf build
 mkdir -p build && cd build
-cmake -DBUILD_SHARED_LIBS=ON -DMPI_CXX_COMPILER=mpigcc -DCMAKE_BUILD_TYPE=Debug -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF ..
+cmake -DBUILD_SHARED_LIBS=ON -DMPI_CXX_COMPILER=mpigcc -DCMAKE_BUILD_TYPE=Debug \
+      -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF ..
 make -j
 ```

--- a/pdfconfigs/titlepage.html
+++ b/pdfconfigs/titlepage.html
@@ -10,17 +10,22 @@ permalink: titlepage.html
     <!-- </div> -->
     </div>
     <div class="printSubtitle">{{site.print_subtitle}}</div>
-    <div class="printVersion">Documentation version {{site.precice_version}}</div>
+    <div class="printVersion">Documentation of preCICE v{{site.precice_version}}</div>
     <div class="lastGeneratedDate">Generated: {{ site.time | date: '%B %d, %Y' }}</div>
     <hr />
 
     <div class="copyrightBoilerplate">
         <p>
-            preCICE is free/open-source software, using the GNU LGPL3 license. The code is publicly available and actively developed on Github at <a href="https://github.com/precice/precice">https://github.com/precice/precice</a>.
+            This PDF document is a snapshot of the preCICE documentation hosted at <a href="https://precice.org">precice.org</a> as of {{ site.time | date: '%B %d, %Y' }}. The HTML/CSS version of the documentation is available on Github at
+            <a href="https://github.com/precice/precice.github.io">https://github.com/precice/precice.github.io</a> and can also be built locally.
+            More snapshots are listed on <a href="https://precice.org/fundamentals-previous-versions.html">https://precice.org/fundamentals-previous-versions.html</a>.
         </p>
         <p>
-            This pdf document is a snapshot of the preCICE documentation hosted at <a href="https://precice.org">precice.org</a> as of {{ site.time | date: '%B %d, %Y' }}. The HTML/CSS version of the documentation is available on Github at
-            <a href="https://github.com/precice/precice.github.io">https://github.com/precice/precice.github.io</a> and can also be built locally with Jekyll. For more information consult the <a href="https://github.com/precice/precice.github.io#readme">README</a> in this repository.
+            This snapshot has been generated with a non-commercial license of Prince: <a href="https://www.princexml.com/">https://www.princexml.com/</a>. While we do our best to improve the quality of this PDF archive, some content is only meant for online use, or still needs typesetting adjustments. Find more details on how we generate this archive on <a href="https://precice.org/docs-meta-publish-to-pdf.html">https://precice.org/docs-meta-publish-to-pdf.html</a> and help us improve it.
+        </p>
+        <p>
+            preCICE is free/open-source software. The core library is distributed under the <a href="https://www.gnu.org/licenses/lgpl-3.0.html">GNU LGPL3</a> license. The code is publicly available and actively developed on <a href="https://github.com/precice">GitHub</a>. Further components of the preCICE ecosystem are distributed under different free/open-source licenses and maintained in separate repositories, following independent release cycles and versioning systems.
+            The documentation is licensed under the <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International</a> license. License information: <a href="https://precice.org/fundamentals-license.html">https://precice.org/fundamentals-license.html</a>.
         </p>
     </div>
 


### PR DESCRIPTION
This PR addresses a few issues from #897:

- Expands the information in the title/copyright page
- Improves (but does not solve) the situation with too-wide pages in https://precice.org/installation-special-systems.html by splitting some long code lines. The issue does not seem to originate from the code blocks.
- Fixes the width of the images in https://precice.org/dev-docs-release-strategy.html by setting both `min-width:100%, width:800px".