### PR TITLE
Adjust issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: Bug report
 description: Report a broken link, rendering issue, or incorrect content
-title: "[Bug]: "
 labels: ["bug"]
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/community-story.yml
+++ b/.github/ISSUE_TEMPLATE/community-story.yml
@@ -1,7 +1,7 @@
 name: Your story
 description: Tell us your story and get it published on https://precice.org/community-projects.html
-title: "[Story]: "
-labels: ["content"]
+title: ""
+labels: ["content","community-story"]
 assignees:
   - MakisH
 body:
@@ -60,5 +60,5 @@ body:
       label: Image
       description: Remember to upload an image
       options:
-        - label: I will upload an image to be published on the website directly after opening this issue, or send it via email to @MakisH.
+        - label: I uploaded/will upload an image to be published on the website.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: preCICE Discourse Forum
+  - name: Support
     url: https://precice.discourse.group
-    about: For usage questions, please ask on the preCICE Discourse forum instead of opening a GitHub issue.
+    about: For support questions, please ask on the preCICE Discourse forum instead of opening a GitHub issue.

--- a/.github/ISSUE_TEMPLATE/documentation-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.yml
@@ -1,6 +1,5 @@
 name: Documentation improvement
 description: Suggest an improvement or flag missing/unclear content
-title: "[Docs]: "
 labels: ["content"]
 body:
   - type: input


### PR DESCRIPTION
- Remove title prefixes (we already use labels, we generally don't use title prefixes)
- Add a community-story label, to be able to filter all such stories
- Make story image checkbox more general, removing my name as a recipient