### PR TITLE
Upgrade pre-commit hooks

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,5 +2,6 @@
     "MD013": false,
     "MD028": false,
     "MD033": false,
-    "MD034": false
+    "MD034": false,
+    "MD060": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.39.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint
         files: "^(README.md|content/)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: markdownlint-fix
         files: "^(README.md|content/)"
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
       - id: shellcheck
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: check-added-large-files

--- a/content/docs/adapters/deal.II/adapter-dealii-own-project.md
+++ b/content/docs/adapters/deal.II/adapter-dealii-own-project.md
@@ -15,7 +15,7 @@ In addition to our coupled solid mechanics related codes of the dealii-adapter r
 [Contact us](community-channels.html) if you have any questions. Even if you don't have any questions, please let us know about your experience when your adapter is ready!
 {% endnote %}
 
-### Which information is needed by preCICE?
+## Which information is needed by preCICE?
 
 preCICE uses a black-box coupling approach, which means the solver only needs to provide a minimal set of information. In the simplest case, this includes configuration information, e.g. the name of the participant and the coordinates of the data you want to exchange (the interface mesh vertices). If you want to use a nearest-projection mapping, you need to additionally [specify mesh connectivity between the vertices](couple-your-code-defining-mesh-connectivity.html), which is currently not included in this adapter example.
 

--- a/content/docs/docs-meta/docs-meta-content-guidelines.md
+++ b/content/docs/docs-meta/docs-meta-content-guidelines.md
@@ -5,6 +5,8 @@ keywords: pages, migration, guideline, content, best practices, style guide
 summary: "Learn which style to follow when writing documentation and how to write good titles, content, and page summaries."
 ---
 
+<!-- markdownlint-configure-file {"MD059": false } -->
+
 ## Language & style
 
 This is the style we aim for, even if not all documentation pages are currently ticking all the boxes (nice opportunity for [contributing](community-contribute-to-precice.html)):

--- a/content/docs/docs-meta/docs-meta-publish-to-pdf.md
+++ b/content/docs/docs-meta/docs-meta-publish-to-pdf.md
@@ -9,7 +9,7 @@ summary:
 
 At the core of PDF generation process is [Prince](https://www.princexml.com/), which converts HTML/CSS (and even some JS) to print quality PDF with bookmarks, links, page numbers etc. Unfortunately there are no open-source alternatives that operate at the same level as Prince (yet) - however, Prince offers a [non-commercial license](https://www.princexml.com/purchase/license_faq/#non-commercial) that is perfectly suited for our use-case. As a requisite a water-mark is displayed on the first page of the PDF and we must place prominent links to the Prince website at the places we intend to serve the PDF.
 
-Prince can be downloaded [here](https://www.princexml.com/download/). The minimum version for MathJax 3 support is `20210624` which you can find [here](https://www.princexml.com/latest/).
+[Download Prince](https://www.princexml.com/download/): The minimum version for MathJax 3 support is `20210624`, so get the [latest release](https://www.princexml.com/latest/).
 
 On a Windows environment it makes sense to add the location of the Prince executable, e.g. `C:\Program Files (x86)\Prince\engine\bin`, to the `PATH`.
 
@@ -143,7 +143,7 @@ Furthermore two more pages have to be included in `prince-list.txt`:
 
 These two pages are located in `pdfconfigs/` and govern the layout of the title page as well as the table of contents.
 
-For further information see [here](https://idratherbewriting.com/documentation-theme-jekyll/mydoc_generating_pdfs.html).
+For further information, see the [Jekyll theme documentation](https://idratherbewriting.com/documentation-theme-jekyll/mydoc_generating_pdfs.html).
 
 ## Troubleshooting and common issues
 

--- a/content/docs/installation/bindings/installation-bindings-python.md
+++ b/content/docs/installation/bindings/installation-bindings-python.md
@@ -38,4 +38,4 @@ You can use Python's `help()` function for getting detailed usage information. E
 
 ## More details & troubleshooting
 
-The python package and detailed documentation for the python bindings can be found [here](https://github.com/precice/python-bindings).
+The python package and detailed documentation for the python bindings can be found [in the README](https://github.com/precice/python-bindings).

--- a/content/docs/installation/building-from-source/installation-source-cmake.md
+++ b/content/docs/installation/building-from-source/installation-source-cmake.md
@@ -9,13 +9,13 @@ keywords: configuration, basics, cmake, installation, building, source
 * CMake is a tool for build system configuration.  
   It generates a chosen build system in the directory it was executed in.
   The build system to generate can be specified using the `-G` flag which defaults to `Makefile`.
-  A list of all supported generators (e.g. for IDEs) can be found [here](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#cmake-generators).
+  A list of all supported generators (e.g. for IDEs) can be found in the [CMake documentation](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#cmake-generators).
 * Use the console tool `ccmake` or the gui `cmake-gui`for a more comfortable configuration.
 * The generated build system automatically reconfigures cmake when necessary.
 * It respects your environment variables `CXX`, `CXX_FLAGS`, ... during configuration.  
   Please use them to set your compiler and warning level of choice.
 * Invoke `cmake` with `-DVariable=Value` to set the cmake-internal variable `Variable` to `Value`.  
-  A complete list of variables recognised by cmake can be found [here](https://cmake.org/cmake/help/latest/manual/cmake-variables.7.html#cmake-variables-7).
+  A complete list of variables recognised by cmake can be found in the [CMake documentation](https://cmake.org/cmake/help/latest/manual/cmake-variables.7.html#cmake-variables-7).
 * Use `-DCMAKE_BUILD_TYPE` to specify what type of build you would like `Debug, Release, RelWithDebInfo, MinSizeRel`  
   CMake will select appropriate flag for you (e.g. `-g`, `-O2`).
   Specifying no `BUILD_TYPE` results in an un-optimised non-debug build.

--- a/content/docs/installation/installation-special-systems.md
+++ b/content/docs/installation/installation-special-systems.md
@@ -551,7 +551,7 @@ Additionally, we want to make sure to only use the channel `conda-forge`:
 (precice) $ conda config --env --set channel_priority strict
 ```
 
-See [here](https://www.fz-juelich.de/en/rse/the_latest/the-anaconda-is-squeezing-us) and [here](https://conda-forge.org/docs/user/transitioning_from_defaults/) for more background information.
+See [one announcement](https://www.fz-juelich.de/en/rse/the_latest/the-anaconda-is-squeezing-us) and [another announceent](https://conda-forge.org/docs/user/transitioning_from_defaults/) for more background information.
 
 ##### Installing the Python bindings
 


### PR DESCRIPTION
Fixes the warning

```
Warning:  repo `https://github.com/pre-commit/pre-commit-hooks` uses deprecated stage names (commit, push) which will be removed in a future version.  Hint: often `pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks` will fix this.  if it does not -- consider reporting an issue to that repo.
```

and upgrades the rest of the pre-commit hooks for maintenance.