### PR TITLE
Fix a typo / rendering issue

### DIFF
--- a/content/community/trainings/training-2026-10.md
+++ b/content/community/trainings/training-2026-10.md
@@ -36,7 +36,7 @@ We are preparing an interactive online event with 3h slots over a week. Prelimin
   - 12:00-15:00: Training course: Data mapping
 - Friday (discussion):
   - 12:00-12:30: General Q&A session
-  - 12:30-15:00: In parallel: User support session | Further training
+  - 12:30-15:00: In parallel: User support session, Further training
 
 ## Help us advertise
 


### PR DESCRIPTION
Somehow the `|` in

```
- 12:30-15:00: In parallel: User support session | Further training
```

is rendered as

<img width="868" height="139" alt="Screenshot from 2026-05-22 11-26-41" src="https://github.com/user-attachments/assets/9e87c183-6f8b-461d-95f7-26f2cd2766e1" />
