### PR TITLE
Add a note on Git LFS for the distribution release

### DIFF
--- a/content/docs/dev-docs/publications.md
+++ b/content/docs/dev-docs/publications.md
@@ -58,6 +58,10 @@ Order of authors: maintainers are listed first followed by everybody else, both 
 
 4. Download components
 
+    {% important %}
+    The tutorials repository tracks reference result files in Git LFS. Download this repository with Git LFS enabled and check that the archives in the `reference-results/` directory in each tutorial can be extracted.
+    {% endimportant %}
+
     <!-- Algolia complains if we use too large code snippets with syntax highlighting -->
     ```text
     #!/bin/bash
@@ -143,7 +147,7 @@ Order of authors: maintainers are listed first followed by everybody else, both 
 
     Once there is a machine-readable distribution, simplify the bash script accordingly.
 
-5. Upload to DaRUS
+6. Upload to DaRUS
 
     ```python
     from easyDataverse import Dataverse
@@ -170,6 +174,6 @@ Order of authors: maintainers are listed first followed by everybody else, both 
     dataset.upload("ipvs_us3")
     ```
 
-6. Review and publish
+7. Review and publish
 
     The upload returns a url, which gives you access to the dataset. Review carefully. Currently, for example, licenses still need manual editing. Also the PDF version of the docs, a README.md, and descriptions of all components are missing. Once ready, publish (i.e. send to DaRUS team for review).

--- a/content/docs/dev-docs/publications.md
+++ b/content/docs/dev-docs/publications.md
@@ -58,9 +58,7 @@ Order of authors: maintainers are listed first followed by everybody else, both 
 
 4. Download components
 
-    {% important %}
-    The tutorials repository tracks reference result files in Git LFS. Download this repository with Git LFS enabled and check that the archives in the `reference-results/` directory in each tutorial can be extracted.
-    {% endimportant %}
+   Note that the tutorials repository tracks reference result files in Git LFS. Download this repository with Git LFS enabled and check that the archives in the `reference-results/` directory in each tutorial can be extracted.
 
     <!-- Algolia complains if we use too large code snippets with syntax highlighting -->
     ```text

--- a/content/docs/dev-docs/publications.md
+++ b/content/docs/dev-docs/publications.md
@@ -58,7 +58,7 @@ Order of authors: maintainers are listed first followed by everybody else, both 
 
 4. Download components
 
-   Note that the tutorials repository tracks reference result files in Git LFS. Download this repository with Git LFS enabled and check that the archives in the `reference-results/` directory in each tutorial can be extracted.
+   Note that the tutorials repository tracks reference result files in Git LFS. To preserve these, get this repository using Git, with Git LFS enabled, and check that the archives in the `reference-results/` directory in each tutorial can be extracted. The following script only downloads the tutorials without these archives.
 
     <!-- Algolia complains if we use too large code snippets with syntax highlighting -->
     ```text

--- a/content/docs/dev-docs/publications.md
+++ b/content/docs/dev-docs/publications.md
@@ -147,7 +147,7 @@ Order of authors: maintainers are listed first followed by everybody else, both 
 
     Once there is a machine-readable distribution, simplify the bash script accordingly.
 
-6. Upload to DaRUS
+5. Upload to DaRUS
 
     ```python
     from easyDataverse import Dataverse
@@ -174,6 +174,6 @@ Order of authors: maintainers are listed first followed by everybody else, both 
     dataset.upload("ipvs_us3")
     ```
 
-7. Review and publish
+6. Review and publish
 
     The upload returns a url, which gives you access to the dataset. Review carefully. Currently, for example, licenses still need manual editing. Also the PDF version of the docs, a README.md, and descriptions of all components are missing. Once ready, publish (i.e. send to DaRUS team for review).


### PR DESCRIPTION
The current archive is missing the reference results archives (the files are only placeholders): https://darus.uni-stuttgart.de/file.xhtml?persistentId=doi:10.18419/DARUS-4167/13&version=1.0

This PR only adds a note, but does not modify the script.

@uekerman FYI