### PR TITLE
Add registration and abstract submission links for Workshop 2027

### DIFF
--- a/content/community/workshops/2027.md
+++ b/content/community/workshops/2027.md
@@ -29,7 +29,7 @@ The call for contributions will be announced in late 2026.
 
 ## Registration
 
-Registration will be available in late 2026 / early 2027.
+Registration will be available in late 2026 / early 2027 via the [registration page](https://www.aanmelder.nl/precice2027/registration).
 
 Holders of a [support license](community-support-precice.html) get free registration to the preCICE workshops.
 

--- a/content/community/workshops/2027.md
+++ b/content/community/workshops/2027.md
@@ -20,6 +20,8 @@ For any organizational questions (for example, visa-related requests), please co
 
 The call for contributions will be announced in late 2026.
 
+Once submissions open, [submit your abstract](https://www.aanmelder.nl/precice2027/author) via aanmelder.
+
 ## Important dates
 
 - Abstract submission deadline: (Not yet announced)<br/>


### PR DESCRIPTION
Add the aanmelder registration and abstract submission links to the Workshop 2027 page. Keep the announced opening dates for registration and the call for contributions.
