### PR TITLE
CI: Switch create-github-app-token to client-id

### DIFF
--- a/.github/workflows/update-discourse-data.yml
+++ b/.github/workflows/update-discourse-data.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.WEBSITE_UPDATER_APPID }}
+          client-id: ${{ vars.WEBSITE_UPDATER_CLIENT_ID }}
           private-key: ${{ secrets.WEBSITE_UPDATER_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.WEBSITE_UPDATER_APPID }}
+          client-id: ${{ vars.WEBSITE_UPDATER_CLIENT_ID }}
           private-key: ${{ secrets.WEBSITE_UPDATER_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Since recently, the [update-submodules](https://github.com/precice/precice.github.io/blob/master/.github/workflows/update-submodules.yml) and [update-discourse-data](https://github.com/precice/precice.github.io/blob/master/.github/workflows/update-discourse-data.yml) workflows give a warning that:

```
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

([example](https://github.com/precice/precice.github.io/actions/runs/26398520399)) This has been deprecated since [create-github-app-token v3.1.0](https://github.com/actions/create-github-app-token/releases/tag/v3.1.0).

This PR changes the workflows to use `client-id` instead of `app-id`. I have already created the respective [variable](https://github.com/organizations/precice/settings/variables/actions) based on the [existing app information](https://github.com/organizations/precice/settings/apps/precice-website-updater).

Test job: https://github.com/precice/precice.github.io/actions/runs/26400996402 (worked, nothing to update, since this was triggered very recently)