### PR TITLE
Add Micro Manager two-level parallelization documentation to the sidebar

### DIFF
--- a/_data/sidebars/docs_sidebar.yml
+++ b/_data/sidebars/docs_sidebar.yml
@@ -279,6 +279,10 @@ entries:
         - title: Snapshot Computation
           url: /tooling-micro-manager-snapshot-configuration.html
           output: web, pdf
+
+        - title: Running with two-level parallelization
+          url: /tooling-micro-manager-two-level-parallelization.html
+          output: web, pdf
     
     - title: Performance analysis
       url: /tooling-performance-analysis.html


### PR DESCRIPTION
Prompted by https://github.com/precice/micro-manager/pull/309#discussion_r3569192049