### PR TITLE
Add schedule for WCCM 2026

### DIFF
--- a/content/community/minisymposia/eccomas-coupled-2025.md
+++ b/content/community/minisymposia/eccomas-coupled-2025.md
@@ -6,7 +6,7 @@ permalink: eccomas-coupled-2025.html
 toc: false
 ---
 
-The [ECCOMAS Coupled Problems 2025](https://coupled2025.cimne.com/) will take place on Sardinia, Italy from May 26 to 29.
+The [ECCOMAS Coupled Problems 2025](https://coupled2025.cimne.com/) took place on Sardinia, Italy from May 26 to 29.
 
 We organized a preCICE minisymposium: [Multi-Physics and Multi-Scale Simulations with the Coupling Library preCICE](https://coupled2025.cimne.com/event/session/e430d14b-0b28-11f0-9835-000c29ddfc0c) ([abstract](https://coupled2025.cimne.com/event/area/3dec3ef1-70ff-11ef-bbc6-000c29ddfc0c)) (IS042).
 
@@ -52,4 +52,4 @@ In [IS049B Numerical methods that enable the heterogeneous coupling of conventio
 
 ## Further events
 
-We are organized a coming together of the preCICE community on Monday evening, advertised among participants of the preCICE minisymposium.
+We organized a coming together of the preCICE community on Monday evening, advertised among participants of the preCICE minisymposium.

--- a/content/community/minisymposia/wccomas-wccm-2026.md
+++ b/content/community/minisymposia/wccomas-wccm-2026.md
@@ -8,10 +8,71 @@ toc: false
 
 The [WCCM 2026](https://wccm-eccomas2026.org/) will take place in Munich, Germany, between July 19-24.
 
-We are again organizing a preCICE minisymposium: [Multi-Physics and Multi-Scale Simulations With The Coupling Library preCICE](https://wccm-eccomas2026.org/event/area/7fdfa92c-ab83-11f0-bce5-000c29ddfc0c) (MS070).
+We are again organizing a preCICE minisymposium: [Multi-Physics and Multi-Scale Simulations With The Coupling Library preCICE](https://wccm-eccomas2026.org/event/area/7fdfa92c-ab83-11f0-bce5-000c29ddfc0c) (MS070) and a social event before that.
 
-Call for contributions: November 1st till ~~January 12~~ February 9, 2026. See the [important dates](https://wccm-eccomas2026.org/#fechas).
+Note that we are offering no training course this time. Consider joining the [full online training in October](precice-online-training-2026-oct.html).
 
-Typically, preCICE-related talks are also found among different sessions, which we collect here as well.
+Feel free to ask questions in the [corresponding thread of the forum](https://precice.discourse.group/t/precice-at-eccomas-wccm-2026-munich-germany/2678).
 
-Watch this page for updates.
+## Schedule of the Minisymposium
+
+The preCICE Minisymposium spreads over two sessions on Thursday, July 23.
+
+If you are a speaker, see the documentation page [Talk about your work](community-contribute-to-precice.html#talk-about-your-work) for some guidelines on preparing a great talk for this audience.
+
+### Thursday, July 23, 14:00-14:45
+
+Room: [NM - 6 (Munich)](https://wccm-eccomas2026.org/event/room/a1346743-418e-11f1-986a-000c29ddfc0c),
+Session: [MS070A](https://wccm-eccomas2026.org/event/session/74b7e537-4163-11f1-986a-000c29ddfc0c)
+
+- [A quick introduction to the coupling library preCICE](https://wccm-eccomas2026.org/event/contribution/8542955f-ef2b-11f0-b205-000c29ddfc0c) (Gerasimos Chourdakis, University of Stuttgart, Germany)
+- [Beyond Static Meshes in preCICE](https://wccm-eccomas2026.org/event/contribution/246c3756-d73b-11f0-b527-000c29ddfc0c) (Frédéric Simonis, University of Stuttgart, Germany)
+- [Turek-Hron FSI Benchmark simulations with TRACE and CalculiX](https://wccm-eccomas2026.org/event/contribution/8ce85c70-0587-11f1-919d-000c29ddfc0c) (Matthias Freimuth, MTU Aero Engines AG, Germany)
+
+Stay until the end of the second session for an extended Q&A.
+
+### Thursday, July 23, 15:00-16:30
+
+Room: [NM - 6 (Munich)](https://wccm-eccomas2026.org/event/room/a1346743-418e-11f1-986a-000c29ddfc0c),
+Session: [MS070B](https://wccm-eccomas2026.org/event/session/f9207f47-4180-11f1-986a-000c29ddfc0c)
+
+- [Simulation of Moving Electromagnetic Parts with Finite- and Boundary Elements](https://wccm-eccomas2026.org/event/contribution/003df3a4-ed50-11f0-b205-000c29ddfc0c) (Jürgen Zechner, TAILSIT GmbH, Austria)
+- [Partitioned Physics Coupling for Thermal Transport Problems in the Subsurface using preCICE](https://wccm-eccomas2026.org/event/contribution/5f3957a1-ed98-11f0-b205-000c29ddfc0c) (Orie Cecil, USACE ERDC, USA)
+- [Numerical Integration of OpenFOAM with BioDynaMo Using preCICE for Multiscale and Multiphysics Problems in (Bio)Physics](https://wccm-eccomas2026.org/event/contribution/3c79eade-05d9-11f1-919d-000c29ddfc0c) (Alexandros Iosif, University of Cyprus, Cyprus)
+- [Thermo-Mechanically Coupled FE–FFT Homogenization of Porous Materials](https://wccm-eccomas2026.org/event/contribution/b085c385-01cf-11f1-919d-000c29ddfc0c) (Julian Dahler, RPTU Kaiserslautern-Landau, Fraunhofer ITWM, Germany)
+
+At the end of the session, we will use the remaining time for an extended Q&A.
+
+## Related talks in other sessions and further events
+
+Let us know if you are talking about preCICE in another session, and we will add it to the list.
+
+### Monday
+
+14:00-14:45, in [MS243B - Progress in Computational Multiphysics Using Open-Source Software II](https://wccm-eccomas2026.org/event/session/f37ebc32-4184-11f1-986a-000c29ddfc0c):
+
+- [Coupling in-house and open-source simulation codes via preCICE](https://wccm-eccomas2026.org/event/contribution/6b59a348-ec9c-11f0-b205-000c29ddfc0c) (Gerasimos Chourdakis, University of Stuttgart, Germany)
+
+### Tuesday
+
+We are organizing an informal coming together of the preCICE community at a restaurant on Tuesday evening, advertised among participants of the preCICE minisymposium. Contact [Gerasimos Chourdakis](https://www.ipvs.uni-stuttgart.de/institute/team/Chourdakis/) until lunchtime on Tuesday if you would like to join us.
+
+### Wednesday
+
+9:45-11:15, in [MS093A Novel Coupling Techniques to Enable Efficient and Robust Simulation of Digital Twins I](https://wccm-eccomas2026.org/event/session/75acfe75-4163-11f1-986a-000c29ddfc0c):
+
+- [Surrogate-assisted Partitioned Modeling of Fractures in Glacier Ice](https://wccm-eccomas2026.org/event/contribution/899b77c9-ec9f-11f0-b205-000c29ddfc0c) (Jun Chen, University of Stuttgart, Germany)
+
+11:30-13:00, in [MS057B Modeling of Glaciers and Ice Sheets II](https://wccm-eccomas2026.org/event/session/97e1e03e-4180-11f1-986a-000c29ddfc0c) (Wednesday, 11:30-13:00):
+
+- [Subglacial hydrology modelling: achievements and challenges in simulating entire ice sheets](https://wccm-eccomas2026.org/event/contribution/3e43245f-e017-11f0-b205-000c29ddfc0c) (Angelika Humbert, Alfred Wegener Institute, Germany)
+
+11:30-13:00, in [MS093B Novel Coupling Techniques to Enable Efficient and Robust Simulation of Digital Twins II](https://wccm-eccomas2026.org/event/session/afedae3a-4181-11f1-986a-000c29ddfc0c):
+
+- [Efficient Partition-of-Unity Radial-Basis-Function Interpolation for Coupled Problems](https://wccm-eccomas2026.org/event/contribution/ca0edb40-efaf-11f0-b205-000c29ddfc0c) (Benjamin Uekermann, University of Stuttgart, Germany)
+
+### Friday
+
+11:30-13:00, in [MS007B Synthesizing Experimental and Computational Perspectives in Mechanics/Mechanobiology of Soft Tissues: Dialogue Towards Mechanistic Insight II](https://wccm-eccomas2026.org/event/session/f3b66475-417e-11f1-986a-000c29ddfc0c):
+
+- [A Multi-scale Framework for Electromechanical Simulations of Skeletal Muscle](https://wccm-eccomas2026.org/event/contribution/075a9ea3-fcf8-11f0-919d-000c29ddfc0c) (Carme Homs-Pons, University of Stuttgart, Germany)


### PR DESCRIPTION
Overview of the MS schedule and of related (preCICE-only) talks. Who am I still missing?

- [Schedule search](https://wccm-eccomas2026.org/event/programme)
- [Overview](https://wccm-eccomas2026.org/programme_overview)

I am suggesting a social event on Tuesday evening, so that:

- We have enough time to network, not just before the MS,
- We have enough time to propagate the information to more people,
- People can still travel on Monday,
- We have more restaurant options (many are closed on Mondays).

Current rendering:

<img width="1201" height="2015" alt="Screenshot 2026-06-10 at 11-50-31 ECCOMAS WCCM 2026 preCICE - The Coupling Library" src="https://github.com/user-attachments/assets/2b92b148-0e7f-4293-a184-aa8ad7c5d908" />