### PR TITLE
Limit PDF image height

### DIFF
--- a/css/printstyles.css
+++ b/css/printstyles.css
@@ -13,10 +13,14 @@ body.print .print-content {
     padding-right: 0;
 }
 
-body.print .docimage {
+body.print .print-content img {
     display: block;
     max-width: 100%;
+    max-height: 520pt;
+    width: auto;
     height: auto;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .nav ul li a {border-top:0px; background-color:transparent; color: #808080; }


### PR DESCRIPTION
Limit image height in PDF output to prevent tall, narrow images from taking excessive page space e.g the heat exchanger image

Screenshot of the generated Pdf:

<img width="502" height="567" alt="image" src="https://github.com/user-attachments/assets/f93f7e5a-4e0f-478b-bdbf-33686165e3ff" />
