### PR TITLE
Bump currently supported Ubuntu versions

### DIFF
--- a/content/docs/installation/building-from-source/installation-source-dependencies.md
+++ b/content/docs/installation/building-from-source/installation-source-dependencies.md
@@ -421,8 +421,8 @@ sudo apt update && \
 sudo apt install build-essential cmake libeigen3-dev libxml2-dev libboost-all-dev petsc-dev python3-dev python3-numpy
 ```
 
-These instructions are known to work for Ubuntu 22.04, 24.04, and they should apply to later releases as well ([release history](https://endoflife.date/ubuntu)).
-See also the [Ubuntu Dockerfile used in the preCICE tests](https://github.com/precice/ci-images/blob/master/ci-ubuntu-2404.dockerfile).
+These instructions are known to work for Ubuntu 24.04, 26.04, and they should apply to later releases as well ([release history](https://endoflife.date/ubuntu)).
+See also the [Ubuntu Dockerfile used in the preCICE tests](https://github.com/precice/ci-images/blob/master/ci-ubuntu-2604.dockerfile).
 
 ### macOS
 

--- a/content/docs/installation/installation-packages.md
+++ b/content/docs/installation/installation-packages.md
@@ -28,7 +28,7 @@ sudo apt install ./libprecice3_{{ site.precice_version }}_noble.deb
 
 We support the latest two Ubuntu LTS versions, as well as the latest normal Ubuntu release.
 Check the [official release-cycle](https://ubuntu.com/about/release-cycle) for more information and the version code names.
-As an example, change `noble` to `jammy` for 22.04 (Jammy Jellyfish).
+As an example, change `noble` to `resolute` for 26.04 (Resolute Raccoon).
 
 Is a newer preCICE release out, and have we not yet updated the above links? Please edit this page.
 


### PR DESCRIPTION
Adds 26.04 and removes 22.04 in the dependencies and system packages pages.

22.04 is still supported in 3.4, but is already being phased out (https://github.com/precice/precice/pull/2564).