### PR TITLE
Prevent embedded YouTube videos from breaking page layout

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -111,6 +111,12 @@ margin-top: -40px
     max-height: 100%;
 }
 
+.post-content iframe:is([src*="youtube.com/embed/"], [src*="youtube-nocookie.com/embed/"]) {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 16 / 9;
+}
+
 .post-content ol li, .post-content ul li {
     margin: 10px 0px;
 }


### PR DESCRIPTION
Fixes #933 by preventing fixed-width YouTube embeds from breaking the page layout on mobile.

Screenshot:

<img width="263" height="585" alt="image" src="https://github.com/user-attachments/assets/6c7dc05b-edf2-4701-af7f-005dc12a8ff7" />
