### PR TITLE
Fix XML reference layout on mobile

### DIFF
--- a/css/customstyles-precice.css
+++ b/css/customstyles-precice.css
@@ -587,6 +587,13 @@ ul.devlist>li {
   max-width: 100%;
 }
 
+.post-content .katex-display {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
 .post-content .table thead {
   --bs-table-color: #fff;
   --bs-table-bg: #777;


### PR DESCRIPTION
Fixes the XML reference layout on mobile (#934)  by making wide formulas horizontally scrollable instead of overflowing the page.
 Screenshot:
 
<img width="450" height="798" alt="image" src="https://github.com/user-attachments/assets/520984c9-d927-4e0e-9f61-765bf668ab4e" />
