### PR TITLE
Document more files in tutorials structure

### DIFF
--- a/content/community/contribute/community-contribute-to-precice.md
+++ b/content/community/contribute/community-contribute-to-precice.md
@@ -112,7 +112,9 @@ Other files you may encounter are the following:
 - <tutorial>/                     
   - <visualization scripts>       # gnuplot or simple Python scripts
   - images/                       # any images used by the documentation
+  - utils/                        # further utilities, e.g., for pre-/post-processing
   - solver-<code>/                # any configurable, tutorial-specific code, e.g., solver-fenics
+  - .gitignore                    # tutorial-specific files to be ignored in Git repositories
   - reference-results/            # results from different case combinations, used for regression tests
     - <case_combination>.tar.gz   # Git LFS objects, generated from GitHub Actions
 ```

--- a/content/community/contribute/community-contribute-to-precice.md
+++ b/content/community/contribute/community-contribute-to-precice.md
@@ -114,10 +114,11 @@ Other files you may encounter are the following:
   - images/                       # any images used by the documentation
   - utils/                        # further utilities, e.g., for pre-/post-processing
   - solver-<code>/                # any configurable, tutorial-specific code, e.g., solver-fenics
-  - .gitignore                    # tutorial-specific files to be ignored in Git repositories
   - reference-results/            # results from different case combinations, used for regression tests
     - <case_combination>.tar.gz   # Git LFS objects, generated from GitHub Actions
 ```
+
+In some directories, you can find `.gitignore` files. These are typically located in the respective case directory and complement the central `.gitignore` file at the root of the tutorials with any case-specific files not covered by that.
 
 ### The run.sh scripts
 


### PR DESCRIPTION
Adds the following files that are possible:

- `utils/` (introduced in https://github.com/precice/tutorials/pull/670/)
- `.gitignore` (to define where to create such a file)
   - This is currently a bit inconsistent. I will look over all tutorials and adjust.
