### PR TITLE
Update the workshop 2027 details

### DIFF
--- a/content/community/workshops/2027.md
+++ b/content/community/workshops/2027.md
@@ -46,7 +46,27 @@ Please arrange accommodation independently. We will never contact you regarding 
 
 Expect talks, posters, training, and further interactive and networking program components. We also plan to incorporate optional training in [G+Smo](https://gismo.github.io/).
 
-All workshop activities will take place in the [TUDelft Aula](https://map.tudelftcampus.nl/poi/aula-conference-centre/).
+All workshop activities will take place in the [TUDelft Aula](https://map.tudelftcampus.nl/poi/aula-conference-centre/), in a single track.
+
+Preliminary schedule (details in December):
+
+- Monday:
+  - Training in preCICE: basics and tools
+- Tuesday:
+  - Training in preCICE: implicit coupling, data mapping, adapter software engineering
+- Wednesday:
+  - Training in preCICE: coupling to IGA
+  - User and developer talks including dedicated session on IGA coupling
+  - Conference dinner
+- Thursday:
+  - User and developer talks, including an invited speaker
+  - World Café
+  - Poster session
+- Friday
+  - Hands-on user support
+  - Training in G+Smo
+
+Not interested in the training modules on Monday and Tuesday? You can skip the training and only join the main workshop, with a reduced ticket, while still getting access to the new preCICE training content on Wednesday and the G+Smo training on Friday.
 
 ## Travel awards
 

--- a/content/community/workshops/2027.md
+++ b/content/community/workshops/2027.md
@@ -26,20 +26,21 @@ You do not need to submit a contribution to join this workshop. However, your co
 
 ## Important dates
 
-- Abstract submission deadline: (Not yet announced)<br/>
+- **Abstract submission deadline:** November 8, 2026<br/>
   Expect news on your submission two weeks later.<br/>
   You don't need to submit a contribution in order to attend.
-- Registration deadline: (Not yet announced).
+- **Registration deadline:** February 21, 2027. Registration opens in November 2026.
 
 ## Registration
 
-Registration will be available in late 2026 / early 2027.
+Registration will be available in November 2026.
 
 Holders of a [support license](community-support-precice.html) get free registration to the preCICE workshops.
+Contact us for a voucher before registering.
 
 ## Accommodation
 
-Please arrange accommodation independently.
+Please arrange accommodation independently. We will never contact you regarding booking accommodation.
 
 ## Program
 

--- a/content/community/workshops/2027.md
+++ b/content/community/workshops/2027.md
@@ -35,8 +35,22 @@ You do not need to submit a contribution to join this workshop. However, your co
 
 Registration will be available in November 2026.
 
-Holders of a [support license](community-support-precice.html) get free registration to the preCICE workshops.
-Contact us for a voucher before registering.
+The workshop includes two main parts:
+
+- Training course: Mon-Tue (March 1-2). Includes selected [training course modules](community-training.html) (see schedule).
+- Main workshop: Wed-Fri (March 3-5). Includes the latest training course modules and [everything else](precice-workshop.html).
+
+Ticket prices:
+
+| Ticket                                                         | Price   |
+| ---                                                            | ---     |
+| Full ticket (incl. course)                                     | 900 €   |
+| Full ticket (incl. course) - academic discount                 | 450 €   |
+| Main workshop (no course)                                      | 600 €   |
+| Main workshop (no course) - academic discount                  | 300 €   |
+| Holders of a [support license](community-support-precice.html) | 0 €     |
+
+The full ticket includes access to all talks, the consulting/user-support sessions (during the workshop and an online post-workshop session), an invited dinner, as well as lunch and coffee breaks on all days. The main workshop ticket does not include access to the training course (Monday-Tuesday).
 
 ## Accommodation
 

--- a/content/community/workshops/2027.md
+++ b/content/community/workshops/2027.md
@@ -40,7 +40,7 @@ Contact us for a voucher before registering.
 
 ## Accommodation
 
-Please arrange accommodation independently. We will never contact you regarding booking accommodation.
+Please arrange accommodation independently. We are preparing a list of recommended hotels, but we will never contact you regarding booking accommodation on your behalf.
 
 ## Program
 

--- a/content/community/workshops/2027.md
+++ b/content/community/workshops/2027.md
@@ -18,7 +18,11 @@ For any organizational questions (for example, visa-related requests), please co
 
 ## Call for contributions
 
-The call for contributions will be announced in late 2026.
+The form for contributions will be available very soon.
+
+We are looking for talks and posters that could be beneficial for the wider preCICE community. Are you developing a new adapter? Are you using preCICE for an exciting new application? Are you developing new methods that should not be missing from preCICE? If the answer to any of these questions was yes, we encourage you to submit a brief abstract for a 20 minutes talk. Are you revisiting one of the classical preCICE use cases? Did you already present your work in a previous workshop? Then we would be very happy to catch up with your work, and we encourage you to present a poster. After review, and depending on the available slots, we might suggest a different presentation format than you originally applied for.
+
+You do not need to submit a contribution to join this workshop. However, your contributions are very welcome!
 
 ## Important dates
 

--- a/content/community/workshops/2027.md
+++ b/content/community/workshops/2027.md
@@ -50,7 +50,7 @@ All workshop activities will take place in the [TUDelft Aula](https://map.tudelf
 
 ## Travel awards
 
-We are looking into options for a few travel awards for participants that cannot join otherwise. Stay tuned.
+We have up to five travel awards available for those who cannot join otherwise. Each award includes co-funding of 500€ for travel and accommodation and a waiver for the registration fee. If you are interested in this support, please briefly explain your situation by mailing to `precice2027-org` at `lists.tudelft.nl`.
 
 ## Help us advertise
 


### PR DESCRIPTION
This PR adds/updates:

- The important dates (did we really decide against an early-bird this year, or was it just copy-paste from the 2025?)
- The call for contributions
- The preliminary program
- The travel grants text
- The accommodation disclaimer

cc @Crazy-Rich-Meghan